### PR TITLE
fix: use minimum length check for compute budget instruction data

### DIFF
--- a/src/parsers/instruction/compute_budget_program.rs
+++ b/src/parsers/instruction/compute_budget_program.rs
@@ -79,7 +79,7 @@ fn parse_u32_instruction(
     field_name: &str,
     data: &[u8],
 ) -> Result<Option<ParsedInstruction>> {
-    if data.len() != 4 {
+    if data.len() < 4 {
         return Ok(None);
     }
 
@@ -97,7 +97,7 @@ fn parse_u64_instruction(
     field_name: &str,
     data: &[u8],
 ) -> Result<Option<ParsedInstruction>> {
-    if data.len() != 8 {
+    if data.len() < 8 {
         return Ok(None);
     }
 


### PR DESCRIPTION
## Summary
- Changed compute budget instruction data length checks from exact (`!= N`) to minimum (`< N`)
- Allows parsing instructions that have trailing data beyond the expected payload

## Test plan
- [ ] Existing unit tests still pass
- [ ] Verify instructions with exact-length data still parse correctly
- [ ] Verify instructions with extra trailing bytes are now accepted instead of rejected