### PR TITLE
test: improve testability of sonar-sim and sonar-idl

### DIFF
--- a/crates/sonar-idl/src/parser.rs
+++ b/crates/sonar-idl/src/parser.rs
@@ -270,7 +270,7 @@ fn parse_simple_type(data: &[u8], offset: &mut usize, type_name: &str) -> Result
         }
         "i8" => {
             check_data_len(data, start, 1)?;
-            (OrderedJsonValue::Number(JsonNumber::from(data[start] as i64)), 1)
+            (OrderedJsonValue::Number(JsonNumber::from(data[start] as i8 as i64)), 1)
         }
         "u16" => {
             check_data_len(data, start, 2)?;
@@ -1017,5 +1017,200 @@ mod tests {
         let data = vec![1, 0, 0, 0];
         let found = find_instruction_by_discriminator(&idl, &data).unwrap();
         assert_eq!(found.name, "specific");
+    }
+
+    // ── Direct parse_simple_type tests ──
+
+    #[test]
+    fn parse_simple_u8() {
+        let data = [42u8];
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "u8").unwrap();
+        assert_eq!(val, OrderedJsonValue::Number(42u64.into()));
+        assert_eq!(offset, 1);
+    }
+
+    #[test]
+    fn parse_simple_i8() {
+        let data = [(-5i8) as u8];
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "i8").unwrap();
+        assert_eq!(val, OrderedJsonValue::Number((-5i64).into()));
+        assert_eq!(offset, 1);
+    }
+
+    #[test]
+    fn parse_simple_u16() {
+        let data = 1000u16.to_le_bytes();
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "u16").unwrap();
+        assert_eq!(val, OrderedJsonValue::Number(1000u64.into()));
+        assert_eq!(offset, 2);
+    }
+
+    #[test]
+    fn parse_simple_i16() {
+        let data = (-300i16).to_le_bytes();
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "i16").unwrap();
+        assert_eq!(val, OrderedJsonValue::Number((-300i64).into()));
+        assert_eq!(offset, 2);
+    }
+
+    #[test]
+    fn parse_simple_u32() {
+        let data = 70000u32.to_le_bytes();
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "u32").unwrap();
+        assert_eq!(val, OrderedJsonValue::Number(70000u64.into()));
+        assert_eq!(offset, 4);
+    }
+
+    #[test]
+    fn parse_simple_i32() {
+        let data = (-70000i32).to_le_bytes();
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "i32").unwrap();
+        assert_eq!(val, OrderedJsonValue::Number((-70000i64).into()));
+        assert_eq!(offset, 4);
+    }
+
+    #[test]
+    fn parse_simple_u64() {
+        let data = u64::MAX.to_le_bytes();
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "u64").unwrap();
+        assert_eq!(val, OrderedJsonValue::Number(u64::MAX.into()));
+        assert_eq!(offset, 8);
+    }
+
+    #[test]
+    fn parse_simple_i64() {
+        let data = i64::MIN.to_le_bytes();
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "i64").unwrap();
+        assert_eq!(val, OrderedJsonValue::Number(i64::MIN.into()));
+        assert_eq!(offset, 8);
+    }
+
+    #[test]
+    fn parse_simple_u128() {
+        let val_in: u128 = 340_282_366_920_938_463;
+        let data = val_in.to_le_bytes();
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "u128").unwrap();
+        assert_eq!(val, OrderedJsonValue::String(val_in.to_string()));
+        assert_eq!(offset, 16);
+    }
+
+    #[test]
+    fn parse_simple_i128() {
+        let val_in: i128 = -170_141_183_460_469;
+        let data = val_in.to_le_bytes();
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "i128").unwrap();
+        assert_eq!(val, OrderedJsonValue::String(val_in.to_string()));
+        assert_eq!(offset, 16);
+    }
+
+    #[test]
+    fn parse_simple_bool_true() {
+        let data = [1u8];
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "bool").unwrap();
+        assert_eq!(val, OrderedJsonValue::Bool(true));
+        assert_eq!(offset, 1);
+    }
+
+    #[test]
+    fn parse_simple_bool_false() {
+        let data = [0u8];
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "bool").unwrap();
+        assert_eq!(val, OrderedJsonValue::Bool(false));
+        assert_eq!(offset, 1);
+    }
+
+    #[test]
+    fn parse_simple_pubkey() {
+        let pk = Pubkey::from_str("11111111111111111111111111111111").unwrap();
+        let data = pk.to_bytes();
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "pubkey").unwrap();
+        assert_eq!(val, OrderedJsonValue::String(pk.to_string()));
+        assert_eq!(offset, 32);
+    }
+
+    #[test]
+    fn parse_simple_string() {
+        let s = b"hello";
+        let mut data = (s.len() as u32).to_le_bytes().to_vec();
+        data.extend_from_slice(s);
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "string").unwrap();
+        assert_eq!(val, OrderedJsonValue::String("hello".into()));
+        assert_eq!(offset, 9);
+    }
+
+    #[test]
+    fn parse_simple_bytes() {
+        let payload = vec![0xAA, 0xBB, 0xCC];
+        let mut data = (payload.len() as u32).to_le_bytes().to_vec();
+        data.extend_from_slice(&payload);
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "bytes").unwrap();
+        assert_eq!(
+            val,
+            OrderedJsonValue::Array(vec![
+                OrderedJsonValue::Number(0xAAu64.into()),
+                OrderedJsonValue::Number(0xBBu64.into()),
+                OrderedJsonValue::Number(0xCCu64.into()),
+            ])
+        );
+        assert_eq!(offset, 7);
+    }
+
+    // ── Error paths ──
+
+    #[test]
+    fn parse_simple_type_truncated_u32() {
+        let data = [0u8; 2]; // need 4 for u32
+        let mut offset = 0;
+        let err = parse_simple_type(&data, &mut offset, "u32").unwrap_err();
+        assert!(err.to_string().contains("Insufficient data"));
+    }
+
+    #[test]
+    fn parse_simple_type_truncated_string_length() {
+        let data = [0u8; 2]; // need 4 for length prefix
+        let mut offset = 0;
+        let err = parse_simple_type(&data, &mut offset, "string").unwrap_err();
+        assert!(err.to_string().contains("Insufficient data"));
+    }
+
+    #[test]
+    fn parse_simple_type_truncated_string_body() {
+        // length says 10 bytes but only 2 available
+        let mut data = 10u32.to_le_bytes().to_vec();
+        data.extend_from_slice(&[0, 0]);
+        let mut offset = 0;
+        let err = parse_simple_type(&data, &mut offset, "string").unwrap_err();
+        assert!(err.to_string().contains("Insufficient data"));
+    }
+
+    #[test]
+    fn parse_simple_type_unknown_falls_back_to_raw() {
+        let data = [1, 2, 3, 4];
+        let mut offset = 0;
+        let val = parse_simple_type(&data, &mut offset, "unknown_type").unwrap();
+        // Should return a raw_unparsed_value object
+        if let OrderedJsonValue::Object(entries) = &val {
+            let keys: Vec<&str> = entries.iter().map(|(k, _)| k.as_str()).collect();
+            assert!(keys.contains(&"context"));
+            assert!(keys.contains(&"type_hint"));
+            assert!(keys.contains(&"raw_hex"));
+        } else {
+            panic!("expected Object for unknown type, got {:?}", val);
+        }
     }
 }

