### PR TITLE
refactor: add global --json flag to all subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,19 @@ cargo build --release
 | `cache` | You want to list, clean, or inspect cached account data |
 | `completions` | You want to generate shell completion scripts |
 
+### Global Options
+
+| Flag | Description |
+|------|-------------|
+| `--json` / `-j` | Output machine-readable JSON instead of human-readable text. Available on all data-producing subcommands. Silently ignored by `completions` and `program-elf`. |
+
 ### Output Stream Convention
 
-- **stdout**: Machine-consumable primary results (stable fields, success output, confirmation messages).
-  - `send`: signature, cluster-aware explorer URL (inferred from `--rpc-url`), and `--wait` confirmation (when used).
+- **stdout**: Machine-consumable primary results (stable fields, success output).
+  - `send`: signature only. Explorer URL and `--wait` confirmation go to stderr.
   - `program-elf -o <file>`: success message (bytes written, path).
-  - Other commands: main structured output.
-- **stderr**: Warnings, diagnostics, and errors only.
+  - Other commands: main structured output (JSON when `--json` is active).
+- **stderr**: Warnings, diagnostics, explorer URLs, and errors.
 
 ### Simulate
 

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -23,10 +23,6 @@ pub struct AccountArgs {
     /// Output raw account data as base64 JSON, skip decoding
     #[arg(long)]
     pub raw: bool,
-
-    /// Output as JSON instead of the default colored text format
-    #[arg(short = 'j', long)]
-    pub json: bool,
 }
 
 #[cfg(test)]
@@ -77,10 +73,7 @@ mod tests {
         ])
         .expect("should parse --json");
 
-        let Some(Commands::Account(args)) = cli.command else {
-            panic!("expected account subcommand");
-        };
-        assert!(args.json);
+        assert!(cli.json);
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -48,6 +48,10 @@ pub struct RpcArgs {
     next_line_help = true
 )]
 pub struct Cli {
+    /// Output as JSON instead of human-readable text
+    #[arg(short = 'j', long, global = true)]
+    pub json: bool,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }

