### PR TITLE
feat: add --close-account flag to simulate subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ sonar simulate <TX> --rpc-url <RPC_URL> \
 sonar simulate <TX> --rpc-url <RPC_URL> \
   --patch-account-data <PUBKEY>=<OFFSET>:<HEX_DATA>
 
+# State Preparation: close an account so it does not exist during simulation
+sonar simulate <TX> --rpc-url <RPC_URL> \
+  --close-account <PUBKEY>
+
 # Cache: store accounts for offline replay
 sonar simulate <TX> --rpc-url <RPC_URL> --cache
 # Replay from cache (no network; uses ~/.sonar/cache/ when cache is complete)

--- a/crates/sonar-sim/src/executor.rs
+++ b/crates/sonar-sim/src/executor.rs
@@ -62,6 +62,7 @@ pub struct ExecutionOptions {
 /// Pre-simulation mutations applied to the account set before execution.
 #[derive(Debug, Clone, Default)]
 pub struct StateMutationOptions {
+    pub account_closures: Vec<Pubkey>,
     pub overrides: Vec<AccountOverride>,
     pub sol_fundings: Vec<SolFunding>,
     pub token_fundings: Vec<PreparedTokenFunding>,
@@ -110,6 +111,11 @@ impl SimulationOptionsBuilder {
         self
     }
 
+    pub fn account_closures(mut self, account_closures: Vec<Pubkey>) -> Self {
+        self.opts.mutations.account_closures = account_closures;
+        self
+    }
+
     pub fn overrides(mut self, overrides: Vec<AccountOverride>) -> Self {
         self.opts.mutations.overrides = overrides;
         self
@@ -142,6 +148,7 @@ impl StateMutationOptions {
         svm: &mut B,
         resolved: &ResolvedAccounts,
     ) -> Result<()> {
+        apply_account_closures(svm, &self.account_closures)?;
         apply_overrides(svm, &self.overrides, resolved)?;
         apply_sol_fundings(svm, &self.sol_fundings)?;
         apply_data_patches(svm, &self.data_patches)?;
@@ -166,6 +173,28 @@ pub fn load_accounts<B: SvmBackend + ?Sized>(
     for (pubkey, account) in ordered {
         svm.set_account(*pubkey, Account::from(account.clone())).map_err(|e| {
             SonarSimError::Svm { reason: format!("Failed to set account {}: {}", pubkey, e) }
+        })?;
+    }
+    Ok(())
+}
+
+/// Close accounts by setting them to zero lamports.
+///
+/// On LiteSVM, zero-lamport accounts are removed from its internal
+/// `AccountsDb`, so `get_account` returns `None` afterwards.
+/// Other `SvmBackend` implementations may retain the zero-lamport account.
+pub fn apply_account_closures<B: SvmBackend + ?Sized>(
+    svm: &mut B,
+    closures: &[Pubkey],
+) -> Result<()> {
+    for pubkey in closures {
+        if svm.get_account(pubkey).is_none() {
+            warn!("Account closure target {} does not exist in SVM; skipping.", pubkey);
+            continue;
+        }
+        info!("Closing account {} (setting to zero lamports)", pubkey);
+        svm.set_account(*pubkey, Account::default()).map_err(|e| SonarSimError::Svm {
+            reason: format!("Failed to close account `{}`: {}", pubkey, e),
         })?;
     }
     Ok(())
@@ -341,6 +370,10 @@ impl<B: SvmBackend> PreparedSimulation<B> {
         &self.resolved
     }
 
+    pub fn account_closures(&self) -> &[Pubkey] {
+        &self.record.account_closures
+    }
+
     pub fn overrides(&self) -> &[AccountOverride] {
         &self.record.overrides
     }
@@ -450,6 +483,10 @@ impl<B: SvmBackend> SimulationRunner<B> {
 
     pub fn resolved_accounts(&self) -> &ResolvedAccounts {
         &self.resolved
+    }
+
+    pub fn account_closures(&self) -> &[Pubkey] {
+        &self.record.account_closures
     }
 
     pub fn overrides(&self) -> &[AccountOverride] {
@@ -950,5 +987,103 @@ mod tests {
         let mut svm = MockSvm::new();
         apply_slot(&mut svm, 42);
         assert_eq!(svm.slot, 42);
+    }
+
+    // ── Account closure tests ──
+
+    #[test]
+    fn pipeline_close_account_removes_from_litesvm() {
+        let mut svm = new_svm();
+        let key = Pubkey::new_unique();
+
+        let account = Account {
+            lamports: 1_000_000,
+            data: vec![1, 2, 3],
+            owner: solana_sdk_ids::system_program::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+        svm.set_account(key, account).unwrap();
+        assert!(svm.get_account(&key).is_some());
+
+        apply_account_closures(&mut svm, &[key]).expect("closure should succeed");
+        assert!(svm.get_account(&key).is_none(), "account should no longer exist");
+    }
+
+    #[test]
+    fn pipeline_close_nonexistent_account_is_noop() {
+        let mut svm = new_svm();
+        let key = Pubkey::new_unique();
+
+        // Should not error, just warn
+        apply_account_closures(&mut svm, &[key]).expect("closure of missing account should succeed");
+        assert!(svm.get_account(&key).is_none());
+    }
+
+    #[test]
+    fn pipeline_close_multiple_accounts() {
+        let mut svm = new_svm();
+        let k1 = Pubkey::new_unique();
+        let k2 = Pubkey::new_unique();
+
+        for key in [k1, k2] {
+            svm.set_account(
+                key,
+                Account {
+                    lamports: 100,
+                    data: vec![],
+                    owner: solana_sdk_ids::system_program::id(),
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .unwrap();
+        }
+
+        apply_account_closures(&mut svm, &[k1, k2]).expect("closures should succeed");
+        assert!(svm.get_account(&k1).is_none());
+        assert!(svm.get_account(&k2).is_none());
+    }
+
+    #[test]
+    fn pipeline_close_then_fund_creates_fresh_account() {
+        let mut svm = new_svm();
+        let key = Pubkey::new_unique();
+
+        let account = Account {
+            lamports: 1_000_000,
+            data: vec![1, 2, 3, 4],
+            owner: Pubkey::new_unique(),
+            executable: false,
+            rent_epoch: 0,
+        };
+        svm.set_account(key, account).unwrap();
+
+        // Close first, then fund — mimics the mutation pipeline order
+        apply_account_closures(&mut svm, &[key]).unwrap();
+        assert!(svm.get_account(&key).is_none());
+
+        apply_sol_fundings(&mut svm, &[SolFunding { pubkey: key, amount_lamports: 500 }]).unwrap();
+        let created = svm.get_account(&key).expect("account should exist after funding");
+        assert_eq!(created.lamports, 500);
+        assert!(created.data.is_empty(), "newly funded account should have empty data");
+    }
+
+    #[test]
+    fn close_account_on_mock_removes_account() {
+        let key = Pubkey::new_unique();
+        let account = Account {
+            lamports: 100,
+            data: vec![42],
+            owner: solana_sdk_ids::system_program::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+        let mut svm = MockSvm::new().with_account(key, account);
+
+        apply_account_closures(&mut svm, &[key]).expect("should close");
+        // MockSvm stores the zero-lamport account (doesn't auto-remove like LiteSVM)
+        let closed = svm.get_account(&key).unwrap();
+        assert_eq!(closed.lamports, 0);
     }
 }

--- a/crates/sonar-sim/src/lib.rs
+++ b/crates/sonar-sim/src/lib.rs
@@ -60,7 +60,7 @@ pub use svm_backend::SvmBackend;
 pub use executor::{
     ExecutionOptions, ExecutionStatus, PreparedSimulation, SignatureVerification,
     SimulationOptions, SimulationOptionsBuilder, SimulationResult, SimulationRunner,
-    StateMutationOptions,
+    StateMutationOptions, apply_account_closures,
 };
 pub use known_programs::{is_litesvm_builtin_program, is_native_or_sysvar};
 

--- a/src/cli/simulate.rs
+++ b/src/cli/simulate.rs
@@ -105,6 +105,16 @@ pub struct SimulateArgs {
         value_parser = clap::builder::NonEmptyStringValueParser::new()
     )]
     pub data_patches: Vec<String>,
+    /// Close an account so it does not exist during simulation.
+    /// Takes one or more account pubkeys.
+    #[arg(
+        long = "close-account",
+        help_heading = HELP_HEADING_STATE_PREPARATION,
+        value_name = "PUBKEY",
+        num_args = 1..,
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
+    )]
+    pub account_closures: Vec<String>,
     /// Enable account caching: load from cache on repeat runs, save to cache on first run.
     /// Cache is stored per-transaction under ~/.sonar/cache/<KEY>/
     #[arg(short = 'c', long, help_heading = HELP_HEADING_STATE_PREPARATION, env = "SONAR_CACHE")]
@@ -410,6 +420,12 @@ pub fn parse_ix_data_patch(raw: &str) -> Result<InstructionDataPatch, String> {
     let data = crate::utils::parse_hex_data(hex_str)?;
 
     Ok(InstructionDataPatch { instruction_index: ix_1based - 1, offset, data })
+}
+
+pub fn parse_close_account(raw: &str) -> Result<Pubkey, String> {
+    let trimmed = raw.trim();
+    Pubkey::from_str(trimmed)
+        .map_err(|err| format!("Failed to parse --close-account pubkey `{trimmed}`: {err}"))
 }
 
 pub fn parse_timestamp(raw: &str) -> Result<i64, String> {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -248,6 +248,14 @@ fn find_unmatched_sol_fundings(
     fundings.iter().filter(|f| !tx_keys.contains(&f.pubkey)).map(|f| f.pubkey).collect()
 }
 
+/// Finds --close-account pubkeys that are not present in the given transaction account key set.
+fn find_unmatched_closures(
+    closures: &[Pubkey],
+    tx_keys: &std::collections::HashSet<Pubkey>,
+) -> Vec<Pubkey> {
+    closures.iter().filter(|pk| !tx_keys.contains(pk)).copied().collect()
+}
+
 /// Finds --fund-token pubkeys (account and mint) that are not present in the given
 /// transaction account key set.
 fn find_unmatched_token_fundings(
@@ -268,16 +276,21 @@ fn find_unmatched_token_fundings(
     unmatched
 }
 
-/// Warns the user when --override, --fund-sol, or --fund-token addresses are not found
-/// in the transaction's account keys, which likely indicates a typo.
+/// Warns the user when --override, --fund-sol, --fund-token, or --close-account addresses
+/// are not found in the transaction's account keys, which likely indicates a typo.
 pub(crate) fn warn_unmatched_addresses(
     overrides: &[cli::AccountOverride],
     fundings: &[cli::SolFunding],
     token_fundings: &[cli::TokenFunding],
+    account_closures: &[Pubkey],
     parsed_txs: &[&transaction::ParsedTransaction],
     resolved_accounts: &ResolvedAccounts,
 ) {
-    if overrides.is_empty() && fundings.is_empty() && token_fundings.is_empty() {
+    if overrides.is_empty()
+        && fundings.is_empty()
+        && token_fundings.is_empty()
+        && account_closures.is_empty()
+    {
         return;
     }
 
@@ -303,13 +316,20 @@ pub(crate) fn warn_unmatched_addresses(
             pubkey,
         );
     }
+
+    for pubkey in find_unmatched_closures(account_closures, &tx_keys) {
+        log::warn!(
+            "--close-account target {} is not referenced in the transaction's account keys. Did you mean a different address?",
+            pubkey,
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        collect_program_ids, find_unmatched_overrides, find_unmatched_sol_fundings,
-        find_unmatched_token_fundings,
+        collect_program_ids, find_unmatched_closures, find_unmatched_overrides,
+        find_unmatched_sol_fundings, find_unmatched_token_fundings,
     };
     use crate::cli;
     use solana_account::{Account, AccountSharedData};
@@ -495,6 +515,29 @@ mod tests {
         ];
 
         let unmatched = find_unmatched_overrides(&overrides, &tx_keys);
+        assert!(unmatched.is_empty());
+    }
+
+    #[test]
+    fn find_unmatched_closures_detects_missing_address() {
+        let key_in_tx = Pubkey::new_unique();
+        let key_not_in_tx = Pubkey::new_unique();
+        let tx_keys: HashSet<Pubkey> = [key_in_tx].into_iter().collect();
+
+        let closures = vec![key_in_tx, key_not_in_tx];
+        let unmatched = find_unmatched_closures(&closures, &tx_keys);
+        assert_eq!(unmatched.len(), 1);
+        assert_eq!(unmatched[0], key_not_in_tx);
+    }
+
+    #[test]
+    fn find_unmatched_closures_returns_empty_when_all_match() {
+        let key_a = Pubkey::new_unique();
+        let key_b = Pubkey::new_unique();
+        let tx_keys: HashSet<Pubkey> = [key_a, key_b].into_iter().collect();
+
+        let closures = vec![key_a, key_b];
+        let unmatched = find_unmatched_closures(&closures, &tx_keys);
         assert!(unmatched.is_empty());
     }
 }

--- a/src/handlers/simulate.rs
+++ b/src/handlers/simulate.rs
@@ -85,6 +85,7 @@ pub(crate) fn handle(args: SimulateArgs) -> Result<()> {
         timestamp,
         slot,
         data_patches: data_patch_args,
+        account_closures: account_closure_args,
         cache,
         cache_dir,
         refresh_cache,
@@ -102,6 +103,7 @@ pub(crate) fn handle(args: SimulateArgs) -> Result<()> {
     let sol_fundings = parse_cli_args(funding_args, cli::parse_funding)?;
     let token_funding_requests = parse_cli_args(token_funding_args, cli::parse_token_funding)?;
     let data_patches = parse_cli_args(data_patch_args, cli::parse_data_patch)?;
+    let account_closures = parse_cli_args(account_closure_args, cli::parse_close_account)?;
     let ix_account_patches = parse_cli_args(ix_account_patch_args, cli::parse_ix_account_patch)?;
     let ix_account_appends = parse_cli_args(ix_account_append_args, cli::parse_ix_account_append)?;
     let ix_data_patches = parse_cli_args(ix_data_patch_args, cli::parse_ix_data_patch)?;
@@ -125,6 +127,7 @@ pub(crate) fn handle(args: SimulateArgs) -> Result<()> {
                 timestamp,
             },
             mutations: StateMutationOptions {
+                account_closures,
                 overrides,
                 sol_fundings,
                 data_patches,
@@ -183,6 +186,7 @@ pub(crate) fn handle(args: SimulateArgs) -> Result<()> {
         &overrides,
         &sol_fundings,
         &token_funding_requests,
+        &account_closures,
         &[&parsed_tx],
         &prepared.resolved_accounts,
     );
@@ -231,6 +235,7 @@ pub(crate) fn handle(args: SimulateArgs) -> Result<()> {
             timestamp,
         },
         mutations: StateMutationOptions {
+            account_closures,
             overrides,
             sol_fundings,
             token_fundings: prepared_token_fundings,
@@ -254,6 +259,7 @@ pub(crate) fn handle(args: SimulateArgs) -> Result<()> {
         &parsed_tx,
         runner.resolved_accounts(),
         &simulation,
+        runner.account_closures(),
         runner.overrides(),
         runner.sol_fundings(),
         runner.token_fundings(),
@@ -317,6 +323,7 @@ fn handle_bundle(
         &sim_opts.mutations.overrides,
         &sim_opts.mutations.sol_fundings,
         &token_funding_requests,
+        &sim_opts.mutations.account_closures,
         &parsed_tx_refs,
         &prepared.resolved_accounts,
     );
@@ -407,6 +414,7 @@ fn handle_bundle(
         total_tx_count,
         runner.resolved_accounts(),
         &simulations,
+        runner.account_closures(),
         runner.overrides(),
         runner.sol_fundings(),
         runner.token_fundings(),

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -8,6 +8,8 @@ pub(crate) use account_text::render_account_text;
 
 use anyhow::Result;
 
+use solana_pubkey::Pubkey;
+
 use crate::{core::transaction::ParsedTransaction, parsers::instruction::ParserRegistry};
 use sonar_sim::{
     AccountOverride, PreparedTokenFunding, ResolvedAccounts, SimulationResult, SolFunding,
@@ -44,6 +46,7 @@ pub fn render(
     parsed: &ParsedTransaction,
     resolved: &ResolvedAccounts,
     simulation: &SimulationResult,
+    account_closures: &[Pubkey],
     overrides: &[AccountOverride],
     fundings: &[SolFunding],
     token_fundings: &[PreparedTokenFunding],
@@ -54,6 +57,7 @@ pub fn render(
         parsed,
         resolved,
         simulation,
+        account_closures,
         overrides,
         fundings,
         token_fundings,
@@ -127,6 +131,7 @@ pub fn render_bundle(
     total_tx_count: usize,
     resolved: &ResolvedAccounts,
     simulations: &[SimulationResult],
+    account_closures: &[Pubkey],
     overrides: &[AccountOverride],
     fundings: &[SolFunding],
     token_fundings: &[PreparedTokenFunding],
@@ -137,6 +142,7 @@ pub fn render_bundle(
         parsed_txs,
         resolved,
         simulations,
+        account_closures,
         overrides,
         fundings,
         token_fundings,

--- a/src/output/report.rs
+++ b/src/output/report.rs
@@ -24,6 +24,8 @@ use super::BalanceChangeOptions;
 pub(super) struct Report {
     pub(super) transaction: TransactionSection,
     pub(super) simulation: SimulationSection,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    account_closures: Vec<AccountClosureSection>,
     overrides: Vec<AccountOverrideSection>,
     fundings: Vec<SolFundingSection>,
     token_fundings: Vec<TokenSolFundingSection>,
@@ -58,6 +60,8 @@ pub(super) struct TokenBalanceChangeSection {
 #[derive(Serialize)]
 pub(super) struct BundleReport {
     pub(super) transactions: Vec<BundleTransactionReport>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    account_closures: Vec<AccountClosureSection>,
     overrides: Vec<AccountOverrideSection>,
     fundings: Vec<SolFundingSection>,
     token_fundings: Vec<TokenSolFundingSection>,
@@ -82,6 +86,7 @@ impl BundleReport {
         parsed_txs: &[ParsedTransaction],
         resolved: &ResolvedAccounts,
         simulations: &[SimulationResult],
+        account_closures: &[Pubkey],
         overrides: &[AccountOverride],
         fundings: &[SolFunding],
         token_fundings: &[PreparedTokenFunding],
@@ -109,6 +114,7 @@ impl BundleReport {
             })
             .collect();
 
+        let account_closures = closures_to_sections(account_closures);
         let overrides = overrides.iter().map(override_to_section).collect();
 
         let fundings = fundings
@@ -140,6 +146,7 @@ impl BundleReport {
 
         Self {
             transactions,
+            account_closures,
             overrides,
             fundings,
             token_fundings,
@@ -155,6 +162,7 @@ impl Report {
         parsed: &ParsedTransaction,
         resolved: &ResolvedAccounts,
         simulation: &SimulationResult,
+        account_closures: &[Pubkey],
         overrides: &[AccountOverride],
         fundings: &[SolFunding],
         token_fundings: &[PreparedTokenFunding],
@@ -171,6 +179,7 @@ impl Report {
             verify_signatures,
         );
         let simulation_section = SimulationSection::from_result(simulation);
+        let account_closures = closures_to_sections(account_closures);
         let overrides = overrides.iter().map(override_to_section).collect();
         let (sol_balance_changes, token_balance_changes) =
             if matches!(simulation.status, ExecutionStatus::Succeeded)
@@ -202,6 +211,7 @@ impl Report {
         Self {
             transaction,
             simulation: simulation_section,
+            account_closures,
             overrides,
             fundings,
             token_fundings,
@@ -807,6 +817,11 @@ struct TokenSolFundingSection {
 }
 
 #[derive(Serialize)]
+struct AccountClosureSection {
+    pubkey: String,
+}
+
+#[derive(Serialize)]
 struct AccountOverrideSection {
     #[serde(rename = "type")]
     override_type: String,
@@ -816,6 +831,10 @@ struct AccountOverrideSection {
 
 fn serialize_bytes_as_hex<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
     serializer.serialize_str(&format!("0x{}", hex::encode(bytes)))
+}
+
+fn closures_to_sections(closures: &[Pubkey]) -> Vec<AccountClosureSection> {
+    closures.iter().map(|pk| AccountClosureSection { pubkey: pk.to_string() }).collect()
 }
 
 fn override_to_section(entry: &AccountOverride) -> AccountOverrideSection {


### PR DESCRIPTION
## Summary
- Add `--close-account <PUBKEY>` flag to `sonar simulate` that removes accounts from the SVM state before execution, making `get_account` return `None`
- Closures applied first in the mutation pipeline (before overrides, fundings, patches), enabling close-then-rebuild workflows
- Includes JSON output support, unmatched address warnings, and README documentation

## Changes
- **sonar-sim**: `account_closures` field on `StateMutationOptions`, `apply_account_closures()` pipeline step, builder/accessor methods
- **CLI**: `--close-account` arg with `parse_close_account()` parser
- **Handler**: Wired through single-tx and bundle paths
- **Output**: `AccountClosureSection` in Report/BundleReport for JSON serialization
- **Docs**: README example added

## Test plan
- [x] 6 unit tests for `apply_account_closures` (close existing, close nonexistent, close multiple, close-then-fund, MockSvm)
- [x] 2 unit tests for `find_unmatched_closures` helper
- [x] Full test suite passes (537 passed, 7 ignored)
- [ ] Manual: `sonar simulate <TX> --close-account <PUBKEY>` with a known account