--- a/crates/sonar-idl/src/parser.rs
+++ b/crates/sonar-idl/src/parser.rs
@@ -1318,4 +1318,141 @@ mod tests {
         );
         assert_eq!(offset, 3);
     }
+
+    // ── Enum variant tests ──
+
+    #[test]
+    fn parse_enum_with_struct_variant() {
+        let idl: Idl = serde_json::from_str(
+            r#"{
+                "address": "11111111111111111111111111111111",
+                "metadata": { "name": "t", "version": "0.1.0", "spec": "0.1.0" },
+                "instructions": [{
+                    "name": "cmd",
+                    "discriminator": [9,9,9,9,9,9,9,9],
+                    "accounts": [],
+                    "args": [{ "name": "op", "type": { "defined": "Op" } }]
+                }],
+                "types": [{
+                    "name": "Op",
+                    "type": {
+                        "kind": "enum",
+                        "variants": [
+                            { "name": "Noop" },
+                            {
+                                "name": "Transfer",
+                                "fields": [
+                                    { "name": "amount", "type": "u64" },
+                                    { "name": "fee", "type": "u16" }
+                                ]
+                            }
+                        ]
+                    }
+                }]
+            }"#,
+        )
+        .unwrap();
+
+        let registry = IdlRegistry::new();
+        let mut data = vec![9, 9, 9, 9, 9, 9, 9, 9];
+        data.push(1); // variant index 1 = Transfer
+        data.extend_from_slice(&5000u64.to_le_bytes());
+        data.extend_from_slice(&100u16.to_le_bytes());
+
+        let parsed = parse_instruction(&idl, &data, &registry).unwrap().unwrap();
+        let val = &parsed.fields[0].value;
+        assert_eq!(
+            *val,
+            OrderedJsonValue::Object(vec![(
+                "Transfer".into(),
+                OrderedJsonValue::Object(vec![
+                    ("amount".into(), OrderedJsonValue::Number(5000u64.into())),
+                    ("fee".into(), OrderedJsonValue::Number(100u64.into())),
+                ]),
+            )])
+        );
+    }
+
+    #[test]
+    fn parse_enum_with_tuple_variant() {
+        let idl: Idl = serde_json::from_str(
+            r#"{
+                "address": "11111111111111111111111111111111",
+                "metadata": { "name": "t", "version": "0.1.0", "spec": "0.1.0" },
+                "instructions": [{
+                    "name": "cmd",
+                    "discriminator": [8,8,8,8,8,8,8,8],
+                    "accounts": [],
+                    "args": [{ "name": "op", "type": { "defined": "Op" } }]
+                }],
+                "types": [{
+                    "name": "Op",
+                    "type": {
+                        "kind": "enum",
+                        "variants": [
+                            { "name": "Noop" },
+                            { "name": "SetPair", "fields": ["u32", "u32"] }
+                        ]
+                    }
+                }]
+            }"#,
+        )
+        .unwrap();
+
+        let registry = IdlRegistry::new();
+        let mut data = vec![8, 8, 8, 8, 8, 8, 8, 8];
+        data.push(1); // variant index 1 = SetPair
+        data.extend_from_slice(&111u32.to_le_bytes());
+        data.extend_from_slice(&222u32.to_le_bytes());
+
+        let parsed = parse_instruction(&idl, &data, &registry).unwrap().unwrap();
+        let val = &parsed.fields[0].value;
+        assert_eq!(
+            *val,
+            OrderedJsonValue::Object(vec![(
+                "SetPair".into(),
+                OrderedJsonValue::Array(vec![
+                    OrderedJsonValue::Number(111u64.into()),
+                    OrderedJsonValue::Number(222u64.into()),
+                ]),
+            )])
+        );
+    }
+
+    #[test]
+    fn parse_enum_out_of_range_variant_index_falls_through() {
+        let idl: Idl = serde_json::from_str(
+            r#"{
+                "address": "11111111111111111111111111111111",
+                "metadata": { "name": "t", "version": "0.1.0", "spec": "0.1.0" },
+                "instructions": [{
+                    "name": "cmd",
+                    "discriminator": [7,7,7,7,7,7,7,7],
+                    "accounts": [],
+                    "args": [{ "name": "val", "type": { "defined": "Small" } }]
+                }],
+                "types": [{
+                    "name": "Small",
+                    "type": {
+                        "kind": "enum",
+                        "variants": [{ "name": "Only" }]
+                    }
+                }]
+            }"#,
+        )
+        .unwrap();
+
+        let registry = IdlRegistry::new();
+        let mut data = vec![7, 7, 7, 7, 7, 7, 7, 7];
+        data.push(99); // out-of-range variant
+
+        let parsed = parse_instruction(&idl, &data, &registry).unwrap().unwrap();
+        // Should fall through to raw_unparsed_value
+        if let OrderedJsonValue::Object(entries) = &parsed.fields[0].value {
+            let keys: Vec<&str> = entries.iter().map(|(k, _)| k.as_str()).collect();
+            assert!(keys.contains(&"raw_hex"));
+        } else {
+            panic!("expected raw fallback for out-of-range variant");
+        }
+    }
 }