--- a/src/cli/simulate.rs
+++ b/src/cli/simulate.rs
@@ -184,9 +184,6 @@ pub struct TransactionInputArgs {
     /// Pass multiple values for bundle mode.
     #[arg(value_name = "TX", required = false)]
     pub tx: Vec<String>,
-    /// Output as JSON instead of human-readable text
-    #[arg(short = 'j', long, default_value_t = false)]
-    pub json: bool,
 }
 
 pub use sonar_sim::{

--- a/src/handlers/account.rs
+++ b/src/handlers/account.rs
@@ -19,7 +19,7 @@ use crate::{
     core::idl_fetcher, parsers::metaplex_metadata_decoder, parsers::token_account_decoder,
 };
 
-pub(crate) fn handle(args: AccountArgs) -> Result<()> {
+pub(crate) fn handle(args: AccountArgs, json: bool) -> Result<()> {
     let (pubkey_str, account_pubkey, account) = match &args.account {
         Some(input) if input == "-" => load_account_json(std::io::stdin().lock())?,
         Some(input) => {
@@ -58,7 +58,7 @@ pub(crate) fn handle(args: AccountArgs) -> Result<()> {
     let client = RpcClient::new(&args.rpc.rpc_url);
 
     let (mut output, account_type, metadata_output) =
-        decode_account_output(&args, &client, &account_pubkey, &account)?;
+        decode_account_output(&args, &client, &account_pubkey, &account, json)?;
 
     if let Some(meta) = &metadata_output {
         output
@@ -67,7 +67,7 @@ pub(crate) fn handle(args: AccountArgs) -> Result<()> {
             .insert("metaplexMetadata".into(), meta.clone());
     }
 
-    if args.json {
+    if json {
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
         crate::output::render_account_text(
@@ -165,10 +165,11 @@ fn decode_account_output(
     client: &RpcClient,
     account_pubkey: &Pubkey,
     account: &solana_account::Account,
+    json: bool,
 ) -> Result<(Value, String, Option<Value>)> {
     if *account_pubkey == solana_sdk_ids::sysvar::clock::id() {
         if let Ok(clock) = bincode::deserialize::<solana_clock::Clock>(account.data.as_slice()) {
-            let data_json = if args.json {
+            let data_json = if json {
                 serde_json::json!({
                     "slot": clock.slot,
                     "epoch": clock.epoch,

--- a/src/handlers/borsh.rs
+++ b/src/handlers/borsh.rs
@@ -73,8 +73,7 @@ fn handle_ser(args: BorshSerArgs, json: bool) -> Result<()> {
     let hex_str = format!("0x{}{}", prefix_hex, hex::encode(&bytes));
 
     if json {
-        let output = BorshSerOutput { hex: hex_str };
-        println!("{}", serde_json::to_string_pretty(&output)?);
+        crate::output::print_json(&BorshSerOutput { hex: hex_str })?;
     } else {
         println!("{hex_str}");
     }

--- a/src/handlers/borsh.rs
+++ b/src/handlers/borsh.rs
@@ -5,10 +5,10 @@ use crate::converters::borsh_decode::decode_borsh;
 use crate::converters::borsh_encode::encode_borsh;
 use crate::converters::borsh_type::parse_borsh_type;
 
-pub(crate) fn handle(args: BorshArgs, _json: bool) -> Result<()> {
+pub(crate) fn handle(args: BorshArgs, json: bool) -> Result<()> {
     match args.command {
         BorshCommands::De(args) => handle_de(args),
-        BorshCommands::Ser(args) => handle_ser(args),
+        BorshCommands::Ser(args) => handle_ser(args, json),
     }
 }
 
@@ -45,7 +45,12 @@ fn handle_de(args: BorshDeArgs) -> Result<()> {
     Ok(())
 }
 
-fn handle_ser(args: BorshSerArgs) -> Result<()> {
+#[derive(serde::Serialize)]
+struct BorshSerOutput {
+    hex: String,
+}
+
+fn handle_ser(args: BorshSerArgs, json: bool) -> Result<()> {
     let ty = parse_borsh_type(&args.type_str)
         .map_err(|e| anyhow::anyhow!("invalid type descriptor: {e}"))?;
 
@@ -65,7 +70,14 @@ fn handle_ser(args: BorshSerArgs) -> Result<()> {
         None => String::new(),
     };
 
-    println!("0x{}{}", prefix_hex, hex::encode(&bytes));
+    let hex_str = format!("0x{}{}", prefix_hex, hex::encode(&bytes));
+
+    if json {
+        let output = BorshSerOutput { hex: hex_str };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        println!("{hex_str}");
+    }
     Ok(())
 }
 

--- a/src/handlers/borsh.rs
+++ b/src/handlers/borsh.rs
@@ -5,7 +5,7 @@ use crate::converters::borsh_decode::decode_borsh;
 use crate::converters::borsh_encode::encode_borsh;
 use crate::converters::borsh_type::parse_borsh_type;
 
-pub(crate) fn handle(args: BorshArgs) -> Result<()> {
+pub(crate) fn handle(args: BorshArgs, _json: bool) -> Result<()> {
     match args.command {
         BorshCommands::De(args) => handle_de(args),
         BorshCommands::Ser(args) => handle_ser(args),

--- a/src/handlers/cache.rs
+++ b/src/handlers/cache.rs
@@ -116,7 +116,7 @@ fn handle_list(json: bool) -> Result<()> {
                 }
             })
             .collect();
-        println!("{}", serde_json::to_string_pretty(&list)?);
+        crate::output::print_json(&list)?;
     } else {
         println!("{} ({}):\n", "Cached entries".bold(), cache_root.display());
 
@@ -168,7 +168,7 @@ fn handle_clean(args: crate::cli::CacheCleanArgs, json: bool) -> Result<()> {
     let cache_root = cache::resolve_cache_dir(&None);
     if !cache_root.exists() {
         if json {
-            println!("{}", serde_json::to_string_pretty(&CacheCleanOutput { removed: 0 })?);
+            crate::output::print_json(&CacheCleanOutput { removed: 0 })?;
         } else {
             eprintln!("No cache directory found at {}", cache_root.display());
         }
@@ -207,7 +207,7 @@ fn handle_clean(args: crate::cli::CacheCleanArgs, json: bool) -> Result<()> {
     }
 
     if json {
-        println!("{}", serde_json::to_string_pretty(&CacheCleanOutput { removed })?);
+        crate::output::print_json(&CacheCleanOutput { removed })?;
     } else {
         println!("Removed {} cache entries", removed);
     }
@@ -233,8 +233,10 @@ fn handle_info(args: crate::cli::CacheInfoArgs, json: bool) -> Result<()> {
         })
         .unwrap_or(0);
 
+    let meta_result = cache::read_meta_json(&dir);
+
     if json {
-        match cache::read_meta_json(&dir) {
+        match meta_result {
             Ok(meta) => {
                 let output = CacheInfoOutput {
                     key: args.key,
@@ -254,20 +256,19 @@ fn handle_info(args: crate::cli::CacheInfoArgs, json: bool) -> Result<()> {
                         .collect(),
                     account_files: file_count,
                 };
-                println!("{}", serde_json::to_string_pretty(&output)?);
+                crate::output::print_json(&output)?;
             }
             Err(_) => {
-                // Minimal JSON when no metadata exists
                 let output = serde_json::json!({
                     "key": args.key,
                     "account_files": file_count,
                     "error": "no _meta.json found"
                 });
-                println!("{}", serde_json::to_string_pretty(&output)?);
+                crate::output::print_json(&output)?;
             }
         }
     } else {
-        match cache::read_meta_json(&dir) {
+        match meta_result {
             Ok(meta) => {
                 println!("{}: {}", "Key".bold(), args.key);
                 println!("{}: {}", "Type".bold(), meta.cache_type);

--- a/src/handlers/cache.rs
+++ b/src/handlers/cache.rs
@@ -1,21 +1,68 @@
 use anyhow::{Context, Result};
 use colored::Colorize;
+use serde::Serialize;
 
 use crate::cli::{CacheArgs, CacheCommands};
 use crate::core::cache;
 
-pub(crate) fn handle(args: CacheArgs, _json: bool) -> Result<()> {
+#[derive(Serialize)]
+struct CacheListEntry {
+    key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    account_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rpc_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sonar_version: Option<String>,
+    /// Only present for entries without metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file_count: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct CacheInfoTransaction {
+    input: String,
+    raw_tx: String,
+    resolved_from: String,
+}
+
+#[derive(Serialize)]
+struct CacheInfoOutput {
+    key: String,
+    cache_type: String,
+    created_at: String,
+    rpc_url: String,
+    account_count: usize,
+    sonar_version: String,
+    transactions: Vec<CacheInfoTransaction>,
+    account_files: usize,
+}
+
+#[derive(Serialize)]
+struct CacheCleanOutput {
+    removed: usize,
+}
+
+pub(crate) fn handle(args: CacheArgs, json: bool) -> Result<()> {
     match args.command {
-        CacheCommands::List => handle_list(),
-        CacheCommands::Clean(args) => handle_clean(args),
-        CacheCommands::Info(args) => handle_info(args),
+        CacheCommands::List => handle_list(json),
+        CacheCommands::Clean(args) => handle_clean(args, json),
+        CacheCommands::Info(args) => handle_info(args, json),
     }
 }
 
-fn handle_list() -> Result<()> {
+fn handle_list(json: bool) -> Result<()> {
     let cache_root = cache::resolve_cache_dir(&None);
     if !cache_root.exists() {
-        eprintln!("No cache directory found at {}", cache_root.display());
+        if json {
+            println!("[]");
+        } else {
+            eprintln!("No cache directory found at {}", cache_root.display());
+        }
         return Ok(());
     }
 
@@ -26,42 +73,82 @@ fn handle_list() -> Result<()> {
         .collect();
 
     if entries.is_empty() {
-        eprintln!("Cache is empty");
+        if json {
+            println!("[]");
+        } else {
+            eprintln!("Cache is empty");
+        }
         return Ok(());
     }
 
     entries.sort_by_key(|e| e.file_name());
 
-    println!("{} ({}):\n", "Cached entries".bold(), cache_root.display());
+    if json {
+        let list: Vec<CacheListEntry> = entries
+            .iter()
+            .map(|entry| {
+                let dir = entry.path();
+                let key = entry.file_name().to_string_lossy().to_string();
+                match cache::read_meta_json(&dir) {
+                    Ok(meta) => CacheListEntry {
+                        key,
+                        cache_type: Some(meta.cache_type),
+                        account_count: Some(meta.account_count),
+                        created_at: Some(meta.created_at),
+                        rpc_url: Some(meta.rpc_url),
+                        sonar_version: Some(meta.sonar_version),
+                        file_count: None,
+                    },
+                    Err(_) => {
+                        let fc = std::fs::read_dir(&dir)
+                            .map(|rd| rd.filter_map(|e| e.ok()).count())
+                            .unwrap_or(0);
+                        CacheListEntry {
+                            key,
+                            cache_type: None,
+                            account_count: None,
+                            created_at: None,
+                            rpc_url: None,
+                            sonar_version: None,
+                            file_count: Some(fc),
+                        }
+                    }
+                }
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&list)?);
+    } else {
+        println!("{} ({}):\n", "Cached entries".bold(), cache_root.display());
 
-    for entry in &entries {
-        let dir = entry.path();
-        let key = entry.file_name().to_string_lossy().to_string();
-        match cache::read_meta_json(&dir) {
-            Ok(meta) => {
-                let type_label = if meta.cache_type == "bundle" {
-                    format!("bundle, {} txs", meta.transactions.len())
-                } else {
-                    "single".to_string()
-                };
-                println!(
-                    "  {} — {} accounts, {} ({})",
-                    key.cyan(),
-                    meta.account_count,
-                    type_label,
-                    meta.created_at,
-                );
-            }
-            Err(_) => {
-                let file_count = std::fs::read_dir(&dir)
-                    .map(|rd| rd.filter_map(|e| e.ok()).count())
-                    .unwrap_or(0);
-                println!("  {} — {} files (no metadata)", key.yellow(), file_count,);
+        for entry in &entries {
+            let dir = entry.path();
+            let key = entry.file_name().to_string_lossy().to_string();
+            match cache::read_meta_json(&dir) {
+                Ok(meta) => {
+                    let type_label = if meta.cache_type == "bundle" {
+                        format!("bundle, {} txs", meta.transactions.len())
+                    } else {
+                        "single".to_string()
+                    };
+                    println!(
+                        "  {} — {} accounts, {} ({})",
+                        key.cyan(),
+                        meta.account_count,
+                        type_label,
+                        meta.created_at,
+                    );
+                }
+                Err(_) => {
+                    let file_count = std::fs::read_dir(&dir)
+                        .map(|rd| rd.filter_map(|e| e.ok()).count())
+                        .unwrap_or(0);
+                    println!("  {} — {} files (no metadata)", key.yellow(), file_count,);
+                }
             }
         }
-    }
 
-    println!("\n{} entries total", entries.len());
+        println!("\n{} entries total", entries.len());
+    }
     Ok(())
 }
 
@@ -77,10 +164,14 @@ fn parse_duration_days(s: &str) -> Result<u64> {
     }
 }
 
-fn handle_clean(args: crate::cli::CacheCleanArgs) -> Result<()> {
+fn handle_clean(args: crate::cli::CacheCleanArgs, json: bool) -> Result<()> {
     let cache_root = cache::resolve_cache_dir(&None);
     if !cache_root.exists() {
-        eprintln!("No cache directory found at {}", cache_root.display());
+        if json {
+            println!("{}", serde_json::to_string_pretty(&CacheCleanOutput { removed: 0 })?);
+        } else {
+            eprintln!("No cache directory found at {}", cache_root.display());
+        }
         return Ok(());
     }
 
@@ -115,41 +206,20 @@ fn handle_clean(args: crate::cli::CacheCleanArgs) -> Result<()> {
         removed += 1;
     }
 
-    println!("Removed {} cache entries", removed);
+    if json {
+        println!("{}", serde_json::to_string_pretty(&CacheCleanOutput { removed })?);
+    } else {
+        println!("Removed {} cache entries", removed);
+    }
     Ok(())
 }
 
-fn handle_info(args: crate::cli::CacheInfoArgs) -> Result<()> {
+fn handle_info(args: crate::cli::CacheInfoArgs, json: bool) -> Result<()> {
     let cache_root = cache::resolve_cache_dir(&args.cache_dir);
     let dir = cache_root.join(&args.key);
 
     if !dir.exists() {
         anyhow::bail!("Cache entry not found: {}", args.key);
-    }
-
-    match cache::read_meta_json(&dir) {
-        Ok(meta) => {
-            println!("{}: {}", "Key".bold(), args.key);
-            println!("{}: {}", "Type".bold(), meta.cache_type);
-            println!("{}: {}", "Created".bold(), meta.created_at);
-            println!("{}: {}", "RPC".bold(), meta.rpc_url);
-            println!("{}: {}", "Accounts".bold(), meta.account_count);
-            println!("{}: {}", "Sonar version".bold(), meta.sonar_version);
-            if meta.transactions.len() > 1 || meta.cache_type == "bundle" {
-                println!("{}:", "Transactions".bold());
-                for (i, tx) in meta.transactions.iter().enumerate() {
-                    let display = if tx.input.len() > 44 {
-                        format!("{}...", &tx.input[..44])
-                    } else {
-                        tx.input.clone()
-                    };
-                    println!("  {}: {} ({})", i + 1, display, tx.resolved_from);
-                }
-            }
-        }
-        Err(_) => {
-            println!("{}: {} (no _meta.json found)", "Key".bold(), args.key);
-        }
     }
 
     let file_count = std::fs::read_dir(&dir)
@@ -162,7 +232,67 @@ fn handle_info(args: crate::cli::CacheInfoArgs) -> Result<()> {
                 .count()
         })
         .unwrap_or(0);
-    println!("{}: {} account files on disk", "Files".bold(), file_count);
+
+    if json {
+        match cache::read_meta_json(&dir) {
+            Ok(meta) => {
+                let output = CacheInfoOutput {
+                    key: args.key,
+                    cache_type: meta.cache_type,
+                    created_at: meta.created_at,
+                    rpc_url: meta.rpc_url,
+                    account_count: meta.account_count,
+                    sonar_version: meta.sonar_version,
+                    transactions: meta
+                        .transactions
+                        .into_iter()
+                        .map(|tx| CacheInfoTransaction {
+                            input: tx.input,
+                            raw_tx: tx.raw_tx,
+                            resolved_from: tx.resolved_from,
+                        })
+                        .collect(),
+                    account_files: file_count,
+                };
+                println!("{}", serde_json::to_string_pretty(&output)?);
+            }
+            Err(_) => {
+                // Minimal JSON when no metadata exists
+                let output = serde_json::json!({
+                    "key": args.key,
+                    "account_files": file_count,
+                    "error": "no _meta.json found"
+                });
+                println!("{}", serde_json::to_string_pretty(&output)?);
+            }
+        }
+    } else {
+        match cache::read_meta_json(&dir) {
+            Ok(meta) => {
+                println!("{}: {}", "Key".bold(), args.key);
+                println!("{}: {}", "Type".bold(), meta.cache_type);
+                println!("{}: {}", "Created".bold(), meta.created_at);
+                println!("{}: {}", "RPC".bold(), meta.rpc_url);
+                println!("{}: {}", "Accounts".bold(), meta.account_count);
+                println!("{}: {}", "Sonar version".bold(), meta.sonar_version);
+                if meta.transactions.len() > 1 || meta.cache_type == "bundle" {
+                    println!("{}:", "Transactions".bold());
+                    for (i, tx) in meta.transactions.iter().enumerate() {
+                        let display = if tx.input.len() > 44 {
+                            format!("{}...", &tx.input[..44])
+                        } else {
+                            tx.input.clone()
+                        };
+                        println!("  {}: {} ({})", i + 1, display, tx.resolved_from);
+                    }
+                }
+            }
+            Err(_) => {
+                println!("{}: {} (no _meta.json found)", "Key".bold(), args.key);
+            }
+        }
+        println!("{}: {} account files on disk", "Files".bold(), file_count);
+    }
 
     Ok(())
 }

--- a/src/handlers/cache.rs
+++ b/src/handlers/cache.rs
@@ -32,7 +32,7 @@ fn handle_list() -> Result<()> {
 
     entries.sort_by_key(|e| e.file_name());
 
-    eprintln!("{} ({}):\n", "Cached entries".bold(), cache_root.display());
+    println!("{} ({}):\n", "Cached entries".bold(), cache_root.display());
 
     for entry in &entries {
         let dir = entry.path();
@@ -44,7 +44,7 @@ fn handle_list() -> Result<()> {
                 } else {
                     "single".to_string()
                 };
-                eprintln!(
+                println!(
                     "  {} — {} accounts, {} ({})",
                     key.cyan(),
                     meta.account_count,
@@ -56,12 +56,12 @@ fn handle_list() -> Result<()> {
                 let file_count = std::fs::read_dir(&dir)
                     .map(|rd| rd.filter_map(|e| e.ok()).count())
                     .unwrap_or(0);
-                eprintln!("  {} — {} files (no metadata)", key.yellow(), file_count,);
+                println!("  {} — {} files (no metadata)", key.yellow(), file_count,);
             }
         }
     }
 
-    eprintln!("\n{} entries total", entries.len());
+    println!("\n{} entries total", entries.len());
     Ok(())
 }
 
@@ -115,7 +115,7 @@ fn handle_clean(args: crate::cli::CacheCleanArgs) -> Result<()> {
         removed += 1;
     }
 
-    eprintln!("Removed {} cache entries", removed);
+    println!("Removed {} cache entries", removed);
     Ok(())
 }
 
@@ -129,26 +129,26 @@ fn handle_info(args: crate::cli::CacheInfoArgs) -> Result<()> {
 
     match cache::read_meta_json(&dir) {
         Ok(meta) => {
-            eprintln!("{}: {}", "Key".bold(), args.key);
-            eprintln!("{}: {}", "Type".bold(), meta.cache_type);
-            eprintln!("{}: {}", "Created".bold(), meta.created_at);
-            eprintln!("{}: {}", "RPC".bold(), meta.rpc_url);
-            eprintln!("{}: {}", "Accounts".bold(), meta.account_count);
-            eprintln!("{}: {}", "Sonar version".bold(), meta.sonar_version);
+            println!("{}: {}", "Key".bold(), args.key);
+            println!("{}: {}", "Type".bold(), meta.cache_type);
+            println!("{}: {}", "Created".bold(), meta.created_at);
+            println!("{}: {}", "RPC".bold(), meta.rpc_url);
+            println!("{}: {}", "Accounts".bold(), meta.account_count);
+            println!("{}: {}", "Sonar version".bold(), meta.sonar_version);
             if meta.transactions.len() > 1 || meta.cache_type == "bundle" {
-                eprintln!("{}:", "Transactions".bold());
+                println!("{}:", "Transactions".bold());
                 for (i, tx) in meta.transactions.iter().enumerate() {
                     let display = if tx.input.len() > 44 {
                         format!("{}...", &tx.input[..44])
                     } else {
                         tx.input.clone()
                     };
-                    eprintln!("  {}: {} ({})", i + 1, display, tx.resolved_from);
+                    println!("  {}: {} ({})", i + 1, display, tx.resolved_from);
                 }
             }
         }
         Err(_) => {
-            eprintln!("{}: {} (no _meta.json found)", "Key".bold(), args.key);
+            println!("{}: {} (no _meta.json found)", "Key".bold(), args.key);
         }
     }
 
@@ -162,7 +162,7 @@ fn handle_info(args: crate::cli::CacheInfoArgs) -> Result<()> {
                 .count()
         })
         .unwrap_or(0);
-    eprintln!("{}: {} account files on disk", "Files".bold(), file_count);
+    println!("{}: {} account files on disk", "Files".bold(), file_count);
 
     Ok(())
 }

--- a/src/handlers/cache.rs
+++ b/src/handlers/cache.rs
@@ -4,7 +4,7 @@ use colored::Colorize;
 use crate::cli::{CacheArgs, CacheCommands};
 use crate::core::cache;
 
-pub(crate) fn handle(args: CacheArgs) -> Result<()> {
+pub(crate) fn handle(args: CacheArgs, _json: bool) -> Result<()> {
     match args.command {
         CacheCommands::List => handle_list(),
         CacheCommands::Clean(args) => handle_clean(args),

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result, anyhow};
 use crate::cli::{ConfigArgs, ConfigSetArgs, ConfigSubcommands};
 use crate::utils::config::{self, ConfigKey};
 
-pub(crate) fn handle(args: ConfigArgs) -> Result<()> {
+pub(crate) fn handle(args: ConfigArgs, _json: bool) -> Result<()> {
     match args.command {
         ConfigSubcommands::List => handle_list(),
         ConfigSubcommands::Get(args) => handle_get(&args.key),

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -1,38 +1,75 @@
+use std::collections::BTreeMap;
+
 use anyhow::{Context, Result, anyhow};
+use serde::Serialize;
 
 use crate::cli::{ConfigArgs, ConfigSetArgs, ConfigSubcommands};
 use crate::utils::config::{self, ConfigKey};
 
-pub(crate) fn handle(args: ConfigArgs, _json: bool) -> Result<()> {
+pub(crate) fn handle(args: ConfigArgs, json: bool) -> Result<()> {
     match args.command {
-        ConfigSubcommands::List => handle_list(),
-        ConfigSubcommands::Get(args) => handle_get(&args.key),
-        ConfigSubcommands::Set(args) => handle_set(args),
+        ConfigSubcommands::List => handle_list(json),
+        ConfigSubcommands::Get(args) => handle_get(&args.key, json),
+        ConfigSubcommands::Set(args) => handle_set(args, json),
     }
 }
 
-fn handle_list() -> Result<()> {
+fn handle_list(json: bool) -> Result<()> {
     let current = config::load_config();
-    for key in config::all_config_keys() {
-        match current.value_for_key(*key) {
-            Some(value) => println!("{}={}", key.as_str(), value),
-            None => println!("{}=<unset>", key.as_str()),
+
+    if json {
+        let mut map = BTreeMap::new();
+        for key in config::all_config_keys() {
+            let value = match current.value_for_key(*key) {
+                Some(v) => serde_json::Value::String(v),
+                None => serde_json::Value::Null,
+            };
+            map.insert(key.as_str().to_string(), value);
+        }
+        println!("{}", serde_json::to_string(&map)?);
+    } else {
+        for key in config::all_config_keys() {
+            match current.value_for_key(*key) {
+                Some(value) => println!("{}={}", key.as_str(), value),
+                None => println!("{}=<unset>", key.as_str()),
+            }
         }
     }
+
     Ok(())
 }
 
-fn handle_get(key: &str) -> Result<()> {
+#[derive(Serialize)]
+struct ConfigGetOutput {
+    key: String,
+    value: Option<String>,
+}
+
+fn handle_get(key: &str, json: bool) -> Result<()> {
     let key = parse_known_key(key)?;
     let current = config::load_config();
-    match current.value_for_key(key) {
-        Some(value) => println!("{}", value),
-        None => println!("<unset>"),
+    let value = current.value_for_key(key);
+
+    if json {
+        let output = ConfigGetOutput { key: key.as_str().to_string(), value };
+        println!("{}", serde_json::to_string(&output)?);
+    } else {
+        match value {
+            Some(v) => println!("{}", v),
+            None => println!("<unset>"),
+        }
     }
+
     Ok(())
 }
 
-fn handle_set(args: ConfigSetArgs) -> Result<()> {
+#[derive(Serialize)]
+struct ConfigSetOutput {
+    key: String,
+    value: String,
+}
+
+fn handle_set(args: ConfigSetArgs, json: bool) -> Result<()> {
     let (raw_key, raw_value) = if let Some(value) = args.value {
         if args.key_or_assignment.contains('=') {
             return Err(anyhow!("Ambiguous input. Use either KEY=VALUE or KEY VALUE format."));
@@ -47,7 +84,14 @@ fn handle_set(args: ConfigSetArgs) -> Result<()> {
 
     let key = parse_known_key(raw_key.trim())?;
     let normalized = config::set_config_key_value(key, &raw_value)?;
-    println!("{}={}", key.as_str(), normalized);
+
+    if json {
+        let output = ConfigSetOutput { key: key.as_str().to_string(), value: normalized };
+        println!("{}", serde_json::to_string(&output)?);
+    } else {
+        println!("{}={}", key.as_str(), normalized);
+    }
+
     Ok(())
 }
 

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -26,7 +26,7 @@ fn handle_list(json: bool) -> Result<()> {
             };
             map.insert(key.as_str().to_string(), value);
         }
-        println!("{}", serde_json::to_string(&map)?);
+        crate::output::print_json(&map)?;
     } else {
         for key in config::all_config_keys() {
             match current.value_for_key(*key) {
@@ -51,8 +51,7 @@ fn handle_get(key: &str, json: bool) -> Result<()> {
     let value = current.value_for_key(key);
 
     if json {
-        let output = ConfigGetOutput { key: key.as_str().to_string(), value };
-        println!("{}", serde_json::to_string(&output)?);
+        crate::output::print_json(&ConfigGetOutput { key: key.as_str().to_string(), value })?;
     } else {
         match value {
             Some(v) => println!("{}", v),
@@ -86,8 +85,10 @@ fn handle_set(args: ConfigSetArgs, json: bool) -> Result<()> {
     let normalized = config::set_config_key_value(key, &raw_value)?;
 
     if json {
-        let output = ConfigSetOutput { key: key.as_str().to_string(), value: normalized };
-        println!("{}", serde_json::to_string(&output)?);
+        crate::output::print_json(&ConfigSetOutput {
+            key: key.as_str().to_string(),
+            value: normalized,
+        })?;
     } else {
         println!("{}={}", key.as_str(), normalized);
     }

--- a/src/handlers/convert.rs
+++ b/src/handlers/convert.rs
@@ -37,8 +37,12 @@ pub(crate) fn handle(mut args: ConvertArgs, json: bool) -> Result<()> {
     if json {
         let from_name = args.from.to_possible_value().unwrap().get_name().to_string();
         let to_name = args.to.to_possible_value().unwrap().get_name().to_string();
-        let json_output = ConvertOutput { input: input_str, output, from: from_name, to: to_name };
-        println!("{}", serde_json::to_string_pretty(&json_output)?);
+        crate::output::print_json(&ConvertOutput {
+            input: input_str,
+            output,
+            from: from_name,
+            to: to_name,
+        })?;
     } else {
         println!("{}", output);
     }

--- a/src/handlers/convert.rs
+++ b/src/handlers/convert.rs
@@ -1,8 +1,17 @@
 use anyhow::Result;
+use clap::ValueEnum;
 
 use crate::cli::{ConvertArgs, ConvertOutputFormat};
 
-pub(crate) fn handle(args: ConvertArgs, _json: bool) -> Result<()> {
+#[derive(serde::Serialize)]
+struct ConvertOutput {
+    input: String,
+    output: String,
+    from: String,
+    to: String,
+}
+
+pub(crate) fn handle(mut args: ConvertArgs, json: bool) -> Result<()> {
     if args.escape && args.to != ConvertOutputFormat::Text {
         log::warn!("--escape has no effect when output format is not 'text'");
     }
@@ -15,7 +24,23 @@ pub(crate) fn handle(args: ConvertArgs, _json: bool) -> Result<()> {
         log::warn!("--sep has no effect when output format is not 'hex-bytes' or 'bytes'");
     }
 
+    // Eagerly resolve stdin so the input string is available for JSON output
+    // and is not consumed twice.
+    let input_str = crate::utils::read_cli_input(args.input.as_deref(), "input")
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    if args.input.is_none() {
+        args.input = Some(input_str.clone());
+    }
+
     let output = crate::cli::convert(&args).map_err(|e| anyhow::anyhow!("{}", e))?;
-    println!("{}", output);
+
+    if json {
+        let from_name = args.from.to_possible_value().unwrap().get_name().to_string();
+        let to_name = args.to.to_possible_value().unwrap().get_name().to_string();
+        let json_output = ConvertOutput { input: input_str, output, from: from_name, to: to_name };
+        println!("{}", serde_json::to_string_pretty(&json_output)?);
+    } else {
+        println!("{}", output);
+    }
     Ok(())
 }

--- a/src/handlers/convert.rs
+++ b/src/handlers/convert.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use crate::cli::{ConvertArgs, ConvertOutputFormat};
 
-pub(crate) fn handle(args: ConvertArgs) -> Result<()> {
+pub(crate) fn handle(args: ConvertArgs, _json: bool) -> Result<()> {
     if args.escape && args.to != ConvertOutputFormat::Text {
         log::warn!("--escape has no effect when output format is not 'text'");
     }

--- a/src/handlers/decode.rs
+++ b/src/handlers/decode.rs
@@ -9,7 +9,7 @@ use crate::utils::progress::Progress;
 
 use super::{cache_read_dir, prepare_accounts_and_idls, resolve_inputs_to_txs};
 
-pub(crate) fn handle(args: DecodeArgs) -> Result<()> {
+pub(crate) fn handle(args: DecodeArgs, json: bool) -> Result<()> {
     let idl_dir = args.idl_dir.clone();
     let mut parser_registry = ParserRegistry::new(idl_dir);
     let progress = Progress::new();
@@ -27,7 +27,7 @@ pub(crate) fn handle(args: DecodeArgs) -> Result<()> {
     let rpc_url = rpc.rpc_url;
     let resolver_cache_location =
         if refresh_cache { None } else { Some(super::build_cache_location(&cache_dir)) };
-    let TransactionInputArgs { tx, json } = transaction;
+    let TransactionInputArgs { tx } = transaction;
 
     // Check if this is a bundle (multiple positional TX arguments)
     if tx.len() > 1 {

--- a/src/handlers/idl.rs
+++ b/src/handlers/idl.rs
@@ -9,7 +9,7 @@ use crate::cli::{IdlAddressArgs, IdlArgs, IdlFetchArgs, IdlSubcommands, IdlSyncA
 use crate::core::idl_fetcher;
 use crate::utils::progress::Progress;
 
-pub(crate) fn handle(args: IdlArgs) -> Result<()> {
+pub(crate) fn handle(args: IdlArgs, _json: bool) -> Result<()> {
     match args.command {
         IdlSubcommands::Fetch(args) => handle_fetch(args),
         IdlSubcommands::Sync(args) => handle_sync(args),

--- a/src/handlers/idl.rs
+++ b/src/handlers/idl.rs
@@ -3,37 +3,61 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::{Context, Result};
+use serde::Serialize;
 use solana_pubkey::Pubkey;
 
 use crate::cli::{IdlAddressArgs, IdlArgs, IdlFetchArgs, IdlSubcommands, IdlSyncArgs};
 use crate::core::idl_fetcher;
 use crate::utils::progress::Progress;
 
-pub(crate) fn handle(args: IdlArgs, _json: bool) -> Result<()> {
+#[derive(Serialize)]
+struct IdlFetchResult {
+    program: String,
+    path: Option<String>,
+    status: String,
+}
+
+#[derive(Serialize)]
+struct IdlAddressOutput {
+    program: String,
+    idl_address: String,
+}
+
+pub(crate) fn handle(args: IdlArgs, json: bool) -> Result<()> {
     match args.command {
-        IdlSubcommands::Fetch(args) => handle_fetch(args),
-        IdlSubcommands::Sync(args) => handle_sync(args),
-        IdlSubcommands::Address(args) => handle_address(args),
+        IdlSubcommands::Fetch(args) => handle_fetch(args, json),
+        IdlSubcommands::Sync(args) => handle_sync(args, json),
+        IdlSubcommands::Address(args) => handle_address(args, json),
     }
 }
 
-fn handle_fetch(args: IdlFetchArgs) -> Result<()> {
+fn handle_fetch(args: IdlFetchArgs, json: bool) -> Result<()> {
     let program_ids = parse_program_ids(&args.programs)?;
     let output_dir = resolve_output_dir(args.output_dir, None);
-    fetch_and_write_idls(program_ids, args.rpc.rpc_url, output_dir, args.allow_partial)
+    fetch_and_write_idls(program_ids, args.rpc.rpc_url, output_dir, args.allow_partial, json)
 }
 
-fn handle_sync(args: IdlSyncArgs) -> Result<()> {
+fn handle_sync(args: IdlSyncArgs, json: bool) -> Result<()> {
     let (program_ids, default_output_dir) = collect_program_ids_from_sync_path(&args.path)?;
     let output_dir = resolve_output_dir(args.output_dir, default_output_dir.as_deref());
-    fetch_and_write_idls(program_ids, args.rpc.rpc_url, output_dir, args.allow_partial)
+    fetch_and_write_idls(program_ids, args.rpc.rpc_url, output_dir, args.allow_partial, json)
 }
 
-fn handle_address(args: IdlAddressArgs) -> Result<()> {
+fn handle_address(args: IdlAddressArgs, json: bool) -> Result<()> {
     let program_id = Pubkey::from_str(args.program.trim())
         .with_context(|| format!("Invalid program ID: {}", args.program.trim()))?;
     let idl_address = idl_fetcher::get_idl_address(&program_id)?;
-    println!("{idl_address}");
+
+    if json {
+        let output = IdlAddressOutput {
+            program: program_id.to_string(),
+            idl_address: idl_address.to_string(),
+        };
+        println!("{}", serde_json::to_string(&output)?);
+    } else {
+        println!("{idl_address}");
+    }
+
     Ok(())
 }
 
@@ -55,6 +79,7 @@ fn fetch_and_write_idls(
     rpc_url: String,
     output_dir: PathBuf,
     allow_partial: bool,
+    json: bool,
 ) -> Result<()> {
     fs::create_dir_all(&output_dir)
         .with_context(|| format!("Failed to create output directory: {}", output_dir.display()))?;
@@ -67,6 +92,7 @@ fn fetch_and_write_idls(
     let mut fetched = 0usize;
     let mut not_found = Vec::new();
     let mut errors = Vec::new();
+    let mut json_results: Vec<IdlFetchResult> = Vec::new();
 
     for (program_id, result) in &results {
         match result {
@@ -80,19 +106,49 @@ fn fetch_and_write_idls(
                 let path = output_dir.join(format!("{}.json", program_id));
                 fs::write(&path, &formatted)
                     .with_context(|| format!("Failed to write IDL file: {}", path.display()))?;
-                println!("{}", path.display());
+                if json {
+                    json_results.push(IdlFetchResult {
+                        program: program_id.to_string(),
+                        path: Some(path.display().to_string()),
+                        status: "ok".to_string(),
+                    });
+                } else {
+                    println!("{}", path.display());
+                }
                 fetched += 1;
             }
-            Ok(None) => not_found.push(program_id),
-            Err(e) => errors.push((program_id, e)),
+            Ok(None) => {
+                if json {
+                    json_results.push(IdlFetchResult {
+                        program: program_id.to_string(),
+                        path: None,
+                        status: "not_found".to_string(),
+                    });
+                }
+                not_found.push(program_id);
+            }
+            Err(_) => {
+                if json {
+                    json_results.push(IdlFetchResult {
+                        program: program_id.to_string(),
+                        path: None,
+                        status: "error".to_string(),
+                    });
+                }
+                errors.push(program_id);
+            }
         }
+    }
+
+    if json {
+        println!("{}", serde_json::to_string(&json_results)?);
     }
 
     for id in &not_found {
         log::warn!("no IDL found: {}", id);
     }
-    for (id, e) in &errors {
-        log::error!("IDL fetch error for {}: {:#}", id, e);
+    for id in &errors {
+        log::error!("IDL fetch error for {}", id);
     }
 
     let has_failures = !not_found.is_empty() || !errors.is_empty();

--- a/src/handlers/idl.rs
+++ b/src/handlers/idl.rs
@@ -11,10 +11,18 @@ use crate::core::idl_fetcher;
 use crate::utils::progress::Progress;
 
 #[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum IdlFetchStatus {
+    Ok,
+    NotFound,
+    Error,
+}
+
+#[derive(Serialize)]
 struct IdlFetchResult {
     program: String,
     path: Option<String>,
-    status: String,
+    status: IdlFetchStatus,
 }
 
 #[derive(Serialize)]
@@ -53,7 +61,7 @@ fn handle_address(args: IdlAddressArgs, json: bool) -> Result<()> {
             program: program_id.to_string(),
             idl_address: idl_address.to_string(),
         };
-        println!("{}", serde_json::to_string(&output)?);
+        crate::output::print_json(&output)?;
     } else {
         println!("{idl_address}");
     }
@@ -110,7 +118,7 @@ fn fetch_and_write_idls(
                     json_results.push(IdlFetchResult {
                         program: program_id.to_string(),
                         path: Some(path.display().to_string()),
-                        status: "ok".to_string(),
+                        status: IdlFetchStatus::Ok,
                     });
                 } else {
                     println!("{}", path.display());
@@ -122,33 +130,31 @@ fn fetch_and_write_idls(
                     json_results.push(IdlFetchResult {
                         program: program_id.to_string(),
                         path: None,
-                        status: "not_found".to_string(),
+                        status: IdlFetchStatus::NotFound,
                     });
                 }
                 not_found.push(program_id);
             }
-            Err(_) => {
+            Err(e) => {
                 if json {
                     json_results.push(IdlFetchResult {
                         program: program_id.to_string(),
                         path: None,
-                        status: "error".to_string(),
+                        status: IdlFetchStatus::Error,
                     });
                 }
+                log::error!("IDL fetch error for {}: {:#}", program_id, e);
                 errors.push(program_id);
             }
         }
     }
 
     if json {
-        println!("{}", serde_json::to_string(&json_results)?);
+        crate::output::print_json(&json_results)?;
     }
 
     for id in &not_found {
         log::warn!("no IDL found: {}", id);
-    }
-    for id in &errors {
-        log::error!("IDL fetch error for {}", id);
     }
 
     let has_failures = !not_found.is_empty() || !errors.is_empty();

--- a/src/handlers/pda.rs
+++ b/src/handlers/pda.rs
@@ -5,7 +5,7 @@ use solana_pubkey::Pubkey;
 
 use crate::cli::PdaArgs;
 
-pub(crate) fn handle(args: PdaArgs) -> Result<()> {
+pub(crate) fn handle(args: PdaArgs, _json: bool) -> Result<()> {
     let program_id = Pubkey::from_str(&args.program_id)
         .with_context(|| format!("Invalid program ID: {}", args.program_id))?;
 

--- a/src/handlers/pda.rs
+++ b/src/handlers/pda.rs
@@ -27,8 +27,7 @@ pub(crate) fn handle(args: PdaArgs, json: bool) -> Result<()> {
     let (pda, bump) = Pubkey::find_program_address(&seed_slices, &program_id);
 
     if json {
-        let output = PdaOutput { pda: pda.to_string(), bump };
-        println!("{}", serde_json::to_string_pretty(&output)?);
+        crate::output::print_json(&PdaOutput { pda: pda.to_string(), bump })?;
     } else {
         println!("{pda} {bump}");
     }

--- a/src/handlers/pda.rs
+++ b/src/handlers/pda.rs
@@ -5,7 +5,13 @@ use solana_pubkey::Pubkey;
 
 use crate::cli::PdaArgs;
 
-pub(crate) fn handle(args: PdaArgs, _json: bool) -> Result<()> {
+#[derive(serde::Serialize)]
+struct PdaOutput {
+    pda: String,
+    bump: u8,
+}
+
+pub(crate) fn handle(args: PdaArgs, json: bool) -> Result<()> {
     let program_id = Pubkey::from_str(&args.program_id)
         .with_context(|| format!("Invalid program ID: {}", args.program_id))?;
 
@@ -20,7 +26,12 @@ pub(crate) fn handle(args: PdaArgs, _json: bool) -> Result<()> {
 
     let (pda, bump) = Pubkey::find_program_address(&seed_slices, &program_id);
 
-    println!("{pda} {bump}");
+    if json {
+        let output = PdaOutput { pda: pda.to_string(), bump };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        println!("{pda} {bump}");
+    }
 
     Ok(())
 }

--- a/src/handlers/send.rs
+++ b/src/handlers/send.rs
@@ -2,13 +2,20 @@ use std::time::{Duration, Instant};
 
 use crate::core::rpc_client::{RpcClient, SendTransactionConfig};
 use anyhow::{Context, Result, anyhow};
+use serde::Serialize;
 use solana_signature::Signature;
 use solana_transaction_status_client_types::{TransactionConfirmationStatus, TransactionStatus};
 
 use crate::cli::{SendArgs, WaitCommitmentArg};
 use crate::core::transaction;
 
-pub(crate) fn handle(args: SendArgs, _json: bool) -> Result<()> {
+#[derive(Serialize)]
+struct SendOutput {
+    signature: String,
+    explorer_url: String,
+}
+
+pub(crate) fn handle(args: SendArgs, json: bool) -> Result<()> {
     let parsed = transaction::parse_raw_transaction(&args.tx)?;
     let client = RpcClient::new(&args.rpc.rpc_url);
 
@@ -29,8 +36,15 @@ pub(crate) fn handle(args: SendArgs, _json: bool) -> Result<()> {
         None
     };
 
-    println!("{}", render_send_output(&signature_text));
-    eprintln!("{}", explorer_url);
+    if json {
+        let output = SendOutput { signature: signature_text, explorer_url };
+        println!("{}", serde_json::to_string(&output)?);
+    } else {
+        println!("{}", signature_text);
+        eprintln!("{}", explorer_url);
+    }
+
+    // Wait-confirmation status always goes to stderr regardless of mode
     if let Some(info) = wait_info {
         eprintln!("{}", info);
     }
@@ -69,10 +83,6 @@ fn build_explorer_url(signature: &str, rpc_url: &str) -> String {
             format!("https://explorer.solana.com/tx/{signature}?cluster=testnet")
         }
     }
-}
-
-fn render_send_output(signature: &str) -> String {
-    signature.to_string()
 }
 
 fn wait_for_confirmation(
@@ -152,9 +162,7 @@ fn status_commitment_label(status: &TransactionStatus) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        ExplorerCluster, build_explorer_url, infer_cluster_from_rpc_url, render_send_output,
-    };
+    use super::{ExplorerCluster, build_explorer_url, infer_cluster_from_rpc_url};
 
     #[test]
     fn build_explorer_url_mainnet_no_cluster_param() {
@@ -218,11 +226,5 @@ mod tests {
             ExplorerCluster::Mainnet
         );
         assert_eq!(infer_cluster_from_rpc_url("https://example.com/rpc"), ExplorerCluster::Mainnet);
-    }
-
-    #[test]
-    fn render_send_output_returns_signature_only() {
-        let rendered = render_send_output("4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ");
-        assert_eq!(rendered, "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ");
     }
 }

--- a/src/handlers/send.rs
+++ b/src/handlers/send.rs
@@ -8,7 +8,7 @@ use solana_transaction_status_client_types::{TransactionConfirmationStatus, Tran
 use crate::cli::{SendArgs, WaitCommitmentArg};
 use crate::core::transaction;
 
-pub(crate) fn handle(args: SendArgs) -> Result<()> {
+pub(crate) fn handle(args: SendArgs, _json: bool) -> Result<()> {
     let parsed = transaction::parse_raw_transaction(&args.tx)?;
     let client = RpcClient::new(&args.rpc.rpc_url);
 

--- a/src/handlers/send.rs
+++ b/src/handlers/send.rs
@@ -29,8 +29,11 @@ pub(crate) fn handle(args: SendArgs) -> Result<()> {
         None
     };
 
-    let output = render_send_output(&signature_text, &explorer_url, wait_info.as_deref());
-    println!("{}", output);
+    println!("{}", render_send_output(&signature_text));
+    eprintln!("{}", explorer_url);
+    if let Some(info) = wait_info {
+        eprintln!("{}", info);
+    }
 
     Ok(())
 }
@@ -68,13 +71,8 @@ fn build_explorer_url(signature: &str, rpc_url: &str) -> String {
     }
 }
 
-fn render_send_output(signature: &str, explorer_url: &str, wait_info: Option<&str>) -> String {
-    let mut out = format!("{signature}\n{explorer_url}");
-    if let Some(info) = wait_info {
-        out.push('\n');
-        out.push_str(info);
-    }
-    out
+fn render_send_output(signature: &str) -> String {
+    signature.to_string()
 }
 
 fn wait_for_confirmation(
@@ -223,30 +221,8 @@ mod tests {
     }
 
     #[test]
-    fn render_send_output_default_mode_stdout_only() {
-        let rendered = render_send_output(
-            "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ",
-            "https://explorer.solana.com/tx/4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ",
-            None,
-        );
-
-        assert_eq!(
-            rendered,
-            "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ\nhttps://explorer.solana.com/tx/4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ"
-        );
-    }
-
-    #[test]
-    fn render_send_output_wait_mode_appends_confirmation_to_stdout() {
-        let rendered = render_send_output(
-            "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ",
-            "https://explorer.solana.com/tx/4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ",
-            Some("Transaction confirmed at finalized commitment."),
-        );
-
-        assert_eq!(
-            rendered,
-            "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ\nhttps://explorer.solana.com/tx/4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ\nTransaction confirmed at finalized commitment."
-        );
+    fn render_send_output_returns_signature_only() {
+        let rendered = render_send_output("4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ");
+        assert_eq!(rendered, "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ");
     }
 }

--- a/src/handlers/send.rs
+++ b/src/handlers/send.rs
@@ -37,8 +37,7 @@ pub(crate) fn handle(args: SendArgs, json: bool) -> Result<()> {
     };
 
     if json {
-        let output = SendOutput { signature: signature_text, explorer_url };
-        println!("{}", serde_json::to_string(&output)?);
+        crate::output::print_json(&SendOutput { signature: signature_text, explorer_url })?;
     } else {
         println!("{}", signature_text);
         eprintln!("{}", explorer_url);

--- a/src/handlers/simulate.rs
+++ b/src/handlers/simulate.rs
@@ -56,7 +56,7 @@ fn apply_ix_mutations(
     Ok(())
 }
 
-pub(crate) fn handle(args: SimulateArgs) -> Result<()> {
+pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
     // Initialize instruction parser registry (uses configured/default IDL directory).
     let idl_dir = args.idl_dir.clone();
     let mut parser_registry = ParserRegistry::new(idl_dir);
@@ -92,7 +92,7 @@ pub(crate) fn handle(args: SimulateArgs) -> Result<()> {
     let rpc_url = rpc.rpc_url;
     let resolver_cache_location = Some(super::build_cache_location(&cache_dir));
 
-    let TransactionInputArgs { tx, json } = transaction;
+    let TransactionInputArgs { tx } = transaction;
 
     let overrides = parse_cli_args(override_args, cli::parse_override)?;
     let sol_fundings = parse_cli_args(funding_args, cli::parse_funding)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ fn run() -> Result<()> {
         colored::control::set_override(false);
     }
 
+    let json = cli.json;
     let command = match cli.command {
         Some(cmd) => cmd,
         None => {
@@ -81,23 +82,23 @@ fn run() -> Result<()> {
             if args.transaction.tx.is_empty() && std::io::stdin().is_terminal() {
                 print_subcommand_help("simulate")?;
             }
-            handlers::simulate::handle(*args)?
+            handlers::simulate::handle(*args, json)?
         }
         Commands::Decode(args) => {
             if args.transaction.tx.is_empty() && std::io::stdin().is_terminal() {
                 print_subcommand_help("decode")?;
             }
-            handlers::decode::handle(args)?
+            handlers::decode::handle(args, json)?
         }
-        Commands::Idl(args) => handlers::idl::handle(args)?,
-        Commands::Account(args) => handlers::account::handle(args)?,
-        Commands::Cache(args) => handlers::cache::handle(args)?,
-        Commands::Convert(args) => handlers::convert::handle(args)?,
-        Commands::Borsh(args) => handlers::borsh::handle(args)?,
-        Commands::Pda(args) => handlers::pda::handle(args)?,
+        Commands::Idl(args) => handlers::idl::handle(args, json)?,
+        Commands::Account(args) => handlers::account::handle(args, json)?,
+        Commands::Cache(args) => handlers::cache::handle(args, json)?,
+        Commands::Convert(args) => handlers::convert::handle(args, json)?,
+        Commands::Borsh(args) => handlers::borsh::handle(args, json)?,
+        Commands::Pda(args) => handlers::pda::handle(args, json)?,
         Commands::ProgramData(args) => handlers::program_elf::handle(args)?,
-        Commands::Send(args) => handlers::send::handle(args)?,
-        Commands::Config(args) => handlers::config::handle(args)?,
+        Commands::Send(args) => handlers::send::handle(args, json)?,
+        Commands::Config(args) => handlers::config::handle(args, json)?,
         Commands::Completions(args) => {
             handlers::completions::handle(args);
             return Ok(());

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -2,21 +2,22 @@ use anyhow::Result;
 
 use super::report::{BundleReport, Report};
 
-pub(super) fn render_json(report: &Report) -> Result<()> {
-    let json = serde_json::to_string_pretty(report)?;
+/// Pretty-print any serializable value as JSON to stdout.
+pub(crate) fn print_json<T: serde::Serialize + ?Sized>(value: &T) -> Result<()> {
+    let json = serde_json::to_string_pretty(value)?;
     println!("{json}");
     Ok(())
 }
 
+pub(super) fn render_json(report: &Report) -> Result<()> {
+    print_json(report)
+}
+
 pub(super) fn render_bundle_json(bundle: &BundleReport) -> Result<()> {
-    let json = serde_json::to_string_pretty(bundle)?;
-    println!("{json}");
-    Ok(())
+    print_json(bundle)
 }
 
 /// Render a slice of serializable values as a single JSON array.
 pub(super) fn render_json_array<T: serde::Serialize>(items: &[T]) -> Result<()> {
-    let json = serde_json::to_string_pretty(items)?;
-    println!("{json}");
-    Ok(())
+    print_json(items)
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod terminal;
 mod text;
 
 pub(crate) use account_text::render_account_text;
+pub(crate) use json::print_json;
 
 use anyhow::Result;
 

--- a/tests/e2e_cli_output_streams.rs
+++ b/tests/e2e_cli_output_streams.rs
@@ -1,4 +1,5 @@
 use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
 
 const VALID_PUBKEY: &str = "11111111111111111111111111111111";
 
@@ -622,5 +623,133 @@ fn cnofig_alias_is_rejected() {
     assert!(
         stderr.contains("unrecognized subcommand"),
         "expected clap unknown subcommand error, got: {stderr}"
+    );
+}
+
+// ─── Global --json flag e2e tests ───────────────────────────────────
+
+#[test]
+fn json_pda_returns_valid_json_with_expected_keys() {
+    let mut cmd = cargo_bin_cmd!("sonar");
+    cmd.arg("--json").arg("pda").arg(VALID_PUBKEY).arg("string:test");
+
+    let assert = cmd.assert().success();
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let json: Value = serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+    assert!(json.get("pda").and_then(|v| v.as_str()).is_some(), "expected 'pda' string key");
+    assert!(json.get("bump").and_then(|v| v.as_u64()).is_some(), "expected 'bump' integer key");
+    assert!(stderr.trim().is_empty(), "expected no stderr for --json pda, got: {stderr}");
+}
+
+#[test]
+fn json_convert_returns_valid_json_with_expected_keys() {
+    let mut cmd = cargo_bin_cmd!("sonar");
+    cmd.arg("--json").arg("convert").arg("hex").arg("text").arg("0x48656c6c6f");
+
+    let assert = cmd.assert().success();
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let json: Value = serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["output"], "Hello");
+    assert!(json.get("input").is_some(), "expected 'input' key");
+    assert!(json.get("from").is_some(), "expected 'from' key");
+    assert!(json.get("to").is_some(), "expected 'to' key");
+    assert!(stderr.trim().is_empty(), "expected no stderr for --json convert, got: {stderr}");
+}
+
+#[test]
+fn json_borsh_ser_returns_valid_json_with_hex_key() {
+    let mut cmd = cargo_bin_cmd!("sonar");
+    cmd.arg("--json").arg("borsh").arg("ser").arg("u8").arg("42");
+
+    let assert = cmd.assert().success();
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let json: Value = serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["hex"], "0x2a");
+    assert!(stderr.trim().is_empty(), "expected no stderr for --json borsh ser, got: {stderr}");
+}
+
+#[test]
+fn json_config_list_returns_valid_json_object() {
+    let mut cmd = cargo_bin_cmd!("sonar");
+    cmd.arg("--json").arg("config").arg("list");
+
+    let assert = cmd.assert().success();
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let json: Value = serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+    assert!(json.is_object(), "config list should return a JSON object");
+    assert!(json.get("rpc_url").is_some(), "config list should include rpc_url key");
+}
+
+#[test]
+fn json_config_get_returns_valid_json_with_key_value() {
+    let mut cmd = cargo_bin_cmd!("sonar");
+    cmd.arg("--json").arg("config").arg("get").arg("rpc_url");
+
+    let assert = cmd.assert().success();
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let json: Value = serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+    assert!(json.get("key").is_some(), "expected 'key' field");
+    assert!(json.get("value").is_some(), "expected 'value' field");
+}
+
+#[test]
+fn json_cache_list_returns_valid_json_array() {
+    let mut cmd = cargo_bin_cmd!("sonar");
+    cmd.arg("--json").arg("cache").arg("list");
+
+    let assert = cmd.assert().success();
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let json: Value = serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+    assert!(json.is_array(), "cache list should return a JSON array");
+    // If entries exist, check they have the expected shape
+    if let Some(first) = json.as_array().and_then(|a| a.first()) {
+        assert!(first.get("key").is_some(), "cache entry should have 'key' field");
+        assert!(first.get("cache_type").is_some(), "cache entry should have 'cache_type' field");
+    }
+    assert!(!stderr.contains('\x1b'), "stderr should not contain ANSI escape codes, got: {stderr}");
+}
+
+#[test]
+fn json_flag_after_subcommand_works() {
+    let mut cmd = cargo_bin_cmd!("sonar");
+    cmd.arg("pda").arg("--json").arg(VALID_PUBKEY).arg("string:test");
+
+    let assert = cmd.assert().success();
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let json: Value = serde_json::from_str(&stdout).expect("--json after subcommand should work");
+    assert!(json.get("pda").is_some());
+}
+
+#[test]
+fn json_flag_ignored_by_completions() {
+    let mut cmd = cargo_bin_cmd!("sonar");
+    cmd.arg("--json").arg("completions").arg("bash");
+
+    let assert = cmd.assert().success();
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // completions should produce shell script, not JSON
+    assert!(
+        stdout.contains("_sonar") || stdout.contains("complete"),
+        "completions should output shell script even with --json, got: {stdout}"
     );
 }


### PR DESCRIPTION
## Summary

- Adds `--json` / `-j` as a global flag on the top-level CLI, available to all data-producing subcommands
- Fixes stdout/stderr contract violations in cache and send handlers
- Adds typed JSON output for all 10 data-producing subcommands (pda, convert, borsh ser, cache list/info/clean, config list/get/set, send, idl fetch/sync/address)
- Existing `sonar simulate --json` and `sonar decode --json` behavior is unchanged

## Motivation

Agents calling sonar as a tool need machine-parseable output. Previously only 3 of 12 subcommands supported `--json`, each with an independent flag. This PR makes every data-producing subcommand uniformly parseable via a single global flag.

## Changes

**stdout/stderr contract fixes:**
- `cache list/info/clean`: moved primary data from `eprintln!` to `println!`
- `send`: signature is now the sole stdout output; explorer URL and wait status go to stderr

**Global `--json` flag:**
- Moved `--json` / `-j` from per-subcommand args to the `Cli` struct with `global = true`
- Removed duplicate flags from `TransactionInputArgs` and `AccountArgs`
- `completions` and `program-elf` silently ignore the flag

**JSON output per subcommand:**
- `pda`: `{"pda": "...", "bump": N}`
- `convert`: `{"input": "...", "output": "...", "from": "...", "to": "..."}`
- `borsh ser`: `{"hex": "0x..."}` (borsh de unchanged — already emits JSON)
- `cache list`: `[{"key": "...", "cache_type": "...", "account_count": N, ...}]`
- `cache info`: single object with full metadata + transactions
- `cache clean`: `{"removed": N}`
- `config list`: `{"key": "value", ...}` (sorted, null for unset)
- `config get`: `{"key": "...", "value": "..."}` (null for unset)
- `config set`: `{"key": "...", "value": "..."}`
- `send`: `{"signature": "...", "explorer_url": "..."}`
- `idl fetch/sync`: `[{"program": "...", "path": "...", "status": "ok|not_found|error"}]`
- `idl address`: `{"program": "...", "idl_address": "..."}`

## Breaking Changes

- `cache list/info/clean` output moved from stderr to stdout (was a bug — primary data should never have been on stderr)
- `send` text output changed: only signature on stdout; explorer URL moved to stderr
- Per-subcommand `--json` / `-j` flags on simulate/decode/account removed (global flag replaces them — `sonar simulate --json` still works via clap global flag forwarding)

## Test plan

- [x] 8 new e2e tests for JSON output (pda, convert, borsh ser, config list/get, cache list, flag position, completions ignore)
- [x] All 543 existing tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] Manual verification of all JSON outputs