### PR TITLE
refactor: deduplicate CLI input, hex parsing, and cache helpers

### DIFF
--- a/src/cli/simulate.rs
+++ b/src/cli/simulate.rs
@@ -184,6 +184,22 @@ pub use sonar_sim::{
     InstructionDataPatch, SolFunding, TokenAmount, TokenFunding,
 };
 
+/// Parse a pubkey string with an optional `:w` (writable) or `:r` (read-only)
+/// suffix.  Defaults to writable when no suffix is present.
+fn parse_pubkey_with_writable_flag(value_str: &str) -> Result<(Pubkey, bool), String> {
+    let value_str = value_str.trim();
+    let (pubkey_str, writable) = if let Some(pk) = value_str.strip_suffix(":w") {
+        (pk, true)
+    } else if let Some(pk) = value_str.strip_suffix(":r") {
+        (pk, false)
+    } else {
+        (value_str, true)
+    };
+    let pubkey = Pubkey::from_str(pubkey_str)
+        .map_err(|err| format!("Failed to parse pubkey `{pubkey_str}`: {err}"))?;
+    Ok((pubkey, writable))
+}
+
 pub fn parse_override(raw: &str) -> Result<AccountOverride, String> {
     let (pubkey_str, path_str) = raw
         .split_once('=')
@@ -317,27 +333,7 @@ pub fn parse_data_patch(raw: &str) -> Result<AccountDataPatch, String> {
         .parse()
         .map_err(|err| format!("Failed to parse offset `{offset_str}`: {err}"))?;
 
-    let hex_str = hex_str.trim();
-    let hex_str =
-        hex_str.strip_prefix("0x").or_else(|| hex_str.strip_prefix("0X")).unwrap_or(hex_str);
-
-    if hex_str.is_empty() {
-        return Err("HEX_DATA must not be empty".to_string());
-    }
-    if hex_str.len() % 2 != 0 {
-        return Err(format!(
-            "HEX_DATA has odd length {}; expected an even number of hex characters",
-            hex_str.len()
-        ));
-    }
-
-    let data = (0..hex_str.len())
-        .step_by(2)
-        .map(|i| {
-            u8::from_str_radix(&hex_str[i..i + 2], 16)
-                .map_err(|err| format!("Invalid hex at position {i}: {err}"))
-        })
-        .collect::<Result<Vec<u8>, _>>()?;
+    let data = crate::utils::parse_hex_data(hex_str)?;
 
     Ok(AccountDataPatch { pubkey, offset, data })
 }
@@ -364,17 +360,7 @@ pub fn parse_ix_account_patch(raw: &str) -> Result<InstructionAccountPatch, Stri
         return Err("Account position is 1-based and must be >= 1".to_string());
     }
 
-    let value_str = value_str.trim();
-    let (pubkey_str, writable) = if let Some(pk) = value_str.strip_suffix(":w") {
-        (pk, true)
-    } else if let Some(pk) = value_str.strip_suffix(":r") {
-        (pk, false)
-    } else {
-        (value_str, true)
-    };
-
-    let new_pubkey = Pubkey::from_str(pubkey_str)
-        .map_err(|err| format!("Failed to parse pubkey `{pubkey_str}`: {err}"))?;
+    let (new_pubkey, writable) = parse_pubkey_with_writable_flag(value_str)?;
     Ok(InstructionAccountPatch {
         instruction_index: ix_1based - 1,
         account_position: pos_1based - 1,
@@ -395,17 +381,7 @@ pub fn parse_ix_account_append(raw: &str) -> Result<InstructionAccountAppend, St
         return Err("Instruction index is 1-based and must be >= 1".to_string());
     }
 
-    let value_str = value_str.trim();
-    let (pubkey_str, writable) = if let Some(pk) = value_str.strip_suffix(":w") {
-        (pk, true)
-    } else if let Some(pk) = value_str.strip_suffix(":r") {
-        (pk, false)
-    } else {
-        (value_str, true)
-    };
-
-    let new_pubkey = Pubkey::from_str(pubkey_str)
-        .map_err(|err| format!("Failed to parse pubkey `{pubkey_str}`: {err}"))?;
+    let (new_pubkey, writable) = parse_pubkey_with_writable_flag(value_str)?;
     Ok(InstructionAccountAppend { instruction_index: ix_1based - 1, new_pubkey, writable })
 }
 