--- a/crates/sonar-idl/src/parser.rs
+++ b/crates/sonar-idl/src/parser.rs
@@ -1213,4 +1213,109 @@ mod tests {
             panic!("expected Object for unknown type, got {:?}", val);
         }
     }
+
+    // ── Direct container type tests ──
+
+    #[test]
+    fn parse_vec_type_u32_elements() {
+        let mut data = 3u32.to_le_bytes().to_vec();
+        data.extend_from_slice(&10u32.to_le_bytes());
+        data.extend_from_slice(&20u32.to_le_bytes());
+        data.extend_from_slice(&30u32.to_le_bytes());
+        let mut offset = 0;
+        let registry = IdlRegistry::new();
+        let idl = hello_anchor_idl();
+        let element_type = IdlType::Simple("u32".into());
+        let val = parse_vec_type(&data, &mut offset, &element_type, &registry, &idl).unwrap();
+        assert_eq!(
+            val,
+            OrderedJsonValue::Array(vec![
+                OrderedJsonValue::Number(10u64.into()),
+                OrderedJsonValue::Number(20u64.into()),
+                OrderedJsonValue::Number(30u64.into()),
+            ])
+        );
+        assert_eq!(offset, 16);
+    }
+
+    #[test]
+    fn parse_vec_type_empty() {
+        let data = 0u32.to_le_bytes();
+        let mut offset = 0;
+        let registry = IdlRegistry::new();
+        let idl = hello_anchor_idl();
+        let element_type = IdlType::Simple("u8".into());
+        let val = parse_vec_type(&data, &mut offset, &element_type, &registry, &idl).unwrap();
+        assert_eq!(val, OrderedJsonValue::Array(vec![]));
+        assert_eq!(offset, 4);
+    }
+
+    #[test]
+    fn parse_vec_type_truncated_length() {
+        let data = [0u8; 2];
+        let mut offset = 0;
+        let registry = IdlRegistry::new();
+        let idl = hello_anchor_idl();
+        let element_type = IdlType::Simple("u8".into());
+        let err = parse_vec_type(&data, &mut offset, &element_type, &registry, &idl).unwrap_err();
+        assert!(err.to_string().contains("Insufficient data"));
+    }
+
+    #[test]
+    fn parse_option_type_some() {
+        let mut data = vec![1u8];
+        data.extend_from_slice(&500u16.to_le_bytes());
+        let mut offset = 0;
+        let registry = IdlRegistry::new();
+        let idl = hello_anchor_idl();
+        let inner = IdlType::Simple("u16".into());
+        let val = parse_option_type(&data, &mut offset, &inner, &registry, &idl).unwrap();
+        assert_eq!(val, OrderedJsonValue::Number(500u64.into()));
+        assert_eq!(offset, 3);
+    }
+
+    #[test]
+    fn parse_option_type_none() {
+        let data = vec![0u8];
+        let mut offset = 0;
+        let registry = IdlRegistry::new();
+        let idl = hello_anchor_idl();
+        let inner = IdlType::Simple("u16".into());
+        let val = parse_option_type(&data, &mut offset, &inner, &registry, &idl).unwrap();
+        assert_eq!(val, OrderedJsonValue::Null);
+        assert_eq!(offset, 1);
+    }
+
+    #[test]
+    fn parse_option_type_truncated_discriminant() {
+        let data: [u8; 0] = [];
+        let mut offset = 0;
+        let registry = IdlRegistry::new();
+        let idl = hello_anchor_idl();
+        let inner = IdlType::Simple("u8".into());
+        let err = parse_option_type(&data, &mut offset, &inner, &registry, &idl).unwrap_err();
+        assert!(err.to_string().contains("Insufficient data"));
+    }
+
+    #[test]
+    fn parse_array_type_fixed_3_u8() {
+        let data = vec![10, 20, 30];
+        let mut offset = 0;
+        let registry = IdlRegistry::new();
+        let idl = hello_anchor_idl();
+        let array_def = [
+            serde_json::json!("u8"),
+            serde_json::json!(3),
+        ];
+        let val = parse_array_type(&data, &mut offset, &array_def, &registry, &idl).unwrap();
+        assert_eq!(
+            val,
+            OrderedJsonValue::Array(vec![
+                OrderedJsonValue::Number(10u64.into()),
+                OrderedJsonValue::Number(20u64.into()),
+                OrderedJsonValue::Number(30u64.into()),
+            ])
+        );
+        assert_eq!(offset, 3);
+    }
 }

