### PR TITLE
feat: support owner-aware --fund-token funding

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ sonar simulate <TX> \
   --rpc-url https://api.mainnet-beta.solana.com \
   --fund-token <ACCOUNT>:<MINT>=1000000
 
+# Fund a new token account with explicit mint and owner
+# Owner is required when the token account does not already exist on-chain
+sonar simulate <TX> \
+  --rpc-url https://api.mainnet-beta.solana.com \
+  --fund-token <ACCOUNT>:<MINT>:<OWNER>=1000000
+
 # Fund using decimal amount (uses mint decimals, e.g. 1.5 USDC = 1500000 raw units)
 sonar simulate <TX> \
   --rpc-url https://api.mainnet-beta.solana.com \

--- a/crates/sonar-sim/src/funding/common.rs
+++ b/crates/sonar-sim/src/funding/common.rs
@@ -28,6 +28,7 @@ pub(super) fn update_token_amount_account<T: TokenAmountMut>(
     account: &mut Account,
     account_pubkey: &Pubkey,
     mint: &Pubkey,
+    owner: &Pubkey,
     amount_raw: u64,
     decimals: u8,
     program_kind: TokenProgramKind,
@@ -58,6 +59,7 @@ pub(super) fn update_token_amount_account<T: TokenAmountMut>(
     Ok(PreparedTokenFunding {
         account: *account_pubkey,
         mint: *mint,
+        owner: *owner,
         decimals,
         amount_raw,
         ui_amount: raw_to_ui_amount(amount_raw, decimals),

--- a/crates/sonar-sim/src/funding/mod.rs
+++ b/crates/sonar-sim/src/funding/mod.rs
@@ -306,8 +306,12 @@ mod tests {
         resolved.accounts.insert(token, AccountSharedData::from(token_account));
         resolved.accounts.insert(mint, AccountSharedData::from(mint_account.clone()));
 
-        let funding =
-            TokenFunding { account: token, mint: Some(mint), amount: TokenAmount::Raw(1_500_000) };
+        let funding = TokenFunding {
+            account: token,
+            mint: Some(mint),
+            owner: None,
+            amount: TokenAmount::Raw(1_500_000),
+        };
         let before_data = resolved.accounts.get(&token).unwrap().data().to_vec();
 
         let prepared =
@@ -374,8 +378,12 @@ mod tests {
         let mut resolved = ResolvedAccounts { accounts: HashMap::new(), lookups: vec![] };
         resolved.accounts.insert(mint, mint_shared.clone());
 
-        let funding =
-            TokenFunding { account: token, mint: Some(mint), amount: TokenAmount::Raw(1_500_000) };
+        let funding = TokenFunding {
+            account: token,
+            mint: Some(mint),
+            owner: None,
+            amount: TokenAmount::Raw(1_500_000),
+        };
         let prepared =
             prepare_token_fundings(&mut loader, &resolved, &[funding]).expect("prepares funding");
 

--- a/crates/sonar-sim/src/funding/mod.rs
+++ b/crates/sonar-sim/src/funding/mod.rs
@@ -131,6 +131,7 @@ fn prepare_single_token_funding(
     Ok(PreparedTokenFunding {
         account: request.account,
         mint,
+        owner: request.account, // placeholder — real logic in Task 4
         decimals,
         amount_raw,
         ui_amount: raw_to_ui_amount(amount_raw, decimals),
@@ -183,6 +184,7 @@ fn apply_single_token_funding<B: SvmBackend + ?Sized>(
             &mut account,
             &funding.account,
             &funding.mint,
+            &funding.owner,
             funding.amount_raw,
             funding.decimals,
         )?,
@@ -190,6 +192,7 @@ fn apply_single_token_funding<B: SvmBackend + ?Sized>(
             &mut account,
             &funding.account,
             &funding.mint,
+            &funding.owner,
             funding.amount_raw,
             funding.decimals,
         )?,

--- a/crates/sonar-sim/src/funding/mod.rs
+++ b/crates/sonar-sim/src/funding/mod.rs
@@ -67,36 +67,55 @@ fn prepare_single_token_funding(
         }
     })?;
 
-    let mint = if let Some(account) = lookup_account(resolved, extras, &request.account) {
-        let detected_mint =
-            detect_mint_from_token_account(account).map_err(|e| SonarSimError::Token {
-                account: Some(request.account),
-                reason: format!(
-                    "Failed to detect mint from existing token account {}: {e}",
-                    request.account
-                ),
-            })?;
+    let (mint, owner) = if let Some(account) = lookup_account(resolved, extras, &request.account) {
+        let decoded = decode_existing_token_account(account, &request.account)?;
+
         if let Some(requested_mint) = request.mint {
-            if detected_mint != requested_mint {
+            if decoded.mint != requested_mint {
                 return Err(SonarSimError::Token {
                     account: Some(request.account),
                     reason: format!(
                         "Token account {} is associated with mint {}, but CLI requested mint {}",
-                        request.account, detected_mint, requested_mint
+                        request.account, decoded.mint, requested_mint
                     ),
                 });
             }
         }
-        detected_mint
+
+        if let Some(requested_owner) = request.owner {
+            if decoded.owner != requested_owner {
+                return Err(SonarSimError::Token {
+                    account: Some(request.account),
+                    reason: format!(
+                        "Token account {} has owner {}, but CLI specified owner {}",
+                        request.account, decoded.owner, requested_owner
+                    ),
+                });
+            }
+        }
+
+        (decoded.mint, decoded.owner)
     } else {
-        request.mint.ok_or_else(|| SonarSimError::Token {
+        let mint = request.mint.ok_or_else(|| SonarSimError::Token {
             account: Some(request.account),
             reason: format!(
                 "Token account {} does not exist on-chain; \
-                 you must specify the mint using <ACCOUNT>:<MINT>=<AMOUNT> format",
+                 you must specify mint and owner using \
+                 <ACCOUNT>:<MINT>:<OWNER>=<AMOUNT> format",
                 request.account
             ),
-        })?
+        })?;
+        let owner = request.owner.ok_or_else(|| SonarSimError::Token {
+            account: Some(request.account),
+            reason: format!(
+                "Token account {} does not exist on-chain; \
+                 you must specify the owner using \
+                 <ACCOUNT>:<MINT>:<OWNER>=<AMOUNT> format",
+                request.account
+            ),
+        })?;
+
+        (mint, owner)
     };
 
     ensure_account_loaded(loader, resolved, extras, &mint).map_err(|e| SonarSimError::Token {
@@ -131,7 +150,7 @@ fn prepare_single_token_funding(
     Ok(PreparedTokenFunding {
         account: request.account,
         mint,
-        owner: request.account, // placeholder — real logic in Task 4
+        owner,
         decimals,
         amount_raw,
         ui_amount: raw_to_ui_amount(amount_raw, decimals),
@@ -214,11 +233,13 @@ fn read_rent_from_svm<B: SvmBackend + ?Sized>(svm: &B) -> Result<Rent> {
     })
 }
 
-fn detect_mint_from_token_account(account: &AccountSharedData) -> Result<Pubkey> {
+fn decode_existing_token_account(
+    account: &AccountSharedData,
+    account_pubkey: &Pubkey,
+) -> Result<token_decode::DecodedTokenAccount> {
     token_decode::try_decode_token_account(account.data(), account.owner())
-        .map(|decoded| decoded.mint)
         .ok_or_else(|| SonarSimError::Token {
-            account: None,
+            account: Some(*account_pubkey),
             reason: format!(
                 "Token account is not owned by any known SPL Token program or cannot be decoded (owner: {})",
                 account.owner()
@@ -341,6 +362,121 @@ mod tests {
     }
 
     #[test]
+    fn prepare_validates_owner_matches_onchain() {
+        let mut loader = NoopAppender;
+        let mint = Pubkey::new_unique();
+        let token = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let wrong_owner = Pubkey::new_unique();
+
+        let (token_account, mint_account) = spl_token_account_and_mint(&mint, &owner);
+
+        let mut resolved = ResolvedAccounts { accounts: HashMap::new(), lookups: vec![] };
+        resolved.accounts.insert(token, AccountSharedData::from(token_account));
+        resolved.accounts.insert(mint, AccountSharedData::from(mint_account));
+
+        let funding = TokenFunding {
+            account: token,
+            mint: Some(mint),
+            owner: Some(wrong_owner),
+            amount: TokenAmount::Raw(100),
+        };
+        let err = prepare_token_fundings(&mut loader, &resolved, &[funding]).unwrap_err();
+        assert!(err.to_string().contains("has owner"));
+    }
+
+    #[test]
+    fn prepare_accepts_matching_owner() {
+        let mut loader = NoopAppender;
+        let mint = Pubkey::new_unique();
+        let token = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+
+        let (token_account, mint_account) = spl_token_account_and_mint(&mint, &owner);
+
+        let mut resolved = ResolvedAccounts { accounts: HashMap::new(), lookups: vec![] };
+        resolved.accounts.insert(token, AccountSharedData::from(token_account));
+        resolved.accounts.insert(mint, AccountSharedData::from(mint_account));
+
+        let funding = TokenFunding {
+            account: token,
+            mint: Some(mint),
+            owner: Some(owner),
+            amount: TokenAmount::Raw(100),
+        };
+        let prepared = prepare_token_fundings(&mut loader, &resolved, &[funding]).expect("prepares");
+        assert_eq!(prepared[0].owner, owner);
+    }
+
+    #[test]
+    fn prepare_reads_owner_from_onchain_account() {
+        let mut loader = NoopAppender;
+        let mint = Pubkey::new_unique();
+        let token = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+
+        let (token_account, mint_account) = spl_token_account_and_mint(&mint, &owner);
+
+        let mut resolved = ResolvedAccounts { accounts: HashMap::new(), lookups: vec![] };
+        resolved.accounts.insert(token, AccountSharedData::from(token_account));
+        resolved.accounts.insert(mint, AccountSharedData::from(mint_account));
+
+        let funding = TokenFunding {
+            account: token,
+            mint: None,
+            owner: None,
+            amount: TokenAmount::Raw(100),
+        };
+        let prepared = prepare_token_fundings(&mut loader, &resolved, &[funding]).expect("prepares");
+        assert_eq!(prepared[0].owner, owner);
+    }
+
+    #[test]
+    fn prepare_errors_when_account_missing_and_no_owner() {
+        let mut loader = NoopAppender;
+        let mint = Pubkey::new_unique();
+        let token = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+
+        let (_, mint_account) = spl_token_account_and_mint(&mint, &owner);
+
+        let mut resolved = ResolvedAccounts { accounts: HashMap::new(), lookups: vec![] };
+        resolved.accounts.insert(mint, AccountSharedData::from(mint_account));
+
+        let funding = TokenFunding {
+            account: token,
+            mint: Some(mint),
+            owner: None,
+            amount: TokenAmount::Raw(100),
+        };
+        let err = prepare_token_fundings(&mut loader, &resolved, &[funding]).unwrap_err();
+        assert!(err.to_string().contains("you must specify the owner"));
+    }
+
+    #[test]
+    fn prepare_creates_with_explicit_owner() {
+        let mut loader = NoopAppender;
+        let mint = Pubkey::new_unique();
+        let token = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+
+        let (_, mint_account) = spl_token_account_and_mint(&mint, &owner);
+
+        let mut resolved = ResolvedAccounts { accounts: HashMap::new(), lookups: vec![] };
+        resolved.accounts.insert(mint, AccountSharedData::from(mint_account));
+
+        let funding = TokenFunding {
+            account: token,
+            mint: Some(mint),
+            owner: Some(owner),
+            amount: TokenAmount::Raw(100),
+        };
+        let prepared = prepare_token_fundings(&mut loader, &resolved, &[funding]).expect("prepares");
+        assert_eq!(prepared[0].owner, owner);
+        assert_eq!(prepared[0].mint, mint);
+    }
+
+    #[test]
     fn resolve_raw_amount_passthrough() {
         assert_eq!(resolve_token_amount(&TokenAmount::Raw(42), 6).unwrap(), 42);
     }
@@ -384,7 +520,7 @@ mod tests {
         let funding = TokenFunding {
             account: token,
             mint: Some(mint),
-            owner: None,
+            owner: Some(owner),
             amount: TokenAmount::Raw(1_500_000),
         };
         let prepared =

--- a/crates/sonar-sim/src/funding/mod.rs
+++ b/crates/sonar-sim/src/funding/mod.rs
@@ -544,6 +544,39 @@ mod tests {
         assert_eq!(created.lamports, expected);
     }
 
+    #[test]
+    fn apply_token_funding_creates_account_with_correct_owner() {
+        let mut loader = NoopAppender;
+        let mint = Pubkey::new_unique();
+        let token = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+
+        let (_, mint_account) = spl_token_account_and_mint(&mint, &owner);
+        let mint_shared = AccountSharedData::from(mint_account.clone());
+
+        let mut resolved = ResolvedAccounts { accounts: HashMap::new(), lookups: vec![] };
+        resolved.accounts.insert(mint, mint_shared);
+
+        let funding = TokenFunding {
+            account: token,
+            mint: Some(mint),
+            owner: Some(owner),
+            amount: TokenAmount::Raw(1_000_000),
+        };
+        let prepared =
+            prepare_token_fundings(&mut loader, &resolved, &[funding]).expect("prepares funding");
+
+        let mut svm = LiteSVM::new().with_blockhash_check(false).with_sigverify(false);
+        svm.set_account(mint, mint_account).unwrap();
+
+        apply_token_fundings(&mut svm, &prepared, &resolved).expect("applies funding to svm");
+
+        let created = svm.get_account(&token).expect("token account should be created");
+        let parsed = SplAccount::unpack(&created.data[..SplAccount::LEN]).unwrap();
+        assert_eq!(Pubkey::new_from_array(parsed.owner.to_bytes()), owner);
+        assert_eq!(parsed.amount, 1_000_000);
+    }
+
     fn spl_token_account_and_mint(mint: &Pubkey, owner: &Pubkey) -> (Account, Account) {
         let token_state = SplAccount {
             mint: ProgramPubkey::new_from_array(mint.to_bytes()),

--- a/crates/sonar-sim/src/funding/mod.rs
+++ b/crates/sonar-sim/src/funding/mod.rs
@@ -186,11 +186,17 @@ fn apply_single_token_funding<B: SvmBackend + ?Sized>(
             .ok_or(SonarSimError::AccountNotFound { pubkey: funding.mint })?;
         let created = match kind {
             TokenProgramKind::Legacy => {
-                token_legacy::build_token_account(&funding.account, &funding.mint, &rent)?
+                token_legacy::build_token_account(
+                    &funding.account,
+                    &funding.mint,
+                    &funding.owner,
+                    &rent,
+                )?
             }
             TokenProgramKind::Token2022 => token2022::build_token_account_with_extensions(
                 &funding.account,
                 &funding.mint,
+                &funding.owner,
                 mint_account,
                 &rent,
             )?,

--- a/crates/sonar-sim/src/funding/token2022.rs
+++ b/crates/sonar-sim/src/funding/token2022.rs
@@ -13,6 +13,7 @@ use crate::types::PreparedTokenFunding;
 pub(super) fn build_token_account_with_extensions(
     account_pubkey: &Pubkey,
     mint: &Pubkey,
+    owner: &Pubkey,
     mint_account: &AccountSharedData,
     rent: &Rent,
 ) -> Result<AccountSharedData> {
@@ -47,7 +48,7 @@ pub(super) fn build_token_account_with_extensions(
 
     state.base = Token2022Account {
         mint: ProgramPubkey::new_from_array(mint.to_bytes()),
-        owner: ProgramPubkey::new_from_array(account_pubkey.to_bytes()),
+        owner: ProgramPubkey::new_from_array(owner.to_bytes()),
         amount: 0,
         delegate: COption::None,
         state: AccountState::Initialized,
@@ -165,10 +166,12 @@ mod tests {
     fn create_base_only_account() {
         let mint = Pubkey::new_unique();
         let token = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
         let mint_account = mint_account_base_only();
         let rent = Rent::default();
         let account =
-            build_token_account_with_extensions(&token, &mint, &mint_account, &rent).unwrap();
+            build_token_account_with_extensions(&token, &mint, &owner, &mint_account, &rent)
+                .unwrap();
         assert_eq!(*account.owner(), token2022_program_id());
         assert_eq!(account.lamports(), rent.minimum_balance(Token2022Account::LEN));
         assert_eq!(
@@ -186,10 +189,12 @@ mod tests {
     fn create_account_with_transfer_fee_extension() {
         let mint = Pubkey::new_unique();
         let token = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
         let mint_account = mint_account_with_transfer_fee_config();
         let rent = Rent::default();
         let account =
-            build_token_account_with_extensions(&token, &mint, &mint_account, &rent).unwrap();
+            build_token_account_with_extensions(&token, &mint, &owner, &mint_account, &rent)
+                .unwrap();
         assert_eq!(*account.owner(), token2022_program_id());
         assert!(
             account.data().len() > Token2022Account::LEN,
@@ -214,8 +219,14 @@ mod tests {
         let owner = Pubkey::new_unique();
         let mint_account = mint_account_base_only();
         let mut account = Account::from(
-            build_token_account_with_extensions(&token, &mint, &mint_account, &Rent::default())
-                .unwrap(),
+            build_token_account_with_extensions(
+                &token,
+                &mint,
+                &owner,
+                &mint_account,
+                &Rent::default(),
+            )
+            .unwrap(),
         );
         let result =
             update_token_balance_in_account(&mut account, &token, &mint, &owner, 5_000_000, 6).unwrap();
@@ -224,5 +235,19 @@ mod tests {
 
         let state = StateWithExtensions::<Token2022Account>::unpack(&account.data).expect("unpack");
         assert_eq!(state.base.amount, 5_000_000);
+    }
+
+    #[test]
+    fn create_sets_owner_field() {
+        let mint = Pubkey::new_unique();
+        let token = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let mint_account = mint_account_base_only();
+        let rent = Rent::default();
+        let account =
+            build_token_account_with_extensions(&token, &mint, &owner, &mint_account, &rent)
+                .unwrap();
+        let state = StateWithExtensions::<Token2022Account>::unpack(account.data()).expect("unpack");
+        assert_eq!(Pubkey::new_from_array(state.base.owner.to_bytes()), owner);
     }
 }

--- a/crates/sonar-sim/src/funding/token2022.rs
+++ b/crates/sonar-sim/src/funding/token2022.rs
@@ -81,6 +81,7 @@ pub(super) fn update_token_balance_in_account(
     account: &mut Account,
     account_pubkey: &Pubkey,
     mint: &Pubkey,
+    owner: &Pubkey,
     amount_raw: u64,
     decimals: u8,
 ) -> Result<PreparedTokenFunding> {
@@ -88,6 +89,7 @@ pub(super) fn update_token_balance_in_account(
         account,
         account_pubkey,
         mint,
+        owner,
         amount_raw,
         decimals,
         TokenProgramKind::Token2022,
@@ -209,13 +211,14 @@ mod tests {
     fn update_sets_amount() {
         let mint = Pubkey::new_unique();
         let token = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
         let mint_account = mint_account_base_only();
         let mut account = Account::from(
             build_token_account_with_extensions(&token, &mint, &mint_account, &Rent::default())
                 .unwrap(),
         );
         let result =
-            update_token_balance_in_account(&mut account, &token, &mint, 5_000_000, 6).unwrap();
+            update_token_balance_in_account(&mut account, &token, &mint, &owner, 5_000_000, 6).unwrap();
         assert_eq!(result.amount_raw, 5_000_000);
         assert!((result.ui_amount - 5.0).abs() < f64::EPSILON);
 

--- a/crates/sonar-sim/src/funding/token_legacy.rs
+++ b/crates/sonar-sim/src/funding/token_legacy.rs
@@ -42,6 +42,7 @@ pub(super) fn update_token_balance_in_account(
     account: &mut Account,
     account_pubkey: &Pubkey,
     mint: &Pubkey,
+    owner: &Pubkey,
     amount_raw: u64,
     decimals: u8,
 ) -> Result<PreparedTokenFunding> {
@@ -49,6 +50,7 @@ pub(super) fn update_token_balance_in_account(
         account,
         account_pubkey,
         mint,
+        owner,
         amount_raw,
         decimals,
         TokenProgramKind::Legacy,
@@ -85,10 +87,11 @@ mod tests {
     fn update_sets_amount() {
         let mint = Pubkey::new_unique();
         let token = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
         let mut account =
             Account::from(build_token_account(&token, &mint, &Rent::default()).unwrap());
         let result =
-            update_token_balance_in_account(&mut account, &token, &mint, 42_000_000, 6).unwrap();
+            update_token_balance_in_account(&mut account, &token, &mint, &owner, 42_000_000, 6).unwrap();
         assert_eq!(result.amount_raw, 42_000_000);
         assert_eq!(result.decimals, 6);
         assert!((result.ui_amount - 42.0).abs() < f64::EPSILON);
@@ -101,6 +104,7 @@ mod tests {
     fn update_rejects_wrong_program() {
         let mint = Pubkey::new_unique();
         let token = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
         let mut account = Account {
             lamports: 0,
             data: vec![0u8; 165],
@@ -108,7 +112,7 @@ mod tests {
             executable: false,
             rent_epoch: 0,
         };
-        let err = update_token_balance_in_account(&mut account, &token, &mint, 100, 6).unwrap_err();
+        let err = update_token_balance_in_account(&mut account, &token, &mint, &owner, 100, 6).unwrap_err();
         assert!(err.to_string().contains("not owned by"));
     }
 }

--- a/crates/sonar-sim/src/funding/token_legacy.rs
+++ b/crates/sonar-sim/src/funding/token_legacy.rs
@@ -12,12 +12,13 @@ use crate::types::PreparedTokenFunding;
 pub(super) fn build_token_account(
     account_pubkey: &Pubkey,
     mint: &Pubkey,
+    owner: &Pubkey,
     rent: &Rent,
 ) -> Result<AccountSharedData> {
     let mut data = vec![0u8; SplAccount::LEN];
     let state = SplAccount {
         mint: ProgramPubkey::new_from_array(mint.to_bytes()),
-        owner: ProgramPubkey::new_from_array(account_pubkey.to_bytes()),
+        owner: ProgramPubkey::new_from_array(owner.to_bytes()),
         amount: 0,
         delegate: COption::None,
         state: AccountState::Initialized,
@@ -73,8 +74,9 @@ mod tests {
     fn create_initializes_valid_account() {
         let mint = Pubkey::new_unique();
         let token = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
         let rent = Rent::default();
-        let account = build_token_account(&token, &mint, &rent).unwrap();
+        let account = build_token_account(&token, &mint, &owner, &rent).unwrap();
         assert_eq!(*account.owner(), legacy_program_id());
         assert_eq!(account.lamports(), rent.minimum_balance(SplAccount::LEN));
 
@@ -89,7 +91,7 @@ mod tests {
         let token = Pubkey::new_unique();
         let owner = Pubkey::new_unique();
         let mut account =
-            Account::from(build_token_account(&token, &mint, &Rent::default()).unwrap());
+            Account::from(build_token_account(&token, &mint, &owner, &Rent::default()).unwrap());
         let result =
             update_token_balance_in_account(&mut account, &token, &mint, &owner, 42_000_000, 6).unwrap();
         assert_eq!(result.amount_raw, 42_000_000);
@@ -114,5 +116,16 @@ mod tests {
         };
         let err = update_token_balance_in_account(&mut account, &token, &mint, &owner, 100, 6).unwrap_err();
         assert!(err.to_string().contains("not owned by"));
+    }
+
+    #[test]
+    fn create_sets_owner_field() {
+        let mint = Pubkey::new_unique();
+        let token = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let rent = Rent::default();
+        let account = build_token_account(&token, &mint, &owner, &rent).unwrap();
+        let parsed = SplAccount::unpack(&account.data()[..SplAccount::LEN]).unwrap();
+        assert_eq!(Pubkey::new_from_array(parsed.owner.to_bytes()), owner);
     }
 }

--- a/crates/sonar-sim/src/types/funding.rs
+++ b/crates/sonar-sim/src/types/funding.rs
@@ -21,6 +21,7 @@ pub enum TokenAmount {
 pub struct TokenFunding {
     pub account: Pubkey,
     pub mint: Option<Pubkey>,
+    pub owner: Option<Pubkey>,
     pub amount: TokenAmount,
 }
 

--- a/crates/sonar-sim/src/types/funding.rs
+++ b/crates/sonar-sim/src/types/funding.rs
@@ -29,6 +29,7 @@ pub struct TokenFunding {
 pub struct PreparedTokenFunding {
     pub account: Pubkey,
     pub mint: Pubkey,
+    pub owner: Pubkey,
     pub decimals: u8,
     pub amount_raw: u64,
     pub ui_amount: f64,

--- a/src/cli/simulate.rs
+++ b/src/cli/simulate.rs
@@ -285,7 +285,7 @@ pub fn parse_token_funding(raw: &str) -> Result<TokenFunding, String> {
         TokenAmount::Raw(raw)
     };
 
-    Ok(TokenFunding { account, mint, amount })
+    Ok(TokenFunding { account, mint, owner: None, amount })
 }
 
 pub fn parse_data_patch(raw: &str) -> Result<AccountDataPatch, String> {

--- a/src/cli/simulate.rs
+++ b/src/cli/simulate.rs
@@ -45,9 +45,11 @@ pub struct SimulateArgs {
     )]
     pub fundings: Vec<String>,
     /// Fund a token account.
-    /// Format: <ACCOUNT>=<AMOUNT> or <ACCOUNT>:<MINT>=<AMOUNT> (mint auto-detected if account exists on-chain).
+    /// Format: <ACCOUNT>=<AMOUNT>, <ACCOUNT>:<MINT>=<AMOUNT>,
+    /// or <ACCOUNT>:<MINT>:<OWNER>=<AMOUNT> (mint/owner auto-detected if account exists on-chain).
+    /// Owner is required when creating a new account that doesn't exist on-chain.
     /// Integer amounts are treated as raw token units; decimal amounts (e.g. 1.5) are
-    /// converted using the mint's decimals (e.g. 1.5 with 6 decimals → 1500000).
+    /// converted using the mint's decimals (e.g. 1.5 with 6 decimals -> 1500000).
     #[arg(
         long = "fund-token",
         help_heading = HELP_HEADING_STATE_PREPARATION,
@@ -246,22 +248,33 @@ pub fn parse_funding(raw: &str) -> Result<SolFunding, String> {
 
 pub fn parse_token_funding(raw: &str) -> Result<TokenFunding, String> {
     let (target, amount_str) = raw.split_once('=').ok_or_else(|| {
-        "Token funding must be in <ACCOUNT>=<AMOUNT> or <ACCOUNT>:<MINT>=<AMOUNT> format"
+        "Token funding must be in <ACCOUNT>=<AMOUNT>, <ACCOUNT>:<MINT>=<AMOUNT>, \
+         or <ACCOUNT>:<MINT>:<OWNER>=<AMOUNT> format"
             .to_string()
     })?;
 
-    let (token_str, mint) = if let Some((token_part, mint_str)) = target.split_once(':') {
-        if mint_str.contains(':') {
+    let parts: Vec<&str> = target.split(':').collect();
+    let (token_str, mint, owner) = match parts.len() {
+        1 => (parts[0], None, None),
+        2 => {
+            let mint = Pubkey::from_str(parts[1])
+                .map_err(|err| format!("Failed to parse mint account `{}`: {err}", parts[1]))?;
+            (parts[0], Some(mint), None)
+        }
+        3 => {
+            let mint = Pubkey::from_str(parts[1])
+                .map_err(|err| format!("Failed to parse mint account `{}`: {err}", parts[1]))?;
+            let owner = Pubkey::from_str(parts[2])
+                .map_err(|err| format!("Failed to parse owner `{}`: {err}", parts[2]))?;
+            (parts[0], Some(mint), Some(owner))
+        }
+        _ => {
             return Err(
-                "Token funding must be in <ACCOUNT>=<AMOUNT> or <ACCOUNT>:<MINT>=<AMOUNT> format"
+                "Token funding must be in <ACCOUNT>=<AMOUNT>, <ACCOUNT>:<MINT>=<AMOUNT>, \
+                 or <ACCOUNT>:<MINT>:<OWNER>=<AMOUNT> format"
                     .to_string(),
             );
         }
-        let mint = Pubkey::from_str(mint_str)
-            .map_err(|err| format!("Failed to parse mint account `{mint_str}`: {err}"))?;
-        (token_part, Some(mint))
-    } else {
-        (target, None)
     };
 
     let account = Pubkey::from_str(token_str)
@@ -285,7 +298,7 @@ pub fn parse_token_funding(raw: &str) -> Result<TokenFunding, String> {
         TokenAmount::Raw(raw)
     };
 
-    Ok(TokenFunding { account, mint, owner: None, amount })
+    Ok(TokenFunding { account, mint, owner, amount })
 }
 
 pub fn parse_data_patch(raw: &str) -> Result<AccountDataPatch, String> {
@@ -560,11 +573,49 @@ mod tests {
     }
 
     #[test]
+    fn parse_token_funding_accepts_owner() {
+        let token = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let input = format!("{token}:{mint}:{owner}=12345");
+        let parsed = parse_token_funding(&input).expect("parses");
+        assert_eq!(parsed.account, token);
+        assert_eq!(parsed.mint, Some(mint));
+        assert_eq!(parsed.owner, Some(owner));
+        assert!(matches!(parsed.amount, TokenAmount::Raw(12_345)));
+    }
+
+    #[test]
+    fn parse_token_funding_with_mint_no_owner() {
+        let token = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let input = format!("{token}:{mint}=100");
+        let parsed = parse_token_funding(&input).expect("parses");
+        assert_eq!(parsed.owner, None);
+    }
+
+    #[test]
+    fn parse_token_funding_without_mint_has_no_owner() {
+        let token = Pubkey::new_unique();
+        let input = format!("{token}=100");
+        let parsed = parse_token_funding(&input).expect("parses");
+        assert_eq!(parsed.mint, None);
+        assert_eq!(parsed.owner, None);
+    }
+
+    #[test]
+    fn parse_token_funding_rejects_four_colons() {
+        let keys: Vec<_> = (0..4).map(|_| Pubkey::new_unique()).collect();
+        let err = parse_token_funding(&format!("{}:{}:{}:{}=100", keys[0], keys[1], keys[2], keys[3])).unwrap_err();
+        assert!(err.contains("<ACCOUNT>"));
+    }
+
+    #[test]
     fn parse_token_funding_rejects_extra_colons() {
         let key = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
         let err = parse_token_funding(&format!("{key}:{mint}:extra=100")).unwrap_err();
-        assert!(err.contains("<ACCOUNT>"));
+        assert!(err.contains("Failed to parse owner"));
     }
 
     #[test]

--- a/src/core/account_file.rs
+++ b/src/core/account_file.rs
@@ -81,6 +81,14 @@ pub fn parse_account_json(path: &Path) -> Result<Account, String> {
     })
 }
 
+pub(crate) fn is_missing_account_placeholder(account: &Account) -> bool {
+    account.lamports == 0
+        && account.data.is_empty()
+        && account.owner == system_program::id()
+        && !account.executable
+        && account.rent_epoch == 0
+}
+
 // ---------------------------------------------------------------------------
 // Account dump (Solana CLI compatible JSON format)
 // ---------------------------------------------------------------------------
@@ -262,6 +270,7 @@ mod tests {
         assert!(parsed.data.is_empty());
         assert_eq!(parsed.owner, solana_sdk_ids::system_program::id());
         assert!(!parsed.executable);
+        assert!(is_missing_account_placeholder(&parsed));
 
         let _ = std::fs::remove_dir_all(&temp_dir);
     }

--- a/src/core/account_loader.rs
+++ b/src/core/account_loader.rs
@@ -29,6 +29,14 @@ impl sonar_sim::AccountSource for LocalDirSource {
             if path.exists() {
                 let account = crate::core::account_file::parse_account_json(&path)
                     .map_err(|e| sonar_sim::SonarSimError::Internal { reason: e.to_string() })?;
+                if crate::core::account_file::is_missing_account_placeholder(&account) {
+                    debug!(
+                        "Ignoring placeholder account {} from local file: {}",
+                        key,
+                        path.display()
+                    );
+                    continue;
+                }
                 debug!("Loaded account {} from local file: {}", key, path.display());
                 found.insert(*key, AccountSharedData::from(account));
             }
@@ -149,8 +157,8 @@ mod tests {
     use solana_sysvar_id::SysvarId;
     use solana_transaction::Transaction;
     use solana_transaction::versioned::VersionedTransaction;
-    use sonar_sim::AccountAppender;
     use sonar_sim::ResolvedAccounts;
+    use sonar_sim::{AccountAppender, AccountSource};
     use sonar_sim::{FakeAccountProvider, RpcAccountProvider};
 
     fn system_account(lamports: u64) -> Account {
@@ -324,7 +332,7 @@ mod tests {
         let payer = Keypair::new();
         let recipient = Pubkey::new_unique();
 
-        for (pubkey, lamports) in [(payer.pubkey(), 10_000_000_000u64), (recipient, 0)] {
+        for (pubkey, lamports) in [(payer.pubkey(), 10_000_000_000u64), (recipient, 1)] {
             let json = serde_json::json!({
                 "lamports": lamports,
                 "data": ["", "base64"],
@@ -350,6 +358,42 @@ mod tests {
 
         assert!(resolved.accounts.contains_key(&payer.pubkey()));
         assert!(resolved.accounts.contains_key(&recipient));
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn local_dir_placeholder_accounts_are_treated_as_missing() {
+        let temp_dir = std::env::temp_dir()
+            .join(format!("sonar_test_local_dir_placeholder_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        let missing = Pubkey::new_unique();
+        let placeholder = serde_json::json!({
+            "pubkey": missing.to_string(),
+            "account": {
+                "lamports": 0,
+                "data": ["", "base64"],
+                "owner": solana_sdk_ids::system_program::id().to_string(),
+                "executable": false,
+                "rentEpoch": 0,
+                "space": 0
+            }
+        });
+        std::fs::write(
+            temp_dir.join(format!("{missing}.json")),
+            serde_json::to_string_pretty(&placeholder).unwrap(),
+        )
+        .unwrap();
+
+        let source = LocalDirSource::new(temp_dir.clone());
+        let resolved = source.resolve(&[missing]).expect("placeholder load should succeed");
+
+        assert!(
+            resolved.is_empty(),
+            "placeholder cache files should be treated as missing accounts"
+        );
 
         let _ = std::fs::remove_dir_all(&temp_dir);
     }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -404,11 +404,13 @@ mod tests {
             cli::TokenFunding {
                 account: account_in_tx,
                 mint: Some(mint_in_tx),
+                owner: None,
                 amount: cli::TokenAmount::Raw(100),
             },
             cli::TokenFunding {
                 account: account_not_in_tx,
                 mint: Some(mint_not_in_tx),
+                owner: None,
                 amount: cli::TokenAmount::Raw(200),
             },
         ];
@@ -428,6 +430,7 @@ mod tests {
         let token_fundings = vec![cli::TokenFunding {
             account,
             mint: Some(mint),
+            owner: None,
             amount: cli::TokenAmount::Raw(100),
         }];
 


### PR DESCRIPTION
## Summary
- add owner-aware `--fund-token` parsing for `<ACCOUNT>:<MINT>:<OWNER>=<AMOUNT>`
- validate and resolve token account owners during preparation, and preserve the resolved owner when creating SPL Token and Token-2022 accounts
- add integration coverage and README docs for funding newly created token accounts with an explicit owner

## Test Plan
- `cargo test parse_token_funding -- --nocapture`
- `cargo test -p sonar-sim --lib`
- `cargo test`