@@ -431,25 +407,7 @@ pub fn parse_ix_data_patch(raw: &str) -> Result<InstructionDataPatch, String> {
         .parse()
         .map_err(|err| format!("Failed to parse offset `{offset_str}`: {err}"))?;
 
-    let hex_str = hex_str.trim();
-    let hex_str =
-        hex_str.strip_prefix("0x").or_else(|| hex_str.strip_prefix("0X")).unwrap_or(hex_str);
-    if hex_str.is_empty() {
-        return Err("HEX_DATA must not be empty".to_string());
-    }
-    if hex_str.len() % 2 != 0 {
-        return Err(format!(
-            "HEX_DATA has odd length {}; expected an even number of hex characters",
-            hex_str.len()
-        ));
-    }
-    let data = (0..hex_str.len())
-        .step_by(2)
-        .map(|i| {
-            u8::from_str_radix(&hex_str[i..i + 2], 16)
-                .map_err(|err| format!("Invalid hex at position {i}: {err}"))
-        })
-        .collect::<Result<Vec<u8>, _>>()?;
+    let data = crate::utils::parse_hex_data(hex_str)?;
 
     Ok(InstructionDataPatch { instruction_index: ix_1based - 1, offset, data })
 }

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -11,10 +11,7 @@ pub mod types;
 
 pub use types::{ConvertRequest, InputFormat, OutputFormat};
 
-use std::{
-    io::{IsTerminal, Read},
-    str::FromStr,
-};
+use std::str::FromStr;
 
 use base64::Engine;
 use num_bigint::{BigUint, Sign};
@@ -232,35 +229,11 @@ fn normalize_separator(raw: &str) -> Result<&str, String> {
     Ok(raw)
 }
 
-fn read_convert_input(input: Option<&str>) -> Result<String, String> {
-    if let Some(input) = input {
-        let trimmed = input.trim();
-        if trimmed.is_empty() {
-            return Err("Input cannot be empty".to_string());
-        }
-        return Ok(trimmed.to_owned());
-    }
-
-    if !std::io::stdin().is_terminal() {
-        let mut buf = String::new();
-        std::io::stdin()
-            .read_to_string(&mut buf)
-            .map_err(|e| format!("Failed to read input from stdin: {}", e))?;
-        let trimmed = buf.trim();
-        if trimmed.is_empty() {
-            return Err("No input data received from stdin".to_string());
-        }
-        return Ok(trimmed.to_owned());
-    }
-
-    Err("No input provided. Pass INPUT as a positional argument or pipe via stdin".to_string())
-}
-
 /// Perform the complete conversion from input to output.
 pub fn convert(req: &ConvertRequest) -> Result<String, String> {
     let separator = normalize_separator(&req.sep)?;
     let big_endian = !req.le;
-    let input = read_convert_input(req.input.as_deref())?;
+    let input = crate::utils::read_cli_input(req.input.as_deref(), "input")?;
     let value = parse_input_with_format(&input, req.from)?;
     format_target(&value, req.to, big_endian, separator, !req.no_prefix, req.escape)
 }

--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -16,7 +16,6 @@ use solana_message::inner_instruction::InnerInstructionsList;
 use solana_signature::Signature;
 use solana_transaction::versioned::{TransactionVersion, VersionedTransaction};
 use solana_transaction_status_client_types::UiTransactionEncoding;
-use std::io::{IsTerminal, Read};
 use std::str::FromStr;
 
 use crate::utils::progress::Progress;