--- a/crates/sonar-sim/src/account_loader.rs
+++ b/crates/sonar-sim/src/account_loader.rs
@@ -589,4 +589,92 @@ mod tests {
 
         assert!(!resolved.accounts.contains_key(&missing_mint));
     }
+
+    // ── Pure function tests: collect_initial_accounts ──
+
+    #[test]
+    fn collect_initial_accounts_single_plan_no_lookups() {
+        let key1 = Pubkey::new_unique();
+        let key2 = Pubkey::new_unique();
+        let plan = MessageAccountPlan {
+            static_accounts: vec![key1, key2],
+            address_lookups: vec![],
+        };
+        let keys = collect_initial_accounts(&[plan]);
+        assert!(keys.contains(&key1));
+        assert!(keys.contains(&key2));
+        assert!(keys.contains(&Clock::id()));
+        assert!(keys.contains(&SlotHashes::id()));
+        assert_eq!(keys.len(), 4);
+    }
+
+    #[test]
+    fn collect_initial_accounts_deduplicates_across_plans() {
+        let shared = Pubkey::new_unique();
+        let unique1 = Pubkey::new_unique();
+        let unique2 = Pubkey::new_unique();
+        let plan1 = MessageAccountPlan {
+            static_accounts: vec![shared, unique1],
+            address_lookups: vec![],
+        };
+        let plan2 = MessageAccountPlan {
+            static_accounts: vec![shared, unique2],
+            address_lookups: vec![],
+        };
+        let keys = collect_initial_accounts(&[plan1, plan2]);
+        let shared_count = keys.iter().filter(|k| **k == shared).count();
+        assert_eq!(shared_count, 1);
+        assert_eq!(keys.len(), 5); // shared + unique1 + unique2 + Clock + SlotHashes
+    }
+
+    #[test]
+    fn collect_initial_accounts_includes_lookup_table_keys() {
+        let static_key = Pubkey::new_unique();
+        let lookup_table_key = Pubkey::new_unique();
+        let plan = MessageAccountPlan {
+            static_accounts: vec![static_key],
+            address_lookups: vec![AddressLookupPlan {
+                account_key: lookup_table_key,
+                writable_indexes: vec![0],
+                readonly_indexes: vec![1],
+            }],
+        };
+        let keys = collect_initial_accounts(&[plan]);
+        assert!(keys.contains(&static_key));
+        assert!(keys.contains(&lookup_table_key));
+    }
+
+    #[test]
+    fn collect_initial_accounts_empty_plans() {
+        let keys = collect_initial_accounts(&[]);
+        assert_eq!(keys.len(), 2);
+        assert!(keys.contains(&Clock::id()));
+        assert!(keys.contains(&SlotHashes::id()));
+    }
+
+    // ── Pure function tests: resolve_lookup_indexes ──
+
+    #[test]
+    fn resolve_lookup_indexes_valid() {
+        let addr0 = Pubkey::new_unique();
+        let addr1 = Pubkey::new_unique();
+        let addr2 = Pubkey::new_unique();
+        let addresses = vec![addr0, addr1, addr2];
+        let result = resolve_lookup_indexes(&addresses, &[2, 0]).unwrap();
+        assert_eq!(result, vec![addr2, addr0]);
+    }
+
+    #[test]
+    fn resolve_lookup_indexes_out_of_bounds() {
+        let addresses = vec![Pubkey::new_unique()];
+        let err = resolve_lookup_indexes(&addresses, &[5]).unwrap_err();
+        assert!(err.to_string().contains("out of"));
+    }
+
+    #[test]
+    fn resolve_lookup_indexes_empty() {
+        let addresses = vec![Pubkey::new_unique()];
+        let result = resolve_lookup_indexes(&addresses, &[]).unwrap();
+        assert!(result.is_empty());
+    }
 }

