### PR TITLE
chore: fix all clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ solana-nonce = "3.0"
 solana-pubkey = "3.0"
 solana-keypair = "3.0"
 solana-transaction = "3.0"
-solana-transaction-status-client-types = "3.0"
+solana-transaction-status-client-types = { version = "3.0", features = ["agave-unstable-api"] }
 ureq = { version = "3", features = ["json"] }
 solana-message = "3.0"
 solana-address-lookup-table-interface = "3.0"

--- a/crates/sonar-idl/src/parser.rs
+++ b/crates/sonar-idl/src/parser.rs
@@ -1303,10 +1303,7 @@ mod tests {
         let mut offset = 0;
         let registry = IdlRegistry::new();
         let idl = hello_anchor_idl();
-        let array_def = [
-            serde_json::json!("u8"),
-            serde_json::json!(3),
-        ];
+        let array_def = [serde_json::json!("u8"), serde_json::json!(3)];
         let val = parse_array_type(&data, &mut offset, &array_def, &registry, &idl).unwrap();
         assert_eq!(
             val,

--- a/crates/sonar-sim/src/account_loader.rs
+++ b/crates/sonar-sim/src/account_loader.rs
@@ -293,16 +293,12 @@ fn expand_lookup_table(
     table_account: &AccountSharedData,
     plan: &AddressLookupPlan,
 ) -> Result<ResolvedLookup> {
-    let lookup_table =
-        AddressLookupTable::deserialize(table_account.data()).map_err(|err| {
-            SonarSimError::LookupTable {
-                table: Some(plan.account_key),
-                reason: format!(
-                    "Failed to parse address lookup table `{}`: {err}",
-                    plan.account_key
-                ),
-            }
-        })?;
+    let lookup_table = AddressLookupTable::deserialize(table_account.data()).map_err(|err| {
+        SonarSimError::LookupTable {
+            table: Some(plan.account_key),
+            reason: format!("Failed to parse address lookup table `{}`: {err}", plan.account_key),
+        }
+    })?;
     let all_addresses = lookup_table.addresses.to_vec();
 
     let writable_addresses = resolve_lookup_indexes(&all_addresses, &plan.writable_indexes)
@@ -607,10 +603,8 @@ mod tests {
     fn collect_initial_accounts_single_plan_no_lookups() {
         let key1 = Pubkey::new_unique();
         let key2 = Pubkey::new_unique();
-        let plan = MessageAccountPlan {
-            static_accounts: vec![key1, key2],
-            address_lookups: vec![],
-        };
+        let plan =
+            MessageAccountPlan { static_accounts: vec![key1, key2], address_lookups: vec![] };
         let keys = collect_initial_accounts(&[plan]);
         assert!(keys.contains(&key1));
         assert!(keys.contains(&key2));
@@ -624,14 +618,10 @@ mod tests {
         let shared = Pubkey::new_unique();
         let unique1 = Pubkey::new_unique();
         let unique2 = Pubkey::new_unique();
-        let plan1 = MessageAccountPlan {
-            static_accounts: vec![shared, unique1],
-            address_lookups: vec![],
-        };
-        let plan2 = MessageAccountPlan {
-            static_accounts: vec![shared, unique2],
-            address_lookups: vec![],
-        };
+        let plan1 =
+            MessageAccountPlan { static_accounts: vec![shared, unique1], address_lookups: vec![] };
+        let plan2 =
+            MessageAccountPlan { static_accounts: vec![shared, unique2], address_lookups: vec![] };
         let keys = collect_initial_accounts(&[plan1, plan2]);
         let shared_count = keys.iter().filter(|k| **k == shared).count();
         assert_eq!(shared_count, 1);
@@ -812,9 +802,6 @@ mod tests {
 
         let err = expand_lookup_table(&account, &plan).unwrap_err();
         let msg = err.to_string();
-        assert!(
-            msg.contains("Failed to parse writable indexes"),
-            "unexpected error: {msg}"
-        );
+        assert!(msg.contains("Failed to parse writable indexes"), "unexpected error: {msg}");
     }
 }

--- a/crates/sonar-sim/src/executor.rs
+++ b/crates/sonar-sim/src/executor.rs
@@ -945,11 +945,7 @@ mod tests {
         };
         let mut svm = MockSvm::new().with_account(key, account);
 
-        let patches = vec![AccountDataPatch {
-            pubkey: key,
-            offset: 1,
-            data: vec![0xAA, 0xBB],
-        }];
+        let patches = vec![AccountDataPatch { pubkey: key, offset: 1, data: vec![0xAA, 0xBB] }];
         apply_data_patches(&mut svm, &patches).expect("should apply");
 
         let loaded = svm.get_account(&key).unwrap();
@@ -1016,7 +1012,8 @@ mod tests {
         let key = Pubkey::new_unique();
 
         // Should not error, just warn
-        apply_account_closures(&mut svm, &[key]).expect("closure of missing account should succeed");
+        apply_account_closures(&mut svm, &[key])
+            .expect("closure of missing account should succeed");
         assert!(svm.get_account(&key).is_none());
     }
 

--- a/crates/sonar-sim/src/funding/mod.rs
+++ b/crates/sonar-sim/src/funding/mod.rs
@@ -185,14 +185,12 @@ fn apply_single_token_funding<B: SvmBackend + ?Sized>(
             .get(&funding.mint)
             .ok_or(SonarSimError::AccountNotFound { pubkey: funding.mint })?;
         let created = match kind {
-            TokenProgramKind::Legacy => {
-                token_legacy::build_token_account(
-                    &funding.account,
-                    &funding.mint,
-                    &funding.owner,
-                    &rent,
-                )?
-            }
+            TokenProgramKind::Legacy => token_legacy::build_token_account(
+                &funding.account,
+                &funding.mint,
+                &funding.owner,
+                &rent,
+            )?,
             TokenProgramKind::Token2022 => token2022::build_token_account_with_extensions(
                 &funding.account,
                 &funding.mint,
@@ -410,7 +408,8 @@ mod tests {
             owner: Some(owner),
             amount: TokenAmount::Raw(100),
         };
-        let prepared = prepare_token_fundings(&mut loader, &resolved, &[funding]).expect("prepares");
+        let prepared =
+            prepare_token_fundings(&mut loader, &resolved, &[funding]).expect("prepares");
         assert_eq!(prepared[0].owner, owner);
     }
 
@@ -427,13 +426,10 @@ mod tests {
         resolved.accounts.insert(token, AccountSharedData::from(token_account));
         resolved.accounts.insert(mint, AccountSharedData::from(mint_account));
 
-        let funding = TokenFunding {
-            account: token,
-            mint: None,
-            owner: None,
-            amount: TokenAmount::Raw(100),
-        };
-        let prepared = prepare_token_fundings(&mut loader, &resolved, &[funding]).expect("prepares");
+        let funding =
+            TokenFunding { account: token, mint: None, owner: None, amount: TokenAmount::Raw(100) };
+        let prepared =
+            prepare_token_fundings(&mut loader, &resolved, &[funding]).expect("prepares");
         assert_eq!(prepared[0].owner, owner);
     }
 
@@ -477,7 +473,8 @@ mod tests {
             owner: Some(owner),
             amount: TokenAmount::Raw(100),
         };
-        let prepared = prepare_token_fundings(&mut loader, &resolved, &[funding]).expect("prepares");
+        let prepared =
+            prepare_token_fundings(&mut loader, &resolved, &[funding]).expect("prepares");
         assert_eq!(prepared[0].owner, owner);
         assert_eq!(prepared[0].mint, mint);
     }

--- a/crates/sonar-sim/src/funding/token2022.rs
+++ b/crates/sonar-sim/src/funding/token2022.rs
@@ -229,7 +229,8 @@ mod tests {
             .unwrap(),
         );
         let result =
-            update_token_balance_in_account(&mut account, &token, &mint, &owner, 5_000_000, 6).unwrap();
+            update_token_balance_in_account(&mut account, &token, &mint, &owner, 5_000_000, 6)
+                .unwrap();
         assert_eq!(result.amount_raw, 5_000_000);
         assert!((result.ui_amount - 5.0).abs() < f64::EPSILON);
 
@@ -247,7 +248,8 @@ mod tests {
         let account =
             build_token_account_with_extensions(&token, &mint, &owner, &mint_account, &rent)
                 .unwrap();
-        let state = StateWithExtensions::<Token2022Account>::unpack(account.data()).expect("unpack");
+        let state =
+            StateWithExtensions::<Token2022Account>::unpack(account.data()).expect("unpack");
         assert_eq!(Pubkey::new_from_array(state.base.owner.to_bytes()), owner);
     }
 }

--- a/crates/sonar-sim/src/funding/token_legacy.rs
+++ b/crates/sonar-sim/src/funding/token_legacy.rs
@@ -93,7 +93,8 @@ mod tests {
         let mut account =
             Account::from(build_token_account(&token, &mint, &owner, &Rent::default()).unwrap());
         let result =
-            update_token_balance_in_account(&mut account, &token, &mint, &owner, 42_000_000, 6).unwrap();
+            update_token_balance_in_account(&mut account, &token, &mint, &owner, 42_000_000, 6)
+                .unwrap();
         assert_eq!(result.amount_raw, 42_000_000);
         assert_eq!(result.decimals, 6);
         assert!((result.ui_amount - 42.0).abs() < f64::EPSILON);
@@ -114,7 +115,8 @@ mod tests {
             executable: false,
             rent_epoch: 0,
         };
-        let err = update_token_balance_in_account(&mut account, &token, &mint, &owner, 100, 6).unwrap_err();
+        let err = update_token_balance_in_account(&mut account, &token, &mint, &owner, 100, 6)
+            .unwrap_err();
         assert!(err.to_string().contains("not owned by"));
     }
 

--- a/crates/sonar-sim/src/rpc_provider.rs
+++ b/crates/sonar-sim/src/rpc_provider.rs
@@ -28,10 +28,8 @@ pub struct SolanaRpcProvider {
 
 impl SolanaRpcProvider {
     pub fn new(rpc_url: String) -> Self {
-        let agent = ureq::Agent::config_builder()
-            .timeout_global(Some(RPC_TIMEOUT))
-            .build()
-            .new_agent();
+        let agent =
+            ureq::Agent::config_builder().timeout_global(Some(RPC_TIMEOUT)).build().new_agent();
         Self { agent: Arc::new(agent), rpc_url }
     }
 }
@@ -53,8 +51,7 @@ impl RpcAccountProvider for SolanaRpcProvider {
             let mut response = match self.agent.post(&self.rpc_url).send_json(&body) {
                 Ok(resp) => resp,
                 Err(ureq::Error::StatusCode(status_code))
-                    if (status_code == 429 || status_code == 503)
-                        && attempt < MAX_RETRIES =>
+                    if (status_code == 429 || status_code == 503) && attempt < MAX_RETRIES =>
                 {
                     let delay = DEFAULT_RETRY_DELAY * (attempt + 1);
                     log::warn!(
@@ -65,8 +62,7 @@ impl RpcAccountProvider for SolanaRpcProvider {
                         MAX_RETRIES,
                     );
                     thread::sleep(delay);
-                    last_err =
-                        Some(SonarSimError::Rpc { reason: format!("HTTP {status_code}") });
+                    last_err = Some(SonarSimError::Rpc { reason: format!("HTTP {status_code}") });
                     continue;
                 }
                 Err(e) => return Err(SonarSimError::Rpc { reason: e.to_string() }),
@@ -81,9 +77,8 @@ impl RpcAccountProvider for SolanaRpcProvider {
                 return Err(SonarSimError::Rpc { reason: err.to_string() });
             }
 
-            let result = rpc
-                .result
-                .ok_or_else(|| SonarSimError::Rpc { reason: "empty result".into() })?;
+            let result =
+                rpc.result.ok_or_else(|| SonarSimError::Rpc { reason: "empty result".into() })?;
 
             return result
                 .value

--- a/crates/sonar-sim/src/svm_backend.rs
+++ b/crates/sonar-sim/src/svm_backend.rs
@@ -6,6 +6,7 @@ use solana_account::Account;
 use solana_pubkey::Pubkey;
 use solana_transaction::versioned::VersionedTransaction;
 
+#[allow(clippy::result_large_err)] // TransactionResult uses upstream litesvm types
 /// Minimal simulation backend abstraction.
 ///
 /// This decouples executor/funding logic from a concrete SVM implementation.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -56,7 +56,7 @@ pub struct Cli {
 pub enum Commands {
     /// Simulate a Solana transaction locally using LiteSVM
     #[command(alias = "sim", next_line_help = true)]
-    Simulate(SimulateArgs),
+    Simulate(Box<SimulateArgs>),
     /// Decode and display a raw transaction without simulation
     #[command(alias = "dec", next_line_help = true)]
     Decode(DecodeArgs),

--- a/src/cli/simulate.rs
+++ b/src/cli/simulate.rs
@@ -295,11 +295,9 @@ pub fn parse_token_funding(raw: &str) -> Result<TokenFunding, String> {
             (parts[0], Some(mint), Some(owner))
         }
         _ => {
-            return Err(
-                "Token funding must be in <ACCOUNT>=<AMOUNT>, <ACCOUNT>:<MINT>=<AMOUNT>, \
+            return Err("Token funding must be in <ACCOUNT>=<AMOUNT>, <ACCOUNT>:<MINT>=<AMOUNT>, \
                  or <ACCOUNT>:<MINT>:<OWNER>=<AMOUNT> format"
-                    .to_string(),
-            );
+                .to_string());
         }
     };
 
@@ -580,7 +578,9 @@ mod tests {
     #[test]
     fn parse_token_funding_rejects_four_colons() {
         let keys: Vec<_> = (0..4).map(|_| Pubkey::new_unique()).collect();
-        let err = parse_token_funding(&format!("{}:{}:{}:{}=100", keys[0], keys[1], keys[2], keys[3])).unwrap_err();
+        let err =
+            parse_token_funding(&format!("{}:{}:{}:{}=100", keys[0], keys[1], keys[2], keys[3]))
+                .unwrap_err();
         assert!(err.contains("<ACCOUNT>"));
     }
 

--- a/src/converters/borsh_encode.rs
+++ b/src/converters/borsh_encode.rs
@@ -463,14 +463,11 @@ fn cmp_values(ty: &BorshType, a: &Value, b: &Value) -> std::cmp::Ordering {
             match (a.as_object(), b.as_object()) {
                 (Some(a_obj), Some(b_obj)) => {
                     for (name, ty) in fields {
-                        match (a_obj.get(name), b_obj.get(name)) {
-                            (Some(av), Some(bv)) => {
-                                let ord = cmp_values(ty, av, bv);
-                                if ord != Ordering::Equal {
-                                    return ord;
-                                }
+                        if let (Some(av), Some(bv)) = (a_obj.get(name), b_obj.get(name)) {
+                            let ord = cmp_values(ty, av, bv);
+                            if ord != Ordering::Equal {
+                                return ord;
                             }
-                            _ => {}
                         }
                     }
                     Ordering::Equal

--- a/src/converters/bytes.rs
+++ b/src/converters/bytes.rs
@@ -15,8 +15,7 @@ pub(crate) fn parse_bytes_input(
         if hex_str.is_empty() {
             return Err("Hex string cannot be empty after 0x prefix".to_string());
         }
-        let hex_str =
-            if !hex_str.len().is_multiple_of(2) { format!("0{}", hex_str) } else { hex_str };
+        let hex_str = if hex_str.len() % 2 != 0 { format!("0{}", hex_str) } else { hex_str };
         return hex::decode(hex_str).map_err(|e| format!("Invalid hex string: {}", e));
     }
 
@@ -68,8 +67,7 @@ pub(crate) fn parse_bytes_input(
         if hex_str.is_empty() {
             return Err("Hex string cannot be empty".to_string());
         }
-        let hex_str =
-            if !hex_str.len().is_multiple_of(2) { format!("0{}", hex_str) } else { hex_str };
+        let hex_str = if hex_str.len() % 2 != 0 { format!("0{}", hex_str) } else { hex_str };
         return hex::decode(hex_str).map_err(|e| format!("Invalid hex string: {}", e));
     }
 

--- a/src/converters/integers.rs
+++ b/src/converters/integers.rs
@@ -190,8 +190,7 @@ pub(crate) fn format_fixed_integer(
             }
             ConvertValue::FixedBigSigned { value, .. } => {
                 let raw = value.to_string();
-                let as_i128 = i128::try_from(value).map_err(|_| out_of_range(&raw))?;
-                as_i128
+                i128::try_from(value).map_err(|_| out_of_range(&raw))?
             }
             ConvertValue::Lamports(value) => {
                 let as_u128 = u128::from(*value);
@@ -246,8 +245,7 @@ pub(crate) fn format_fixed_integer(
                 if value.sign() == Sign::Minus {
                     return Err(out_of_range(&raw));
                 }
-                let as_u128 = u128::try_from(value).map_err(|_| out_of_range(&raw))?;
-                as_u128
+                u128::try_from(value).map_err(|_| out_of_range(&raw))?
             }
             ConvertValue::Lamports(value) => u128::from(*value),
         };

--- a/src/core/rpc_client.rs
+++ b/src/core/rpc_client.rs
@@ -54,10 +54,8 @@ const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(2);
 
 impl RpcClient {
     pub fn new(rpc_url: impl Into<String>) -> Self {
-        let agent = ureq::Agent::config_builder()
-            .timeout_global(Some(RPC_TIMEOUT))
-            .build()
-            .new_agent();
+        let agent =
+            ureq::Agent::config_builder().timeout_global(Some(RPC_TIMEOUT)).build().new_agent();
         Self { agent, rpc_url: rpc_url.into() }
     }
 
@@ -87,7 +85,9 @@ impl RpcClient {
                     }
                     return rpc.result.ok_or_else(|| anyhow!("RPC returned empty result"));
                 }
-                Err(ureq::Error::StatusCode(status_code)) if (status_code == 429 || status_code == 503) && attempt < MAX_RETRIES => {
+                Err(ureq::Error::StatusCode(status_code))
+                    if (status_code == 429 || status_code == 503) && attempt < MAX_RETRIES =>
+                {
                     let delay = DEFAULT_RETRY_DELAY * (attempt + 1);
                     log::warn!(
                         "RPC returned {}; retrying in {:?} (attempt {}/{})",
@@ -129,10 +129,8 @@ impl RpcClient {
                 {"encoding": "base64", "commitment": commitment_str(commitment)}
             ]),
         )?;
-        let value = result
-            .value
-            .map(|info| info.into_account().map_err(|e| anyhow!("{e}")))
-            .transpose()?;
+        let value =
+            result.value.map(|info| info.into_account().map_err(|e| anyhow!("{e}"))).transpose()?;
         Ok(RpcResponse { value })
     }
 
@@ -148,14 +146,11 @@ impl RpcClient {
             "skipPreflight": config.skip_preflight,
         });
         if let Some(commitment) = config.preflight_commitment {
-            opts["preflightCommitment"] = serde_json::Value::String(
-                commitment_str(commitment).into(),
-            );
+            opts["preflightCommitment"] =
+                serde_json::Value::String(commitment_str(commitment).into());
         }
-        let sig_str: String = self.call(
-            "sendTransaction",
-            serde_json::json!([BASE64.encode(&tx_bytes), opts]),
-        )?;
+        let sig_str: String =
+            self.call("sendTransaction", serde_json::json!([BASE64.encode(&tx_bytes), opts]))?;
         Signature::from_str(&sig_str).map_err(|e| anyhow!("Invalid signature: {e}"))
     }
 
@@ -165,9 +160,7 @@ impl RpcClient {
     ) -> Result<RpcResponse<Vec<Option<TransactionStatus>>>> {
         self.call(
             "getSignatureStatuses",
-            serde_json::json!([
-                signatures.iter().map(|s| s.to_string()).collect::<Vec<_>>()
-            ]),
+            serde_json::json!([signatures.iter().map(|s| s.to_string()).collect::<Vec<_>>()]),
         )
     }
 

--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -4,11 +4,11 @@ pub use sonar_sim::{LookupLocation, MessageAccountPlan, RawTransactionEncoding};
 #[cfg(test)]
 use sonar_sim::AddressLookupPlan;
 
+use crate::core::rpc_client::{GetTransactionConfig, RpcClient};
 use anyhow::{Context, Result, anyhow};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use serde::Serialize;
-use crate::core::rpc_client::{GetTransactionConfig, RpcClient};
 use solana_commitment_config::CommitmentConfig;
 use solana_message::VersionedMessage;
 use solana_message::inner_instruction::InnerInstructionsList;

--- a/src/handlers/account.rs
+++ b/src/handlers/account.rs
@@ -3,11 +3,11 @@ use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+use crate::core::rpc_client::RpcClient;
 use anyhow::{Context, Result, anyhow};
 use base64::{Engine as _, engine::general_purpose};
 use serde_json::Value;
 use solana_address_lookup_table_interface::state::AddressLookupTable;
-use crate::core::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
 use solana_loader_v3_interface::state::UpgradeableLoaderState;
 use solana_pubkey::Pubkey;

--- a/src/handlers/decode.rs
+++ b/src/handlers/decode.rs
@@ -25,11 +25,8 @@ pub(crate) fn handle(args: DecodeArgs) -> Result<()> {
         refresh_cache,
     } = args;
     let rpc_url = rpc.rpc_url;
-    let resolver_cache_location = if refresh_cache {
-        None
-    } else {
-        Some(super::build_cache_location(&cache_dir))
-    };
+    let resolver_cache_location =
+        if refresh_cache { None } else { Some(super::build_cache_location(&cache_dir)) };
     let TransactionInputArgs { tx, json } = transaction;
 
     // Check if this is a bundle (multiple positional TX arguments)

--- a/src/handlers/program_elf.rs
+++ b/src/handlers/program_elf.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 
+use crate::core::rpc_client::RpcClient;
 use anyhow::{Context, Result, anyhow};
 use sha2::{Digest, Sha256};
-use crate::core::rpc_client::RpcClient;
 use solana_loader_v3_interface::state::UpgradeableLoaderState;
 use solana_pubkey::Pubkey;
 use solana_sdk_ids::bpf_loader_upgradeable;

--- a/src/handlers/send.rs
+++ b/src/handlers/send.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result, anyhow};
 use crate::core::rpc_client::{RpcClient, SendTransactionConfig};
+use anyhow::{Context, Result, anyhow};
 use solana_signature::Signature;
 use solana_transaction_status_client_types::{TransactionConfirmationStatus, TransactionStatus};
 
@@ -12,10 +12,8 @@ pub(crate) fn handle(args: SendArgs) -> Result<()> {
     let parsed = transaction::parse_raw_transaction(&args.tx)?;
     let client = RpcClient::new(&args.rpc.rpc_url);
 
-    let config = SendTransactionConfig {
-        skip_preflight: args.skip_preflight,
-        ..Default::default()
-    };
+    let config =
+        SendTransactionConfig { skip_preflight: args.skip_preflight, ..Default::default() };
 
     let signature = client
         .send_transaction_with_config(&parsed.transaction, config)

--- a/src/handlers/simulate.rs
+++ b/src/handlers/simulate.rs
@@ -17,13 +17,8 @@ use super::{
 };
 
 /// Parse a vector of raw CLI strings using the given parser function.
-fn parse_cli_args<T>(
-    args: Vec<String>,
-    parser: fn(&str) -> Result<T, String>,
-) -> Result<Vec<T>> {
-    args.iter()
-        .map(|raw| parser(raw).map_err(anyhow::Error::msg))
-        .collect()
+fn parse_cli_args<T>(args: Vec<String>, parser: fn(&str) -> Result<T, String>) -> Result<Vec<T>> {
+    args.iter().map(|raw| parser(raw).map_err(anyhow::Error::msg)).collect()
 }
 
 /// Apply instruction-level mutations (account patches, data patches) and rebuild

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn run() -> Result<()> {
             if args.transaction.tx.is_empty() && std::io::stdin().is_terminal() {
                 print_subcommand_help("simulate")?;
             }
-            handlers::simulate::handle(args)?
+            handlers::simulate::handle(*args)?
         }
         Commands::Decode(args) => {
             if args.transaction.tx.is_empty() && std::io::stdin().is_terminal() {

--- a/src/parsers/instruction/token2022_program.rs
+++ b/src/parsers/instruction/token2022_program.rs
@@ -1115,7 +1115,7 @@ fn parse_reallocate_instruction(
     data: &[u8],
     instruction: &InstructionSummary,
 ) -> Result<Option<ParsedInstruction>> {
-    if !data.len().is_multiple_of(2) {
+    if data.len() % 2 != 0 {
         return Ok(None);
     }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -29,16 +29,12 @@ pub fn read_cli_input(input: Option<&str>, kind: &str) -> Result<String, String>
         return Ok(trimmed.to_owned());
     }
 
-    Err(format!(
-        "No input provided. Pass {kind} as a positional argument or pipe via stdin"
-    ))
+    Err(format!("No input provided. Pass {kind} as a positional argument or pipe via stdin"))
 }
 
 /// Strip an optional `0x` or `0X` prefix from a hex string.
 pub fn strip_hex_prefix(s: &str) -> &str {
-    s.strip_prefix("0x")
-        .or_else(|| s.strip_prefix("0X"))
-        .unwrap_or(s)
+    s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")).unwrap_or(s)
 }
 
 /// Parse a hex string (with optional `0x`/`0X` prefix) into bytes.


### PR DESCRIPTION
## Summary
- Replace `is_multiple_of()` with `% 2 != 0` to respect MSRV 1.86.0
- Remove unnecessary let bindings returned from blocks (`let_and_return`)
- Use `if let` instead of single-arm match (`single_match`)
- Box `SimulateArgs` in `Commands` enum to fix `large_enum_variant`
- Suppress upstream Solana `deprecated` warnings pending agave-unstable-api migration
- Allow `result_large_err` on `SvmBackend` trait (upstream litesvm type)

## Test plan
- [x] `cargo clippy` reports 0 warnings (was 34)
- [x] `cargo test` — all 537 tests pass