@@ -125,27 +124,7 @@ pub struct AddressLookupSummary {
 // ---------------------------------------------------------------------------
 
 pub fn read_raw_transaction(inline: Option<String>) -> Result<String> {
-    if let Some(tx) = inline {
-        let trimmed = tx.trim();
-        if trimmed.is_empty() {
-            Err(anyhow!("Raw transaction string cannot be empty"))
-        } else {
-            Ok(trimmed.to_owned())
-        }
-    } else if !std::io::stdin().is_terminal() {
-        let mut buf = String::new();
-        std::io::stdin()
-            .read_to_string(&mut buf)
-            .context("Failed to read transaction from stdin")?;
-        let trimmed = buf.trim();
-        if trimmed.is_empty() {
-            Err(anyhow!("No transaction data received from stdin"))
-        } else {
-            Ok(trimmed.to_owned())
-        }
-    } else {
-        Err(anyhow!("No transaction provided. Pass TX as a positional argument or pipe via stdin"))
-    }
+    crate::utils::read_cli_input(inline.as_deref(), "transaction").map_err(|e| anyhow!(e))
 }
 
 pub fn is_transaction_signature(s: &str) -> bool {

--- a/src/handlers/account.rs
+++ b/src/handlers/account.rs
@@ -394,20 +394,19 @@ fn try_load_idl_from_dir(idl_dir: &Option<PathBuf>, owner: &Pubkey) -> Option<St
     let path = idl_dir.as_ref()?;
     let idl_file = path.join(format!("{}.json", owner));
 
-    if idl_file.exists() {
-        match fs::read_to_string(&idl_file) {
-            Ok(content) => {
-                log::debug!("Loaded IDL from {}", idl_file.display());
-                Some(content)
-            }
-            Err(e) => {
-                log::warn!("Failed to read IDL file {}: {}", idl_file.display(), e);
-                None
-            }
+    match fs::read_to_string(&idl_file) {
+        Ok(content) => {
+            log::debug!("Loaded IDL from {}", idl_file.display());
+            Some(content)
         }
-    } else {
-        log::debug!("IDL file not found: {}", idl_file.display());
-        None
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            log::debug!("IDL file not found: {}", idl_file.display());
+            None
+        }
+        Err(e) => {
+            log::warn!("Failed to read IDL file {}: {}", idl_file.display(), e);
+            None
+        }
     }
 }
 

--- a/src/handlers/borsh.rs
+++ b/src/handlers/borsh.rs
@@ -1,5 +1,3 @@
-use std::io::{IsTerminal, Read};
-
 use anyhow::{Context, Result};
 
 use crate::cli::{BorshArgs, BorshCommands, BorshDeArgs, BorshSerArgs};
@@ -18,7 +16,8 @@ fn handle_de(args: BorshDeArgs) -> Result<()> {
     let ty = parse_borsh_type(&args.type_str)
         .map_err(|e| anyhow::anyhow!("invalid type descriptor: {e}"))?;
 
-    let raw = read_input(args.input.as_deref(), "bytes")?;
+    let raw = crate::utils::read_cli_input(args.input.as_deref(), "bytes")
+        .map_err(|e| anyhow::anyhow!(e))?;
     let data = parse_input_bytes(&raw)?;
 
     if args.skip_bytes > data.len() {
@@ -50,7 +49,8 @@ fn handle_ser(args: BorshSerArgs) -> Result<()> {
     let ty = parse_borsh_type(&args.type_str)
         .map_err(|e| anyhow::anyhow!("invalid type descriptor: {e}"))?;
 
-    let raw = read_input(args.input.as_deref(), "JSON")?;
+    let raw = crate::utils::read_cli_input(args.input.as_deref(), "JSON")
+        .map_err(|e| anyhow::anyhow!(e))?;
     let value: serde_json::Value =
         serde_json::from_str(&raw).context("failed to parse JSON input")?;
 
@@ -58,7 +58,7 @@ fn handle_ser(args: BorshSerArgs) -> Result<()> {
 
     let prefix_hex = match &args.prefix {
         Some(p) => {
-            let p = p.strip_prefix("0x").or_else(|| p.strip_prefix("0X")).unwrap_or(p);
+            let p = crate::utils::strip_hex_prefix(p);
             hex::decode(p).context("invalid --prefix hex")?;
             p.to_owned()
         }
@@ -67,28 +67,6 @@ fn handle_ser(args: BorshSerArgs) -> Result<()> {
 
     println!("0x{}{}", prefix_hex, hex::encode(&bytes));
     Ok(())
-}
-
-fn read_input(input: Option<&str>, kind: &str) -> Result<String> {
-    if let Some(input) = input {
-        let trimmed = input.trim();
-        if trimmed.is_empty() {
-            anyhow::bail!("input cannot be empty");
-        }
-        return Ok(trimmed.to_owned());
-    }
-
-    if !std::io::stdin().is_terminal() {
-        let mut buf = String::new();
-        std::io::stdin().read_to_string(&mut buf).context("failed to read from stdin")?;
-        let trimmed = buf.trim();
-        if trimmed.is_empty() {
-            anyhow::bail!("no {kind} data received from stdin");
-        }
-        return Ok(trimmed.to_owned());
-    }
-
-    anyhow::bail!("no input provided. Pass {kind} as a positional argument or pipe via stdin")
 }
 
 fn parse_input_bytes(input: &str) -> Result<Vec<u8>> {

--- a/src/handlers/decode.rs
+++ b/src/handlers/decode.rs
@@ -7,33 +7,7 @@ use crate::output;
 use crate::parsers::instruction::ParserRegistry;
 use crate::utils::progress::Progress;
 
-use super::{prepare_accounts_and_idls, resolve_inputs_to_txs};
-
-fn cache_read_dir(cache_dir: Option<PathBuf>, refresh_cache: bool) -> Option<PathBuf> {
-    if refresh_cache { None } else { cache_dir }
-}
-
-fn resolve_decode_cache_state_single(
-    cache: bool,
-    cache_dir: &Option<PathBuf>,
-    refresh_cache: bool,
-    input: &str,
-    parsed_tx: &crate::core::transaction::ParsedTransaction,
-) -> (Option<PathBuf>, bool) {
-    let cache_key = crate::core::cache::derive_cache_key_single(input, &parsed_tx.transaction);
-    crate::core::cache::resolve_cache_state(cache, cache_dir, refresh_cache, &cache_key)
-}
-
-fn resolve_decode_cache_state_bundle(
-    cache: bool,
-    cache_dir: &Option<PathBuf>,
-    refresh_cache: bool,
-    inputs: &[String],
-    parsed_txs: &[crate::core::transaction::ParsedTransaction],
-) -> (Option<PathBuf>, bool) {
-    let cache_key = crate::core::cache::derive_cache_key_bundle(inputs, parsed_txs);
-    crate::core::cache::resolve_cache_state(cache, cache_dir, refresh_cache, &cache_key)
-}
+use super::{cache_read_dir, prepare_accounts_and_idls, resolve_inputs_to_txs};
 
 pub(crate) fn handle(args: DecodeArgs) -> Result<()> {
     let idl_dir = args.idl_dir.clone();
@@ -54,15 +28,7 @@ pub(crate) fn handle(args: DecodeArgs) -> Result<()> {
     let resolver_cache_location = if refresh_cache {
         None
     } else {
-        Some(if cache_dir.is_some() {
-            crate::core::cache::CacheLocation::Explicit(crate::core::cache::resolve_cache_dir(
-                &cache_dir,
-            ))
-        } else {
-            crate::core::cache::CacheLocation::Auto(crate::core::cache::resolve_cache_dir(
-                &cache_dir,
-            ))
-        })
+        Some(super::build_cache_location(&cache_dir))
     };
     let TransactionInputArgs { tx, json } = transaction;
 
@@ -92,13 +58,10 @@ pub(crate) fn handle(args: DecodeArgs) -> Result<()> {
         .expect("single input resolve should produce one transaction");
     let original_input = resolved_tx.original_input;
     let parsed_tx = resolved_tx.parsed_tx;
-    let (decode_cache_dir, offline) = resolve_decode_cache_state_single(
-        !no_cache,
-        &cache_dir,
-        refresh_cache,
-        &original_input,
-        &parsed_tx,
-    );
+    let cache_key =
+        crate::core::cache::derive_cache_key_single(&original_input, &parsed_tx.transaction);
+    let (decode_cache_dir, offline) =
+        crate::core::cache::resolve_cache_state(!no_cache, &cache_dir, refresh_cache, &cache_key);
     let cache_read_dir_for_load = cache_read_dir(decode_cache_dir, refresh_cache);
 
     let prepared = prepare_accounts_and_idls(
@@ -147,13 +110,9 @@ fn handle_bundle(
     let raw_inputs: Vec<_> =
         resolved_txs.iter().map(|entry| entry.original_input.clone()).collect();
     let parsed_txs: Vec<_> = resolved_txs.into_iter().map(|entry| entry.parsed_tx).collect();
-    let (decode_cache_dir, offline) = resolve_decode_cache_state_bundle(
-        cache,
-        &cache_dir,
-        refresh_cache,
-        &raw_inputs,
-        &parsed_txs,
-    );
+    let cache_key = crate::core::cache::derive_cache_key_bundle(&raw_inputs, &parsed_txs);
+    let (decode_cache_dir, offline) =
+        crate::core::cache::resolve_cache_state(cache, &cache_dir, refresh_cache, &cache_key);
     let cache_read_dir_for_load = cache_read_dir(decode_cache_dir, refresh_cache);
     log::info!("Successfully parsed {} transactions", parsed_txs.len());
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod simulate;
 
 use std::path::PathBuf;
 
+use crate::core::cache::CacheLocation;
 use crate::parsers::instruction::ParserRegistry;
 use crate::utils::progress::Progress;
 use crate::{cli, core::account_loader, core::idl_fetcher, core::transaction};
@@ -90,6 +91,22 @@ pub(crate) fn auto_fetch_missing_idls(
     }
 
     Ok(fetched)
+}
+
+/// Returns `None` when `refresh_cache` is true (forcing re-fetch), otherwise
+/// passes through the directory for reading cached accounts.
+pub(crate) fn cache_read_dir(cache_dir: Option<PathBuf>, refresh_cache: bool) -> Option<PathBuf> {
+    if refresh_cache { None } else { cache_dir }
+}
+
+/// Build a `CacheLocation` from CLI args.
+pub(crate) fn build_cache_location(cache_dir: &Option<PathBuf>) -> CacheLocation {
+    let resolved = crate::core::cache::resolve_cache_dir(cache_dir);
+    if cache_dir.is_some() {
+        CacheLocation::Explicit(resolved)
+    } else {
+        CacheLocation::Auto(resolved)
+    }
 }
 
 pub(crate) struct ResolvedInputTransactions {

--- a/src/handlers/simulate.rs
+++ b/src/handlers/simulate.rs
@@ -12,7 +12,19 @@ use sonar_sim::{
     prepare_token_fundings,
 };
 
-use super::{prepare_accounts_and_idls, resolve_inputs_to_txs, warn_unmatched_addresses};
+use super::{
+    cache_read_dir, prepare_accounts_and_idls, resolve_inputs_to_txs, warn_unmatched_addresses,
+};
+
+/// Parse a vector of raw CLI strings using the given parser function.
+fn parse_cli_args<T>(
+    args: Vec<String>,
+    parser: fn(&str) -> Result<T, String>,
+) -> Result<Vec<T>> {
+    args.iter()
+        .map(|raw| parser(raw).map_err(anyhow::Error::msg))
+        .collect()
+}
 
 /// Apply instruction-level mutations (account patches, data patches) and rebuild
 /// the transaction summary so the renderer sees the updated state.
@@ -49,10 +61,6 @@ fn apply_ix_mutations(
     Ok(())
 }
 
-fn cache_read_dir(cache_dir: Option<PathBuf>, refresh_cache: bool) -> Option<PathBuf> {
-    if refresh_cache { None } else { cache_dir }
-}
-
 pub(crate) fn handle(args: SimulateArgs) -> Result<()> {
     // Initialize instruction parser registry (uses configured/default IDL directory).
     let idl_dir = args.idl_dir.clone();
@@ -86,50 +94,17 @@ pub(crate) fn handle(args: SimulateArgs) -> Result<()> {
     // --cache-dir or --refresh-cache imply --cache
     let cache = cache || cache_dir.is_some() || refresh_cache;
     let rpc_url = rpc.rpc_url;
-    let resolver_cache_location = Some(if cache_dir.is_some() {
-        crate::core::cache::CacheLocation::Explicit(crate::core::cache::resolve_cache_dir(
-            &cache_dir,
-        ))
-    } else {
-        crate::core::cache::CacheLocation::Auto(crate::core::cache::resolve_cache_dir(&cache_dir))
-    });
+    let resolver_cache_location = Some(super::build_cache_location(&cache_dir));
 
     let TransactionInputArgs { tx, json } = transaction;
 
-    let overrides = override_args
-        .into_iter()
-        .map(|raw| cli::parse_override(&raw).map_err(anyhow::Error::msg))
-        .collect::<Result<Vec<_>>>()?;
-
-    let sol_fundings = funding_args
-        .into_iter()
-        .map(|raw| cli::parse_funding(&raw).map_err(anyhow::Error::msg))
-        .collect::<Result<Vec<_>>>()?;
-
-    let token_funding_requests = token_funding_args
-        .into_iter()
-        .map(|raw| cli::parse_token_funding(&raw).map_err(anyhow::Error::msg))
-        .collect::<Result<Vec<_>>>()?;
-
-    let data_patches = data_patch_args
-        .into_iter()
-        .map(|raw| cli::parse_data_patch(&raw).map_err(anyhow::Error::msg))
-        .collect::<Result<Vec<_>>>()?;
-
-    let ix_account_patches = ix_account_patch_args
-        .into_iter()
-        .map(|raw| cli::parse_ix_account_patch(&raw).map_err(anyhow::Error::msg))
-        .collect::<Result<Vec<_>>>()?;
-
-    let ix_account_appends = ix_account_append_args
-        .into_iter()
-        .map(|raw| cli::parse_ix_account_append(&raw).map_err(anyhow::Error::msg))
-        .collect::<Result<Vec<_>>>()?;
-
-    let ix_data_patches = ix_data_patch_args
-        .into_iter()
-        .map(|raw| cli::parse_ix_data_patch(&raw).map_err(anyhow::Error::msg))
-        .collect::<Result<Vec<_>>>()?;
+    let overrides = parse_cli_args(override_args, cli::parse_override)?;
+    let sol_fundings = parse_cli_args(funding_args, cli::parse_funding)?;
+    let token_funding_requests = parse_cli_args(token_funding_args, cli::parse_token_funding)?;
+    let data_patches = parse_cli_args(data_patch_args, cli::parse_data_patch)?;
+    let ix_account_patches = parse_cli_args(ix_account_patch_args, cli::parse_ix_account_patch)?;
+    let ix_account_appends = parse_cli_args(ix_account_append_args, cli::parse_ix_account_append)?;
+    let ix_data_patches = parse_cli_args(ix_data_patch_args, cli::parse_ix_data_patch)?;
 
     // Build rendering options once; shared across all code paths.
     let render_opts = output::RenderOptions {

--- a/src/parsers/instruction/mod.rs
+++ b/src/parsers/instruction/mod.rs
@@ -126,37 +126,21 @@ impl ParserRegistry {
             idl_directory: idl_directory.or_else(default_idl_cache_dir),
         };
 
-        // Register default parsers
-        let system_parser = SystemProgramParser::new();
-        registry.parsers.insert(*system_parser.program_id(), Box::new(system_parser));
-
-        // Register Token2022 parser
-        let token2022_parser = Token2022ProgramParser::new();
-        registry.parsers.insert(*token2022_parser.program_id(), Box::new(token2022_parser));
-
-        // Register SPL Token parser by reusing the Token2022 parser implementation
-        let spl_token_parser = Token2022ProgramParser::with_program_id(Pubkey::from_str_const(
+        registry.register(SystemProgramParser::new());
+        registry.register(Token2022ProgramParser::new());
+        registry.register(Token2022ProgramParser::with_program_id(Pubkey::from_str_const(
             "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-        ));
-        registry.parsers.insert(*spl_token_parser.program_id(), Box::new(spl_token_parser));
-
-        // Register Compute Budget parser
-        let compute_budget_parser = ComputeBudgetProgramParser::new();
-        registry
-            .parsers
-            .insert(*compute_budget_parser.program_id(), Box::new(compute_budget_parser));
-
-        // Register Associated Token parser
-        let associated_token_parser = AssociatedTokenProgramParser::new();
-        registry
-            .parsers
-            .insert(*associated_token_parser.program_id(), Box::new(associated_token_parser));
-
-        // Register Memo parser
-        let memo_parser = MemoProgramParser::new();
-        registry.parsers.insert(*memo_parser.program_id(), Box::new(memo_parser));
+        )));
+        registry.register(ComputeBudgetProgramParser::new());
+        registry.register(AssociatedTokenProgramParser::new());
+        registry.register(MemoProgramParser::new());
 
         registry
+    }
+
+    /// Register a parser, keyed by its program ID.
+    fn register(&mut self, parser: impl InstructionParser + 'static) {
+        self.parsers.insert(*parser.program_id(), Box::new(parser));
     }
 
     /// Returns the configured IDL directory used for lazy loading.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,2 +1,67 @@
 pub mod config;
 pub mod progress;
+
+use std::io::{IsTerminal, Read};
+
+/// Read CLI input from a positional argument or stdin.
+///
+/// Returns the trimmed, non-empty input string, or an error describing what
+/// was expected.  The `kind` label (e.g. `"bytes"`, `"JSON"`, `"transaction"`)
+/// is embedded in error messages.
+pub fn read_cli_input(input: Option<&str>, kind: &str) -> Result<String, String> {
+    if let Some(input) = input {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Err(format!("{kind} input cannot be empty"));
+        }
+        return Ok(trimmed.to_owned());
+    }
+
+    if !std::io::stdin().is_terminal() {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(|e| format!("Failed to read {kind} from stdin: {e}"))?;
+        let trimmed = buf.trim();
+        if trimmed.is_empty() {
+            return Err(format!("No {kind} data received from stdin"));
+        }
+        return Ok(trimmed.to_owned());
+    }
+
+    Err(format!(
+        "No input provided. Pass {kind} as a positional argument or pipe via stdin"
+    ))
+}
+
+/// Strip an optional `0x` or `0X` prefix from a hex string.
+pub fn strip_hex_prefix(s: &str) -> &str {
+    s.strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .unwrap_or(s)
+}
+
+/// Parse a hex string (with optional `0x`/`0X` prefix) into bytes.
+///
+/// Returns an error for empty data, odd-length strings, or invalid hex characters.
+pub fn parse_hex_data(raw: &str) -> Result<Vec<u8>, String> {
+    let hex_str = strip_hex_prefix(raw.trim());
+
+    if hex_str.is_empty() {
+        return Err("HEX_DATA must not be empty".to_string());
+    }
+    if hex_str.len() % 2 != 0 {
+        return Err(format!(
+            "HEX_DATA has odd length {}; expected an even number of hex characters",
+            hex_str.len()
+        ));
+    }
+
+    (0..hex_str.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&hex_str[i..i + 2], 16)
+                .map_err(|err| format!("Invalid hex at position {i}: {err}"))
+        })
+        .collect()
+}


### PR DESCRIPTION
## Summary

- Extract `read_cli_input()`, `strip_hex_prefix()`, and `parse_hex_data()` to `src/utils/mod.rs`, replacing 3 near-identical stdin-reading functions and 3 duplicate hex-parsing blocks
- Add `parse_pubkey_with_writable_flag()` in `src/cli/simulate.rs` to unify `:w`/`:r` suffix parsing
- Move `cache_read_dir()` and `build_cache_location()` to `src/handlers/mod.rs`, removing duplicates from simulate and decode handlers
- Inline thin `resolve_decode_cache_state_{single,bundle}` wrappers in decode handler
- Add `ParserRegistry::register()` method, collapsing 6 repetitive 3-line registration blocks
- Add `parse_cli_args()` helper to unify 7 identical `.map(parse).collect()` blocks in simulate handler
- Fix TOCTOU race in `try_load_idl_from_dir()` (read directly, match on NotFound)

Net: **-113 lines** (163 added, 276 removed) across 10 files. All 535 tests pass, no new clippy warnings.

## Test plan

- [x] `cargo test` — 535 passed, 7 ignored
- [x] `cargo clippy` — same 6 pre-existing warnings, no new ones
- [x] `cargo check` — clean compile