--- a/crates/sonar-sim/src/account_loader.rs
+++ b/crates/sonar-sim/src/account_loader.rs
@@ -245,42 +245,7 @@ impl AccountLoader {
                 ),
             })?;
 
-        let lookup_table =
-            AddressLookupTable::deserialize(table_account.data()).map_err(|err| {
-                SonarSimError::LookupTable {
-                    table: Some(plan.account_key),
-                    reason: format!(
-                        "Failed to parse address lookup table `{}`: {err}",
-                        plan.account_key
-                    ),
-                }
-            })?;
-        let all_addresses = lookup_table.addresses.to_vec();
-
-        let writable_addresses = resolve_lookup_indexes(&all_addresses, &plan.writable_indexes)
-            .map_err(|e| SonarSimError::LookupTable {
-                table: Some(plan.account_key),
-                reason: format!(
-                    "Failed to parse writable indexes for address lookup table `{}`: {e}",
-                    plan.account_key
-                ),
-            })?;
-        let readonly_addresses = resolve_lookup_indexes(&all_addresses, &plan.readonly_indexes)
-            .map_err(|e| SonarSimError::LookupTable {
-                table: Some(plan.account_key),
-                reason: format!(
-                    "Failed to parse readonly indexes for address lookup table `{}`: {e}",
-                    plan.account_key
-                ),
-            })?;
-
-        Ok(ResolvedLookup {
-            account_key: plan.account_key,
-            writable_indexes: plan.writable_indexes.clone(),
-            readonly_indexes: plan.readonly_indexes.clone(),
-            writable_addresses,
-            readonly_addresses,
-        })
+        expand_lookup_table(table_account, plan)
     }
 }
 
@@ -318,6 +283,52 @@ fn collect_initial_accounts(plans: &[MessageAccountPlan]) -> Vec<Pubkey> {
     }
 
     keys
