### PR TITLE
chore: add MSRV 1.86.0 to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,14 @@
 [workspace]
 members = [".", "crates/sonar-sim", "crates/sonar-idl"]
 
+[workspace.package]
+rust-version = "1.86.0"
+
 [package]
 name = "sonar"
 version = "0.3.0"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 sonar-idl = { path = "crates/sonar-idl" }

--- a/crates/sonar-idl/Cargo.toml
+++ b/crates/sonar-idl/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sonar-idl"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 description = "Anchor IDL parsing and type resolution for Solana programs"
 
 [dependencies]

--- a/crates/sonar-sim/Cargo.toml
+++ b/crates/sonar-sim/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sonar-sim"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 description = "Solana transaction simulation engine powered by LiteSVM"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Adds `rust-version = "1.86.0"` to `[workspace.package]` and inherits it in all three crates
- 1.86.0 is the minimum required by `litesvm 0.8.1`, our highest-requiring dependency
- Ensures `cargo install` and CI fail early with a clear error on unsupported toolchains

## Test plan
- [x] `cargo check` passes with the new field