+}
+
+/// Expand a fetched address lookup table account into resolved addresses.
+///
+/// Pure function: takes the already-fetched ALT account data and the lookup plan,
+/// deserializes the table, and resolves writable/readonly addresses by index.
+fn expand_lookup_table(
+    table_account: &AccountSharedData,
+    plan: &AddressLookupPlan,
+) -> Result<ResolvedLookup> {
+    let lookup_table =
+        AddressLookupTable::deserialize(table_account.data()).map_err(|err| {
+            SonarSimError::LookupTable {
+                table: Some(plan.account_key),
+                reason: format!(
+                    "Failed to parse address lookup table `{}`: {err}",
+                    plan.account_key
+                ),
+            }
+        })?;
+    let all_addresses = lookup_table.addresses.to_vec();
+
+    let writable_addresses = resolve_lookup_indexes(&all_addresses, &plan.writable_indexes)
+        .map_err(|e| SonarSimError::LookupTable {
+            table: Some(plan.account_key),
+            reason: format!(
+                "Failed to parse writable indexes for address lookup table `{}`: {e}",
+                plan.account_key
+            ),
+        })?;
+    let readonly_addresses = resolve_lookup_indexes(&all_addresses, &plan.readonly_indexes)
+        .map_err(|e| SonarSimError::LookupTable {
+            table: Some(plan.account_key),
+            reason: format!(
+                "Failed to parse readonly indexes for address lookup table `{}`: {e}",
+                plan.account_key
+            ),
+        })?;
+
+    Ok(ResolvedLookup {
+        account_key: plan.account_key,
+        writable_indexes: plan.writable_indexes.clone(),
+        readonly_indexes: plan.readonly_indexes.clone(),
+        writable_addresses,
+        readonly_addresses,
+    })
 }
 
 fn resolve_lookup_indexes(addresses: &[Pubkey], indexes: &[u8]) -> Result<Vec<Pubkey>> {
@@ -676,5 +687,82 @@ mod tests {
         let addresses = vec![Pubkey::new_unique()];
         let result = resolve_lookup_indexes(&addresses, &[]).unwrap();
         assert!(result.is_empty());
+    }
+
+    // ── Pure function tests: expand_lookup_table ──
+
+    /// Helper: build an `AccountSharedData` containing a valid serialized ALT
+    /// with the given addresses.
+    fn make_alt_account(addresses: &[Pubkey]) -> AccountSharedData {
+        use solana_address_lookup_table_interface::state::{AddressLookupTable, LookupTableMeta};
+        use std::borrow::Cow;
+
+        let table = AddressLookupTable {
+            meta: LookupTableMeta::default(), // active table, no authority
+            addresses: Cow::Borrowed(addresses),
+        };
+        let data = table.serialize_for_tests().expect("serialize ALT for test");
+        let mut account = AccountSharedData::default();
+        account.set_data_from_slice(&data);
+        account
+    }
+
+    #[test]
+    fn expand_lookup_table_valid() {
+        let addr0 = Pubkey::new_unique();
+        let addr1 = Pubkey::new_unique();
+        let addr2 = Pubkey::new_unique();
+        let table_key = Pubkey::new_unique();
+
+        let account = make_alt_account(&[addr0, addr1, addr2]);
+        let plan = AddressLookupPlan {
+            account_key: table_key,
+            writable_indexes: vec![0, 2],
+            readonly_indexes: vec![1],
+        };
+
+        let resolved = expand_lookup_table(&account, &plan).unwrap();
+        assert_eq!(resolved.account_key, table_key);
+        assert_eq!(resolved.writable_addresses, vec![addr0, addr2]);
+        assert_eq!(resolved.readonly_addresses, vec![addr1]);
+        assert_eq!(resolved.writable_indexes, vec![0, 2]);
+        assert_eq!(resolved.readonly_indexes, vec![1]);
+    }
+
+    #[test]
+    fn expand_lookup_table_malformed_data() {
+        let plan = AddressLookupPlan {
+            account_key: Pubkey::new_unique(),
+            writable_indexes: vec![0],
+            readonly_indexes: vec![],
+        };
+
+        let mut account = AccountSharedData::default();
+        account.set_data_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+
+        let err = expand_lookup_table(&account, &plan).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Failed to parse address lookup table"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn expand_lookup_table_index_out_of_range() {
+        let addr0 = Pubkey::new_unique();
+        let addr1 = Pubkey::new_unique();
+        let table_key = Pubkey::new_unique();
+
+        let account = make_alt_account(&[addr0, addr1]);
+        let plan = AddressLookupPlan {
+            account_key: table_key,
+            writable_indexes: vec![5], // out of range
+            readonly_indexes: vec![],
+        };
+
+        let err = expand_lookup_table(&account, &plan).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Failed to parse writable indexes"),
+            "unexpected error: {msg}"
+        );
     }
 }

--- a/crates/sonar-sim/src/account_loader.rs
+++ b/crates/sonar-sim/src/account_loader.rs
@@ -746,6 +746,58 @@ mod tests {
     }
 
     #[test]
+    fn bpf_dependency_resolution_discovers_programdata_transitively() {
+        use solana_account::Account;
+        use solana_loader_v3_interface::state::UpgradeableLoaderState;
+        use solana_sdk_ids::bpf_loader_upgradeable;
+
+        fn make_bpf_program(programdata_address: &Pubkey) -> AccountSharedData {
+            let state =
+                UpgradeableLoaderState::Program { programdata_address: *programdata_address };
+            let data = bincode::serialize(&state).unwrap();
+            AccountSharedData::from(Account {
+                lamports: 1,
+                data,
+                owner: bpf_loader_upgradeable::id(),
+                executable: true,
+                rent_epoch: 0,
+            })
+        }
+
+        let program_key = Pubkey::new_unique();
+        let programdata_key = Pubkey::new_unique();
+
+        // The programdata account itself (minimal, just needs to exist)
+        let programdata_account = AccountSharedData::from(Account {
+            lamports: 1,
+            data: vec![0; 64],
+            owner: bpf_loader_upgradeable::id(),
+            executable: false,
+            rent_epoch: 0,
+        });
+
+        let provider = FakeAccountProvider::new(HashMap::from([
+            (program_key, make_bpf_program(&programdata_key)),
+            (programdata_key, programdata_account),
+        ]));
+
+        let mut loader = AccountLoader::with_provider(Arc::new(provider));
+        let mut resolved = ResolvedAccounts { accounts: HashMap::new(), lookups: vec![] };
+
+        // Fetch only the program key; dependency resolution should discover programdata.
+        loader.append_accounts(&mut resolved, &[program_key]).unwrap();
+
+        assert!(
+            resolved.accounts.contains_key(&program_key),
+            "resolved accounts should contain the BPF program"
+        );
+        assert!(
+            resolved.accounts.contains_key(&programdata_key),
+            "resolved accounts should contain the programdata dependency discovered transitively"
+        );
+    }
+
+    #[test]
     fn expand_lookup_table_index_out_of_range() {
         let addr0 = Pubkey::new_unique();
         let addr1 = Pubkey::new_unique();

--- a/crates/sonar-sim/src/executor.rs
+++ b/crates/sonar-sim/src/executor.rs
@@ -520,6 +520,7 @@ fn account_priority(account: &AccountSharedData) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::MockSvm;
     use solana_hash::Hash;
     use solana_keypair::Keypair;
     use solana_message::Message;
@@ -868,5 +869,86 @@ mod tests {
         let clock: Clock = bincode::deserialize(&clock_account.data).expect("valid Clock");
         assert_eq!(clock.slot, 500);
         assert_eq!(clock.unix_timestamp, 1_600_000_000);
+    }
+
+    // ── MockSvm-based error-path & round-trip tests ──
+
+    #[test]
+    fn load_accounts_propagates_set_account_error() {
+        let key = Pubkey::new_unique();
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            key,
+            AccountSharedData::from(Account {
+                lamports: 100,
+                data: vec![],
+                owner: solana_sdk_ids::system_program::id(),
+                executable: false,
+                rent_epoch: 0,
+            }),
+        );
+        let resolved = ResolvedAccounts { accounts, lookups: vec![] };
+
+        let mut svm = MockSvm::new();
+        svm.fail_set_account = Some("disk full".into());
+
+        let err = load_accounts(&mut svm, &resolved).unwrap_err();
+        assert!(err.to_string().contains("disk full"));
+    }
+
+    #[test]
+    fn apply_data_patches_on_mock_writes_exact_bytes() {
+        let key = Pubkey::new_unique();
+        let account = Account {
+            lamports: 100,
+            data: vec![0, 0, 0, 0, 0],
+            owner: solana_sdk_ids::system_program::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+        let mut svm = MockSvm::new().with_account(key, account);
+
+        let patches = vec![AccountDataPatch {
+            pubkey: key,
+            offset: 1,
+            data: vec![0xAA, 0xBB],
+        }];
+        apply_data_patches(&mut svm, &patches).expect("should apply");
+
+        let loaded = svm.get_account(&key).unwrap();
+        assert_eq!(loaded.data, vec![0, 0xAA, 0xBB, 0, 0]);
+    }
+
+    #[test]
+    fn apply_timestamp_on_mock_round_trips_clock() {
+        let clock = Clock {
+            slot: 0,
+            epoch_start_timestamp: 0,
+            epoch: 0,
+            leader_schedule_epoch: 0,
+            unix_timestamp: 1_000_000,
+        };
+        let clock_data = bincode::serialize(&clock).unwrap();
+        let clock_account = Account {
+            lamports: 1,
+            data: clock_data,
+            owner: solana_sdk_ids::sysvar::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+        let mut svm = MockSvm::new().with_account(Clock::id(), clock_account);
+
+        apply_timestamp(&mut svm, 1_700_000_000).unwrap();
+
+        let updated = svm.get_account(&Clock::id()).unwrap();
+        let updated_clock: Clock = bincode::deserialize(&updated.data).unwrap();
+        assert_eq!(updated_clock.unix_timestamp, 1_700_000_000);
+    }
+
+    #[test]
+    fn warp_to_slot_on_mock_updates_slot() {
+        let mut svm = MockSvm::new();
+        apply_slot(&mut svm, 42);
+        assert_eq!(svm.slot, 42);
     }
 }

--- a/crates/sonar-sim/src/test_utils.rs
+++ b/crates/sonar-sim/src/test_utils.rs
@@ -1,5 +1,9 @@
 //! Shared test helpers used across `sonar-sim` unit tests.
 
+use std::collections::HashMap;
+use std::path::Path;
+
+use litesvm::types::{TransactionMetadata, TransactionResult};
 use solana_account::{Account, AccountSharedData};
 use solana_hash::Hash;
 use solana_keypair::Keypair;
@@ -13,6 +17,8 @@ use spl_token::solana_program::program_option::COption;
 use spl_token::solana_program::program_pack::Pack;
 use spl_token::solana_program::pubkey::Pubkey as ProgramPubkey;
 use spl_token::state::{Account as SplAccount, AccountState};
+
+use crate::svm_backend::SvmBackend;
 
 pub(crate) fn system_account(lamports: u64) -> Account {
     Account {
@@ -69,4 +75,62 @@ pub(crate) fn make_token_account_shared_with(
         executable: false,
         rent_epoch: 0,
     })
+}
+
+/// In-memory SVM backend for testing executor pipeline functions
+/// without spinning up a real LiteSVM instance.
+pub(crate) struct MockSvm {
+    pub accounts: HashMap<Pubkey, Account>,
+    pub slot: u64,
+    /// When set, `set_account` returns this error string.
+    pub fail_set_account: Option<String>,
+    /// Records program IDs loaded via `add_program_from_file`.
+    pub loaded_programs: Vec<Pubkey>,
+}
+
+impl MockSvm {
+    pub fn new() -> Self {
+        Self {
+            accounts: HashMap::new(),
+            slot: 0,
+            fail_set_account: None,
+            loaded_programs: Vec::new(),
+        }
+    }
+
+    pub fn with_account(mut self, pubkey: Pubkey, account: Account) -> Self {
+        self.accounts.insert(pubkey, account);
+        self
+    }
+}
+
+impl SvmBackend for MockSvm {
+    fn set_account(&mut self, pubkey: Pubkey, account: Account) -> std::result::Result<(), String> {
+        if let Some(ref msg) = self.fail_set_account {
+            return Err(msg.clone());
+        }
+        self.accounts.insert(pubkey, account);
+        Ok(())
+    }
+
+    fn get_account(&self, pubkey: &Pubkey) -> Option<Account> {
+        self.accounts.get(pubkey).cloned()
+    }
+
+    fn add_program_from_file(
+        &mut self,
+        program_id: Pubkey,
+        _so_path: &Path,
+    ) -> std::result::Result<(), String> {
+        self.loaded_programs.push(program_id);
+        Ok(())
+    }
+
+    fn send_transaction(&mut self, _tx: VersionedTransaction) -> TransactionResult {
+        Ok(TransactionMetadata::default())
+    }
+
+    fn warp_to_slot(&mut self, slot: u64) {
+        self.slot = slot;
+    }
 }


### PR DESCRIPTION
## Summary

- Add `MockSvm` — a HashMap-backed `SvmBackend` implementation for isolated executor testing without LiteSVM
- Add 44 new unit tests across `sonar-sim` and `sonar-idl` (138 → 182)
- Extract `expand_lookup_table` pure function from `AccountLoader::load_lookup_table` for testable ALT expansion
- Fix `i8` sign extension bug in IDL parser (`data[start] as i64` → `data[start] as i8 as i64`)

## What's covered

**sonar-sim:**
- `MockSvm` backend with error injection (`fail_set_account`) and call recording (`loaded_programs`)
- Executor error-path tests: `load_accounts` error propagation, `apply_data_patches` byte verification, `apply_timestamp` Clock round-trip
- `account_loader` pure function tests: `collect_initial_accounts` (dedup, sysvars, lookup keys), `resolve_lookup_indexes`, `expand_lookup_table` (valid/malformed/out-of-range)
- BPF dependency resolution integration test: verifies programdata is transitively discovered

**sonar-idl:**
- Direct `parse_simple_type` tests for all 14 primitive types (u8–u128, i8–i128, bool, pubkey, string, bytes)
- Error path tests: truncated data, unknown type fallback
- Container type tests: `parse_vec_type`, `parse_option_type`, `parse_array_type`
- Enum variant tests: struct variant, tuple variant, out-of-range variant index

## Test plan

- [x] `cargo test -p sonar-sim -p sonar-idl` — 182 tests passing
- [x] `cargo test --test e2e_cli_output_streams` — 19 tests passing
- [x] All existing tests unmodified and passing