### PR TITLE
refactor: deduplicate handler setup pipeline, account decoder, and cache iteration

### DIFF
--- a/src/handlers/account.rs
+++ b/src/handlers/account.rs
@@ -167,163 +167,30 @@ fn decode_account_output(
     account: &solana_account::Account,
     json: bool,
 ) -> Result<(Value, String, Option<Value>)> {
-    if *account_pubkey == solana_sdk_ids::sysvar::clock::id() {
-        if let Ok(clock) = bincode::deserialize::<solana_clock::Clock>(account.data.as_slice()) {
-            let data_json = if json {
-                serde_json::json!({
-                    "slot": clock.slot,
-                    "epoch": clock.epoch,
-                    "leaderScheduleEpoch": clock.leader_schedule_epoch,
-                    "unixTimestamp": clock.unix_timestamp,
-                    "epochStartTimestamp": clock.epoch_start_timestamp,
-                })
-            } else {
-                serde_json::json!({
-                    "slot": clock.slot,
-                    "epoch": clock.epoch,
-                    "leaderScheduleEpoch": clock.leader_schedule_epoch,
-                    "unixTimestamp": format_timestamp_with_utc(clock.unix_timestamp),
-                    "epochStartTimestamp": format_timestamp_with_utc(clock.epoch_start_timestamp),
-                })
-            };
-            return Ok((wrap_account_data_output(account, data_json), "Sysvar Clock".into(), None));
-        }
+    // Try each known account type in order; return on first match.
+    if let Some(result) = decode_clock_sysvar(account_pubkey, account, json) {
+        return Ok(result);
+    }
+    if let Some(result) = decode_rent_sysvar(account_pubkey, account) {
+        return Ok(result);
+    }
+    if let Some(result) = decode_epoch_schedule_sysvar(account_pubkey, account) {
+        return Ok(result);
+    }
+    if let Some(result) = decode_nonce_account(account) {
+        return Ok(result);
+    }
+    if let Some(result) = decode_bpf_upgradeable(account)? {
+        return Ok(result);
+    }
+    if let Some(result) = decode_address_lookup_table(account) {
+        return Ok(result);
+    }
+    if let Some(result) = decode_spl_token(client, account_pubkey, account) {
+        return Ok(result);
     }
 
-    if *account_pubkey == solana_sdk_ids::sysvar::rent::id() {
-        if let Ok(rent) = bincode::deserialize::<solana_rent::Rent>(account.data.as_slice()) {
-            let data_json = serde_json::json!({
-                "lamportsPerByteYear": rent.lamports_per_byte_year,
-                "exemptionThreshold": rent.exemption_threshold,
-                "burnPercent": rent.burn_percent,
-            });
-            return Ok((wrap_account_data_output(account, data_json), "Sysvar Rent".into(), None));
-        }
-    }
-
-    if *account_pubkey == solana_sdk_ids::sysvar::epoch_schedule::id() {
-        if let Ok(schedule) =
-            bincode::deserialize::<solana_epoch_schedule::EpochSchedule>(account.data.as_slice())
-        {
-            let data_json = serde_json::json!({
-                "slotsPerEpoch": schedule.slots_per_epoch,
-                "leaderScheduleSlotOffset": schedule.leader_schedule_slot_offset,
-                "warmup": schedule.warmup,
-                "firstNormalEpoch": schedule.first_normal_epoch,
-                "firstNormalSlot": schedule.first_normal_slot,
-            });
-            return Ok((
-                wrap_account_data_output(account, data_json),
-                "Sysvar Epoch Schedule".into(),
-                None,
-            ));
-        }
-    }
-
-    if account.owner == solana_sdk_ids::system_program::id() && account.data.len() == 80 {
-        if let Ok(versions) =
-            bincode::deserialize::<solana_nonce::versions::Versions>(account.data.as_slice())
-        {
-            if let solana_nonce::state::State::Initialized(data) = versions.state() {
-                let data_json = serde_json::json!({
-                    "authority": data.authority.to_string(),
-                    "blockhash": data.blockhash().to_string(),
-                    "lamportsPerSignature": data.fee_calculator.lamports_per_signature,
-                });
-                return Ok((
-                    wrap_account_data_output(account, data_json),
-                    "Nonce Account".into(),
-                    None,
-                ));
-            }
-        }
-    }
-
-    if account.owner == bpf_loader_upgradeable::id() {
-        if let Ok(state) = bincode::deserialize::<UpgradeableLoaderState>(account.data.as_slice()) {
-            match state {
-                UpgradeableLoaderState::Program { programdata_address } => {
-                    let programdata_pubkey = Pubkey::new_from_array(programdata_address.to_bytes());
-                    let data_json = serde_json::json!({
-                        "programdataAddress": programdata_pubkey.to_string()
-                    });
-                    return Ok((
-                        wrap_account_data_output(account, data_json),
-                        "BPF Upgradeable Program".into(),
-                        None,
-                    ));
-                }
-                UpgradeableLoaderState::ProgramData { .. } => {
-                    let data_json = build_programdata_json(account)?;
-                    return Ok((
-                        wrap_account_data_output(account, data_json),
-                        "Program Data".into(),
-                        None,
-                    ));
-                }
-                UpgradeableLoaderState::Buffer { authority_address, .. } => {
-                    const BUFFER_HEADER_SIZE: usize = 37;
-                    let data_size = account.data.len().saturating_sub(BUFFER_HEADER_SIZE);
-                    let data_json = serde_json::json!({
-                        "authority": authority_address
-                            .map(|a| Pubkey::new_from_array(a.to_bytes()).to_string()),
-                        "dataSize": data_size
-                    });
-                    return Ok((
-                        wrap_account_data_output(account, data_json),
-                        "Buffer".into(),
-                        None,
-                    ));
-                }
-                _ => {}
-            }
-        }
-    }
-
-    if account.owner == address_lookup_table::id() {
-        if let Ok(lookup_table) = AddressLookupTable::deserialize(account.data.as_slice()) {
-            let authority = lookup_table.meta.authority.map(|a| a.to_string());
-            let data_json = serde_json::json!({
-                "meta": {
-                    "deactivation_slot": lookup_table.meta.deactivation_slot,
-                    "last_extended_slot": lookup_table.meta.last_extended_slot,
-                    "last_extended_slot_start_index": lookup_table.meta.last_extended_slot_start_index,
-                    "authority": authority,
-                    "_padding": lookup_table.meta._padding,
-                },
-                "addresses": lookup_table.addresses.iter().map(|k| k.to_string()).collect::<Vec<_>>()
-            });
-            return Ok((
-                wrap_account_data_output(account, data_json),
-                "Address Lookup Table".into(),
-                None,
-            ));
-        }
-    }
-
-    if let Some(token_json) = token_account_decoder::decode_spl_token_account(account) {
-        let account_type = detect_token_type(account, &token_json);
-
-        let metadata_output = if should_enrich_with_metaplex_metadata(account, &token_json) {
-            match fetch_metadata_for_mint(client, account_pubkey) {
-                Ok((meta_account, decoded)) => {
-                    Some(wrap_account_data_output(&meta_account, decoded))
-                }
-                Err(error) => {
-                    log::warn!(
-                        "Metaplex metadata enrichment failed ({error}). \
-                         Showing mint account data only."
-                    );
-                    None
-                }
-            }
-        } else {
-            None
-        };
-
-        return Ok((token_json, account_type, metadata_output));
-    }
-
+    // IDL decode + fallback — depends on args and has complex fallback paths.
     let owner = account.owner;
     let idl_json = try_load_idl_from_dir(&args.idl_dir, &owner).or_else(|| {
         let fetcher = idl_fetcher::IdlFetcher::new(args.rpc.rpc_url.clone(), None).ok()?;
@@ -374,6 +241,208 @@ fn decode_account_output(
             Ok((json, "Unknown".into(), None))
         }
     }
+}
+
+/// Decode a Clock sysvar account. Only Clock needs `json` to toggle timestamp formatting.
+fn decode_clock_sysvar(
+    account_pubkey: &Pubkey,
+    account: &solana_account::Account,
+    json: bool,
+) -> Option<(Value, String, Option<Value>)> {
+    if *account_pubkey != solana_sdk_ids::sysvar::clock::id() {
+        return None;
+    }
+    let clock = bincode::deserialize::<solana_clock::Clock>(account.data.as_slice()).ok()?;
+    let data_json = if json {
+        serde_json::json!({
+            "slot": clock.slot,
+            "epoch": clock.epoch,
+            "leaderScheduleEpoch": clock.leader_schedule_epoch,
+            "unixTimestamp": clock.unix_timestamp,
+            "epochStartTimestamp": clock.epoch_start_timestamp,
+        })
+    } else {
+        serde_json::json!({
+            "slot": clock.slot,
+            "epoch": clock.epoch,
+            "leaderScheduleEpoch": clock.leader_schedule_epoch,
+            "unixTimestamp": format_timestamp_with_utc(clock.unix_timestamp),
+            "epochStartTimestamp": format_timestamp_with_utc(clock.epoch_start_timestamp),
+        })
+    };
+    Some((wrap_account_data_output(account, data_json), "Sysvar Clock".into(), None))
+}
+
+/// Decode a Rent sysvar account.
+fn decode_rent_sysvar(
+    account_pubkey: &Pubkey,
+    account: &solana_account::Account,
+) -> Option<(Value, String, Option<Value>)> {
+    if *account_pubkey != solana_sdk_ids::sysvar::rent::id() {
+        return None;
+    }
+    let rent = bincode::deserialize::<solana_rent::Rent>(account.data.as_slice()).ok()?;
+    let data_json = serde_json::json!({
+        "lamportsPerByteYear": rent.lamports_per_byte_year,
+        "exemptionThreshold": rent.exemption_threshold,
+        "burnPercent": rent.burn_percent,
+    });
+    Some((wrap_account_data_output(account, data_json), "Sysvar Rent".into(), None))
+}
+
+/// Decode an EpochSchedule sysvar account.
+fn decode_epoch_schedule_sysvar(
+    account_pubkey: &Pubkey,
+    account: &solana_account::Account,
+) -> Option<(Value, String, Option<Value>)> {
+    if *account_pubkey != solana_sdk_ids::sysvar::epoch_schedule::id() {
+        return None;
+    }
+    let schedule =
+        bincode::deserialize::<solana_epoch_schedule::EpochSchedule>(account.data.as_slice())
+            .ok()?;
+    let data_json = serde_json::json!({
+        "slotsPerEpoch": schedule.slots_per_epoch,
+        "leaderScheduleSlotOffset": schedule.leader_schedule_slot_offset,
+        "warmup": schedule.warmup,
+        "firstNormalEpoch": schedule.first_normal_epoch,
+        "firstNormalSlot": schedule.first_normal_slot,
+    });
+    Some((
+        wrap_account_data_output(account, data_json),
+        "Sysvar Epoch Schedule".into(),
+        None,
+    ))
+}
+
+/// Decode a Nonce account (system program, 80-byte data).
+fn decode_nonce_account(
+    account: &solana_account::Account,
+) -> Option<(Value, String, Option<Value>)> {
+    if account.owner != solana_sdk_ids::system_program::id() || account.data.len() != 80 {
+        return None;
+    }
+    let versions =
+        bincode::deserialize::<solana_nonce::versions::Versions>(account.data.as_slice()).ok()?;
+    if let solana_nonce::state::State::Initialized(data) = versions.state() {
+        let data_json = serde_json::json!({
+            "authority": data.authority.to_string(),
+            "blockhash": data.blockhash().to_string(),
+            "lamportsPerSignature": data.fee_calculator.lamports_per_signature,
+        });
+        Some((
+            wrap_account_data_output(account, data_json),
+            "Nonce Account".into(),
+            None,
+        ))
+    } else {
+        None
+    }
+}
+
+/// Decode a BPF Upgradeable Loader account (Program, ProgramData, or Buffer).
+fn decode_bpf_upgradeable(
+    account: &solana_account::Account,
+) -> Result<Option<(Value, String, Option<Value>)>> {
+    if account.owner != bpf_loader_upgradeable::id() {
+        return Ok(None);
+    }
+    let state = match bincode::deserialize::<UpgradeableLoaderState>(account.data.as_slice()) {
+        Ok(s) => s,
+        Err(_) => return Ok(None),
+    };
+    match state {
+        UpgradeableLoaderState::Program { programdata_address } => {
+            let programdata_pubkey = Pubkey::new_from_array(programdata_address.to_bytes());
+            let data_json = serde_json::json!({
+                "programdataAddress": programdata_pubkey.to_string()
+            });
+            Ok(Some((
+                wrap_account_data_output(account, data_json),
+                "BPF Upgradeable Program".into(),
+                None,
+            )))
+        }
+        UpgradeableLoaderState::ProgramData { .. } => {
+            let data_json = build_programdata_json(account)?;
+            Ok(Some((
+                wrap_account_data_output(account, data_json),
+                "Program Data".into(),
+                None,
+            )))
+        }
+        UpgradeableLoaderState::Buffer { authority_address, .. } => {
+            const BUFFER_HEADER_SIZE: usize = 37;
+            let data_size = account.data.len().saturating_sub(BUFFER_HEADER_SIZE);
+            let data_json = serde_json::json!({
+                "authority": authority_address
+                    .map(|a| Pubkey::new_from_array(a.to_bytes()).to_string()),
+                "dataSize": data_size
+            });
+            Ok(Some((
+                wrap_account_data_output(account, data_json),
+                "Buffer".into(),
+                None,
+            )))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Decode an Address Lookup Table account.
+fn decode_address_lookup_table(
+    account: &solana_account::Account,
+) -> Option<(Value, String, Option<Value>)> {
+    if account.owner != address_lookup_table::id() {
+        return None;
+    }
+    let lookup_table = AddressLookupTable::deserialize(account.data.as_slice()).ok()?;
+    let authority = lookup_table.meta.authority.map(|a| a.to_string());
+    let data_json = serde_json::json!({
+        "meta": {
+            "deactivation_slot": lookup_table.meta.deactivation_slot,
+            "last_extended_slot": lookup_table.meta.last_extended_slot,
+            "last_extended_slot_start_index": lookup_table.meta.last_extended_slot_start_index,
+            "authority": authority,
+            "_padding": lookup_table.meta._padding,
+        },
+        "addresses": lookup_table.addresses.iter().map(|k| k.to_string()).collect::<Vec<_>>()
+    });
+    Some((
+        wrap_account_data_output(account, data_json),
+        "Address Lookup Table".into(),
+        None,
+    ))
+}
+
+/// Decode an SPL Token or Token-2022 account. Returns `token_json` directly
+/// (not wrapped through `wrap_account_data_output`), with optional Metaplex metadata.
+fn decode_spl_token(
+    client: &RpcClient,
+    account_pubkey: &Pubkey,
+    account: &solana_account::Account,
+) -> Option<(Value, String, Option<Value>)> {
+    let token_json = token_account_decoder::decode_spl_token_account(account)?;
+    let account_type = detect_token_type(account, &token_json);
+
+    let metadata_output = if should_enrich_with_metaplex_metadata(account, &token_json) {
+        match fetch_metadata_for_mint(client, account_pubkey) {
+            Ok((meta_account, decoded)) => {
+                Some(wrap_account_data_output(&meta_account, decoded))
+            }
+            Err(error) => {
+                log::warn!(
+                    "Metaplex metadata enrichment failed ({error}). \
+                     Showing mint account data only."
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    Some((token_json, account_type, metadata_output))
 }
 
 fn detect_token_type(account: &solana_account::Account, token_json: &Value) -> String {

--- a/src/handlers/account.rs
+++ b/src/handlers/account.rs
@@ -308,11 +308,7 @@ fn decode_epoch_schedule_sysvar(
         "firstNormalEpoch": schedule.first_normal_epoch,
         "firstNormalSlot": schedule.first_normal_slot,
     });
-    Some((
-        wrap_account_data_output(account, data_json),
-        "Sysvar Epoch Schedule".into(),
-        None,
-    ))
+    Some((wrap_account_data_output(account, data_json), "Sysvar Epoch Schedule".into(), None))
 }
 
 /// Decode a Nonce account (system program, 80-byte data).
@@ -330,11 +326,7 @@ fn decode_nonce_account(
             "blockhash": data.blockhash().to_string(),
             "lamportsPerSignature": data.fee_calculator.lamports_per_signature,
         });
-        Some((
-            wrap_account_data_output(account, data_json),
-            "Nonce Account".into(),
-            None,
-        ))
+        Some((wrap_account_data_output(account, data_json), "Nonce Account".into(), None))
     } else {
         None
     }
@@ -365,11 +357,7 @@ fn decode_bpf_upgradeable(
         }
         UpgradeableLoaderState::ProgramData { .. } => {
             let data_json = build_programdata_json(account)?;
-            Ok(Some((
-                wrap_account_data_output(account, data_json),
-                "Program Data".into(),
-                None,
-            )))
+            Ok(Some((wrap_account_data_output(account, data_json), "Program Data".into(), None)))
         }
         UpgradeableLoaderState::Buffer { authority_address, .. } => {
             const BUFFER_HEADER_SIZE: usize = 37;
@@ -379,11 +367,7 @@ fn decode_bpf_upgradeable(
                     .map(|a| Pubkey::new_from_array(a.to_bytes()).to_string()),
                 "dataSize": data_size
             });
-            Ok(Some((
-                wrap_account_data_output(account, data_json),
-                "Buffer".into(),
-                None,
-            )))
+            Ok(Some((wrap_account_data_output(account, data_json), "Buffer".into(), None)))
         }
         _ => Ok(None),
     }
@@ -408,11 +392,7 @@ fn decode_address_lookup_table(
         },
         "addresses": lookup_table.addresses.iter().map(|k| k.to_string()).collect::<Vec<_>>()
     });
-    Some((
-        wrap_account_data_output(account, data_json),
-        "Address Lookup Table".into(),
-        None,
-    ))
+    Some((wrap_account_data_output(account, data_json), "Address Lookup Table".into(), None))
 }
 
 /// Decode an SPL Token or Token-2022 account. Returns `token_json` directly
@@ -427,9 +407,7 @@ fn decode_spl_token(
 
     let metadata_output = if should_enrich_with_metaplex_metadata(account, &token_json) {
         match fetch_metadata_for_mint(client, account_pubkey) {
-            Ok((meta_account, decoded)) => {
-                Some(wrap_account_data_output(&meta_account, decoded))
-            }
+            Ok((meta_account, decoded)) => Some(wrap_account_data_output(&meta_account, decoded)),
             Err(error) => {
                 log::warn!(
                     "Metaplex metadata enrichment failed ({error}). \

--- a/src/handlers/cache.rs
+++ b/src/handlers/cache.rs
@@ -1,9 +1,12 @@
+use std::path::{Path, PathBuf};
+
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde::Serialize;
 
 use crate::cli::{CacheArgs, CacheCommands};
 use crate::core::cache;
+use crate::core::cache::CacheMeta;
 
 #[derive(Serialize)]
 struct CacheListEntry {
@@ -47,6 +50,36 @@ struct CacheCleanOutput {
     removed: usize,
 }
 
+struct CacheEntry {
+    path: PathBuf,
+    key: String,
+    meta: Option<CacheMeta>,
+}
+
+/// Reads the cache root directory, filters to directories, sorts by name,
+/// and reads `_meta.json` for each entry (storing `None` on failure).
+fn list_cache_entries(cache_root: &Path) -> Result<Vec<CacheEntry>> {
+    let mut dir_entries: Vec<_> = std::fs::read_dir(cache_root)
+        .with_context(|| format!("Failed to read cache directory: {}", cache_root.display()))?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .collect();
+
+    dir_entries.sort_by_key(|e| e.file_name());
+
+    let entries = dir_entries
+        .into_iter()
+        .map(|e| {
+            let path = e.path();
+            let key = e.file_name().to_string_lossy().to_string();
+            let meta = cache::read_meta_json(&path).ok();
+            CacheEntry { path, key, meta }
+        })
+        .collect();
+
+    Ok(entries)
+}
+
 pub(crate) fn handle(args: CacheArgs, json: bool) -> Result<()> {
     match args.command {
         CacheCommands::List => handle_list(json),
@@ -66,11 +99,7 @@ fn handle_list(json: bool) -> Result<()> {
         return Ok(());
     }
 
-    let mut entries: Vec<_> = std::fs::read_dir(&cache_root)
-        .with_context(|| format!("Failed to read cache directory: {}", cache_root.display()))?
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().is_dir())
-        .collect();
+    let entries = list_cache_entries(&cache_root)?;
 
     if entries.is_empty() {
         if json {
@@ -81,37 +110,31 @@ fn handle_list(json: bool) -> Result<()> {
         return Ok(());
     }
 
-    entries.sort_by_key(|e| e.file_name());
-
     if json {
         let list: Vec<CacheListEntry> = entries
             .iter()
-            .map(|entry| {
-                let dir = entry.path();
-                let key = entry.file_name().to_string_lossy().to_string();
-                match cache::read_meta_json(&dir) {
-                    Ok(meta) => CacheListEntry {
-                        key,
-                        cache_type: Some(meta.cache_type),
-                        account_count: Some(meta.account_count),
-                        created_at: Some(meta.created_at),
-                        rpc_url: Some(meta.rpc_url),
-                        sonar_version: Some(meta.sonar_version),
-                        file_count: None,
-                    },
-                    Err(_) => {
-                        let fc = std::fs::read_dir(&dir)
-                            .map(|rd| rd.filter_map(|e| e.ok()).count())
-                            .unwrap_or(0);
-                        CacheListEntry {
-                            key,
-                            cache_type: None,
-                            account_count: None,
-                            created_at: None,
-                            rpc_url: None,
-                            sonar_version: None,
-                            file_count: Some(fc),
-                        }
+            .map(|entry| match &entry.meta {
+                Some(meta) => CacheListEntry {
+                    key: entry.key.clone(),
+                    cache_type: Some(meta.cache_type.clone()),
+                    account_count: Some(meta.account_count),
+                    created_at: Some(meta.created_at.clone()),
+                    rpc_url: Some(meta.rpc_url.clone()),
+                    sonar_version: Some(meta.sonar_version.clone()),
+                    file_count: None,
+                },
+                None => {
+                    let fc = std::fs::read_dir(&entry.path)
+                        .map(|rd| rd.filter_map(|e| e.ok()).count())
+                        .unwrap_or(0);
+                    CacheListEntry {
+                        key: entry.key.clone(),
+                        cache_type: None,
+                        account_count: None,
+                        created_at: None,
+                        rpc_url: None,
+                        sonar_version: None,
+                        file_count: Some(fc),
                     }
                 }
             })
@@ -121,10 +144,8 @@ fn handle_list(json: bool) -> Result<()> {
         println!("{} ({}):\n", "Cached entries".bold(), cache_root.display());
 
         for entry in &entries {
-            let dir = entry.path();
-            let key = entry.file_name().to_string_lossy().to_string();
-            match cache::read_meta_json(&dir) {
-                Ok(meta) => {
+            match &entry.meta {
+                Some(meta) => {
                     let type_label = if meta.cache_type == "bundle" {
                         format!("bundle, {} txs", meta.transactions.len())
                     } else {
@@ -132,17 +153,17 @@ fn handle_list(json: bool) -> Result<()> {
                     };
                     println!(
                         "  {} — {} accounts, {} ({})",
-                        key.cyan(),
+                        entry.key.cyan(),
                         meta.account_count,
                         type_label,
                         meta.created_at,
                     );
                 }
-                Err(_) => {
-                    let file_count = std::fs::read_dir(&dir)
+                None => {
+                    let file_count = std::fs::read_dir(&entry.path)
                         .map(|rd| rd.filter_map(|e| e.ok()).count())
                         .unwrap_or(0);
-                    println!("  {} — {} files (no metadata)", key.yellow(), file_count,);
+                    println!("  {} — {} files (no metadata)", entry.key.yellow(), file_count,);
                 }
             }
         }
@@ -180,18 +201,12 @@ fn handle_clean(args: crate::cli::CacheCleanArgs, json: bool) -> Result<()> {
         None => None,
     };
 
-    let entries: Vec<_> = std::fs::read_dir(&cache_root)
-        .with_context(|| format!("Failed to read cache directory: {}", cache_root.display()))?
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().is_dir())
-        .collect();
+    let entries = list_cache_entries(&cache_root)?;
 
     let mut removed = 0usize;
     for entry in &entries {
-        let dir = entry.path();
-
         if let Some(max_age_days) = min_age_days {
-            if let Ok(meta) = cache::read_meta_json(&dir) {
+            if let Some(meta) = &entry.meta {
                 if let Ok(created) = chrono::DateTime::parse_from_rfc3339(&meta.created_at) {
                     let age = chrono::Utc::now().signed_duration_since(created);
                     if age.num_days() < max_age_days as i64 {
@@ -201,8 +216,8 @@ fn handle_clean(args: crate::cli::CacheCleanArgs, json: bool) -> Result<()> {
             }
         }
 
-        std::fs::remove_dir_all(&dir)
-            .with_context(|| format!("Failed to remove cache entry: {}", dir.display()))?;
+        std::fs::remove_dir_all(&entry.path)
+            .with_context(|| format!("Failed to remove cache entry: {}", entry.path.display()))?;
         removed += 1;
     }
 

--- a/src/handlers/common.rs
+++ b/src/handlers/common.rs
@@ -27,6 +27,33 @@ pub(crate) struct PreparedPipelineContext {
     pub resolved_accounts: ResolvedAccounts,
 }
 
+/// Result of resolving transaction inputs and deriving a cache key.
+/// This is the first half of the shared setup pipeline, before any
+/// simulate-specific mutations.
+pub(crate) struct ResolvedWithCacheKey {
+    pub resolved_txs: Vec<transaction::ResolvedTxInput>,
+    pub cache_key: String,
+}
+
+/// Common cache and prepare arguments shared by simulate and decode handlers.
+/// Simulate computes `cache_enabled` as `(cache || cache_dir.is_some() || refresh_cache)` (opt-in);
+/// decode computes it as `(!no_cache)` (opt-out).
+pub(crate) struct CachePrepareArgs<'a> {
+    pub rpc_url: &'a str,
+    pub cache_enabled: bool,
+    pub cache_dir: &'a Option<PathBuf>,
+    pub refresh_cache: bool,
+    pub no_idl_fetch: bool,
+}
+
+/// Result of resolving cache state and preparing accounts/IDLs.
+/// This is the second half of the shared setup pipeline.
+pub(crate) struct CachePreparedContext {
+    pub cache_dir: Option<PathBuf>,
+    pub offline: bool,
+    pub prepared: PreparedPipelineContext,
+}
+
 // ---------------------------------------------------------------------------
 // Cache helpers
 // ---------------------------------------------------------------------------
@@ -72,6 +99,70 @@ pub(crate) fn resolve_inputs_to_txs(
     let raw_input = transaction::read_raw_transaction(tx_single)?;
     let resolved_txs = resolver.resolve_many(&[raw_input], Some(progress))?;
     Ok(ResolvedInputTransactions { resolved_txs })
+}
+
+// ---------------------------------------------------------------------------
+// Shared setup pipeline
+// ---------------------------------------------------------------------------
+
+/// Resolves transaction inputs and derives a cache key. This is the first phase
+/// of the shared handler setup — call this before any simulate-specific mutations,
+/// then call [`resolve_cache_and_prepare`] after mutations are applied.
+pub(crate) fn resolve_and_derive_cache_key(
+    tx_inputs: Vec<String>,
+    rpc_url: &str,
+    resolver_cache_location: Option<CacheLocation>,
+    progress: &Progress,
+) -> Result<ResolvedWithCacheKey> {
+    let is_bundle = tx_inputs.len() > 1;
+    let parsed_inputs =
+        resolve_inputs_to_txs(tx_inputs, rpc_url, resolver_cache_location, progress, is_bundle)?;
+    let resolved_txs = parsed_inputs.resolved_txs;
+
+    let cache_key = if resolved_txs.len() == 1 {
+        crate::core::cache::derive_cache_key_single(
+            &resolved_txs[0].original_input,
+            &resolved_txs[0].parsed_tx.transaction,
+        )
+    } else {
+        let inputs: Vec<_> = resolved_txs.iter().map(|tx| tx.original_input.clone()).collect();
+        let parsed_txs: Vec<_> =
+            resolved_txs.iter().map(|tx| tx.parsed_tx.clone()).collect();
+        crate::core::cache::derive_cache_key_bundle(&inputs, &parsed_txs)
+    };
+
+    Ok(ResolvedWithCacheKey { resolved_txs, cache_key })
+}
+
+/// Resolves cache state and prepares accounts/IDLs. This is the second phase of
+/// the shared handler setup — called after any simulate-specific mutations have
+/// been applied to the parsed transactions.
+pub(crate) fn resolve_cache_and_prepare(
+    args: &CachePrepareArgs,
+    cache_key: &str,
+    parsed_txs: &[transaction::ParsedTransaction],
+    parser_registry: &mut ParserRegistry,
+    progress: &Progress,
+) -> Result<CachePreparedContext> {
+    let (resolved_cache_dir, offline) = crate::core::cache::resolve_cache_state(
+        args.cache_enabled,
+        args.cache_dir,
+        args.refresh_cache,
+        cache_key,
+    );
+    let cache_read_dir_for_load = cache_read_dir(resolved_cache_dir.clone(), args.refresh_cache);
+
+    let prepared = prepare_accounts_and_idls(
+        args.rpc_url,
+        cache_read_dir_for_load,
+        offline,
+        parsed_txs,
+        parser_registry,
+        args.no_idl_fetch,
+        progress,
+    )?;
+
+    Ok(CachePreparedContext { cache_dir: resolved_cache_dir, offline, prepared })
 }
 
 // ---------------------------------------------------------------------------

--- a/src/handlers/common.rs
+++ b/src/handlers/common.rs
@@ -126,8 +126,7 @@ pub(crate) fn resolve_and_derive_cache_key(
         )
     } else {
         let inputs: Vec<_> = resolved_txs.iter().map(|tx| tx.original_input.clone()).collect();
-        let parsed_txs: Vec<_> =
-            resolved_txs.iter().map(|tx| tx.parsed_tx.clone()).collect();
+        let parsed_txs: Vec<_> = resolved_txs.iter().map(|tx| tx.parsed_tx.clone()).collect();
         crate::core::cache::derive_cache_key_bundle(&inputs, &parsed_txs)
     };
 

--- a/src/handlers/decode.rs
+++ b/src/handlers/decode.rs
@@ -5,9 +5,7 @@ use crate::output;
 use crate::parsers::instruction::ParserRegistry;
 use crate::utils::progress::Progress;
 
-use super::common::{
-    resolve_and_derive_cache_key, resolve_cache_and_prepare, CachePrepareArgs,
-};
+use super::common::{CachePrepareArgs, resolve_and_derive_cache_key, resolve_cache_and_prepare};
 
 pub(crate) fn handle(args: DecodeArgs, json: bool) -> Result<()> {
     let idl_dir = args.idl_dir.clone();

--- a/src/handlers/decode.rs
+++ b/src/handlers/decode.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use anyhow::Result;
 
 use crate::cli::{DecodeArgs, TransactionInputArgs};
@@ -7,7 +5,9 @@ use crate::output;
 use crate::parsers::instruction::ParserRegistry;
 use crate::utils::progress::Progress;
 
-use super::common::{cache_read_dir, prepare_accounts_and_idls, resolve_inputs_to_txs};
+use super::common::{
+    resolve_and_derive_cache_key, resolve_cache_and_prepare, CachePrepareArgs,
+};
 
 pub(crate) fn handle(args: DecodeArgs, json: bool) -> Result<()> {
     let idl_dir = args.idl_dir.clone();
@@ -29,119 +29,57 @@ pub(crate) fn handle(args: DecodeArgs, json: bool) -> Result<()> {
         if refresh_cache { None } else { Some(super::common::build_cache_location(&cache_dir)) };
     let TransactionInputArgs { tx } = transaction;
 
-    // Check if this is a bundle (multiple positional TX arguments)
-    if tx.len() > 1 {
-        return handle_bundle(
-            tx,
-            &rpc_url,
-            resolver_cache_location,
-            !no_cache,
-            cache_dir,
-            refresh_cache,
-            ix_data,
-            json,
-            no_idl_fetch,
-            &mut parser_registry,
-            &progress,
-        );
-    }
+    let resolved = resolve_and_derive_cache_key(tx, &rpc_url, resolver_cache_location, &progress)?;
+    let is_bundle = resolved.resolved_txs.len() > 1;
+    let parsed_txs: Vec<_> =
+        resolved.resolved_txs.into_iter().map(|entry| entry.parsed_tx).collect();
 
-    let parsed_inputs =
-        resolve_inputs_to_txs(tx, &rpc_url, resolver_cache_location, &progress, false)?;
-    let resolved_tx = parsed_inputs
-        .resolved_txs
-        .into_iter()
-        .next()
-        .expect("single input resolve should produce one transaction");
-    let original_input = resolved_tx.original_input;
-    let parsed_tx = resolved_tx.parsed_tx;
-    let cache_key =
-        crate::core::cache::derive_cache_key_single(&original_input, &parsed_tx.transaction);
-    let (decode_cache_dir, offline) =
-        crate::core::cache::resolve_cache_state(!no_cache, &cache_dir, refresh_cache, &cache_key);
-    let cache_read_dir_for_load = cache_read_dir(decode_cache_dir, refresh_cache);
-
-    let prepared = prepare_accounts_and_idls(
-        &rpc_url,
-        cache_read_dir_for_load,
-        offline,
-        std::slice::from_ref(&parsed_tx),
-        &mut parser_registry,
+    let cache_args = CachePrepareArgs {
+        rpc_url: &rpc_url,
+        cache_enabled: !no_cache,
+        cache_dir: &cache_dir,
+        refresh_cache,
         no_idl_fetch,
+    };
+    let cached = resolve_cache_and_prepare(
+        &cache_args,
+        &resolved.cache_key,
+        &parsed_txs,
+        &mut parser_registry,
         &progress,
     )?;
 
     progress.finish();
-    output::render_transaction_only(
-        &parsed_tx,
-        &prepared.resolved_accounts,
-        &mut parser_registry,
-        json,
-        ix_data,
-        None,
-    )?;
 
-    Ok(())
-}
-
-/// Handle bundle decode (multiple transactions decoded without simulation).
-#[allow(clippy::too_many_arguments)]
-fn handle_bundle(
-    tx_inputs: Vec<String>,
-    rpc_url: &str,
-    resolver_cache_location: Option<crate::core::cache::CacheLocation>,
-    cache: bool,
-    cache_dir: Option<PathBuf>,
-    refresh_cache: bool,
-    ix_data: bool,
-    json: bool,
-    no_idl_fetch: bool,
-    parser_registry: &mut ParserRegistry,
-    progress: &Progress,
-) -> Result<()> {
-    log::info!("Bundle decode mode: {} transactions", tx_inputs.len());
-
-    let parsed_inputs =
-        resolve_inputs_to_txs(tx_inputs, rpc_url, resolver_cache_location, progress, true)?;
-    let resolved_txs = parsed_inputs.resolved_txs;
-    let raw_inputs: Vec<_> =
-        resolved_txs.iter().map(|entry| entry.original_input.clone()).collect();
-    let parsed_txs: Vec<_> = resolved_txs.into_iter().map(|entry| entry.parsed_tx).collect();
-    let cache_key = crate::core::cache::derive_cache_key_bundle(&raw_inputs, &parsed_txs);
-    let (decode_cache_dir, offline) =
-        crate::core::cache::resolve_cache_state(cache, &cache_dir, refresh_cache, &cache_key);
-    let cache_read_dir_for_load = cache_read_dir(decode_cache_dir, refresh_cache);
-    log::info!("Successfully parsed {} transactions", parsed_txs.len());
-
-    let prepared = prepare_accounts_and_idls(
-        rpc_url,
-        cache_read_dir_for_load,
-        offline,
-        &parsed_txs,
-        parser_registry,
-        no_idl_fetch,
-        progress,
-    )?;
-
-    progress.finish();
-
-    if json {
-        output::render_decode_bundle_json(
-            &parsed_txs,
-            &prepared.resolved_accounts,
-            parser_registry,
-        )?;
-    } else {
-        for (i, parsed_tx) in parsed_txs.iter().enumerate() {
-            output::render_transaction_only(
-                parsed_tx,
-                &prepared.resolved_accounts,
-                parser_registry,
-                false,
-                ix_data,
-                Some((i + 1, parsed_txs.len())),
+    if is_bundle {
+        log::info!("Bundle decode mode: {} transactions", parsed_txs.len());
+        if json {
+            output::render_decode_bundle_json(
+                &parsed_txs,
+                &cached.prepared.resolved_accounts,
+                &mut parser_registry,
             )?;
+        } else {
+            for (i, parsed_tx) in parsed_txs.iter().enumerate() {
+                output::render_transaction_only(
+                    parsed_tx,
+                    &cached.prepared.resolved_accounts,
+                    &mut parser_registry,
+                    false,
+                    ix_data,
+                    Some((i + 1, parsed_txs.len())),
+                )?;
+            }
         }
+    } else {
+        output::render_transaction_only(
+            &parsed_txs[0],
+            &cached.prepared.resolved_accounts,
+            &mut parser_registry,
+            json,
+            ix_data,
+            None,
+        )?;
     }
 
     Ok(())

--- a/src/handlers/simulate.rs
+++ b/src/handlers/simulate.rs
@@ -13,8 +13,8 @@ use sonar_sim::{
 };
 
 use super::common::{
-    build_cache_location, cache_read_dir, prepare_accounts_and_idls, resolve_inputs_to_txs,
-    warn_unmatched_addresses,
+    build_cache_location, resolve_and_derive_cache_key, resolve_cache_and_prepare,
+    warn_unmatched_addresses, CachePrepareArgs,
 };
 
 /// Parse a vector of raw CLI strings using the given parser function.
@@ -149,9 +149,8 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
         );
     }
 
-    let parsed_inputs =
-        resolve_inputs_to_txs(tx, &rpc_url, resolver_cache_location, &progress, false)?;
-    let resolved_input = parsed_inputs
+    let resolved = resolve_and_derive_cache_key(tx, &rpc_url, resolver_cache_location, &progress)?;
+    let resolved_input = resolved
         .resolved_txs
         .into_iter()
         .next()
@@ -161,22 +160,25 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
     let resolved_from = resolved_input.source.as_str().to_string();
     let mut parsed_tx = resolved_input.parsed_tx;
 
-    let cache_key = crate::core::cache::derive_cache_key_single(&raw_input, &parsed_tx.transaction);
-
     apply_ix_mutations(&mut parsed_tx, &ix_account_patches, &ix_account_appends, &ix_data_patches)?;
-    let (tx_cache_dir, offline) =
-        crate::core::cache::resolve_cache_state(cache, &cache_dir, refresh_cache, &cache_key);
-    let cache_read_dir_for_load = cache_read_dir(tx_cache_dir.clone(), refresh_cache);
 
-    let mut prepared = prepare_accounts_and_idls(
-        &rpc_url,
-        cache_read_dir_for_load,
-        offline,
+    let cache_args = CachePrepareArgs {
+        rpc_url: &rpc_url,
+        cache_enabled: cache,
+        cache_dir: &cache_dir,
+        refresh_cache,
+        no_idl_fetch,
+    };
+    let cached = resolve_cache_and_prepare(
+        &cache_args,
+        &resolved.cache_key,
         std::slice::from_ref(&parsed_tx),
         &mut parser_registry,
-        no_idl_fetch,
         &progress,
     )?;
+    let tx_cache_dir = cached.cache_dir;
+    let offline = cached.offline;
+    let mut prepared = cached.prepared;
 
     warn_unmatched_addresses(
         &overrides,
@@ -287,32 +289,32 @@ fn handle_bundle(
 ) -> Result<()> {
     log::info!("Bundle simulation mode: {} transactions", tx_inputs.len());
 
-    let parsed_inputs =
-        resolve_inputs_to_txs(tx_inputs, rpc_url, resolver_cache_location, progress, true)?;
-    let resolved_txs = parsed_inputs.resolved_txs;
-    let tx_inputs: Vec<_> = resolved_txs.iter().map(|tx| tx.original_input.clone()).collect();
+    let resolved = resolve_and_derive_cache_key(tx_inputs, rpc_url, resolver_cache_location, progress)?;
+    let resolved_txs = resolved.resolved_txs;
     let mut parsed_txs: Vec<_> = resolved_txs.iter().map(|tx| tx.parsed_tx.clone()).collect();
     log::info!("Successfully parsed {} transactions", parsed_txs.len());
-
-    let cache_key = crate::core::cache::derive_cache_key_bundle(&tx_inputs, &parsed_txs);
 
     for parsed_tx in &mut parsed_txs {
         apply_ix_mutations(parsed_tx, &ix_account_patches, &ix_account_appends, &ix_data_patches)?;
     }
-    let (bundle_cache_dir, offline) =
-        crate::core::cache::resolve_cache_state(cache, &cache_dir, refresh_cache, &cache_key);
-    let cache_read_dir_for_load = cache_read_dir(bundle_cache_dir.clone(), refresh_cache);
 
-    let tx_refs: Vec<_> = parsed_txs.iter().map(|p| &p.transaction).collect();
-    let mut prepared = prepare_accounts_and_idls(
+    let cache_args = CachePrepareArgs {
         rpc_url,
-        cache_read_dir_for_load,
-        offline,
+        cache_enabled: cache,
+        cache_dir: &cache_dir,
+        refresh_cache,
+        no_idl_fetch,
+    };
+    let cached = resolve_cache_and_prepare(
+        &cache_args,
+        &resolved.cache_key,
         &parsed_txs,
         parser_registry,
-        no_idl_fetch,
         progress,
     )?;
+    let bundle_cache_dir = cached.cache_dir;
+    let offline = cached.offline;
+    let mut prepared = cached.prepared;
 
     let parsed_tx_refs: Vec<_> = parsed_txs.iter().collect();
     warn_unmatched_addresses(
@@ -376,6 +378,7 @@ fn handle_bundle(
     let mut runner =
         PreparedSimulation::prepare(prepared.resolved_accounts, sim_opts)?.into_runner();
 
+    let tx_refs: Vec<_> = parsed_txs.iter().map(|p| &p.transaction).collect();
     let bundle_results = runner.execute_bundle(&tx_refs);
     let simulations: Vec<_> = bundle_results
         .into_iter()

--- a/src/handlers/simulate.rs
+++ b/src/handlers/simulate.rs
@@ -13,8 +13,8 @@ use sonar_sim::{
 };
 
 use super::common::{
-    build_cache_location, resolve_and_derive_cache_key, resolve_cache_and_prepare,
-    warn_unmatched_addresses, CachePrepareArgs,
+    CachePrepareArgs, build_cache_location, resolve_and_derive_cache_key,
+    resolve_cache_and_prepare, warn_unmatched_addresses,
 };
 
 /// Parse a vector of raw CLI strings using the given parser function.
@@ -289,7 +289,8 @@ fn handle_bundle(
 ) -> Result<()> {
     log::info!("Bundle simulation mode: {} transactions", tx_inputs.len());
 
-    let resolved = resolve_and_derive_cache_key(tx_inputs, rpc_url, resolver_cache_location, progress)?;
+    let resolved =
+        resolve_and_derive_cache_key(tx_inputs, rpc_url, resolver_cache_location, progress)?;
     let resolved_txs = resolved.resolved_txs;
     let mut parsed_txs: Vec<_> = resolved_txs.iter().map(|tx| tx.parsed_tx.clone()).collect();
     log::info!("Successfully parsed {} transactions", parsed_txs.len());


### PR DESCRIPTION
## Summary

- Extract shared resolve-cache-prepare pipeline into two reusable functions in `common.rs` (`resolve_and_derive_cache_key` + `resolve_cache_and_prepare`), eliminating 4-way duplication across simulate/decode single/bundle paths
- Break up 215-line `decode_account_output` into 7 named helper functions with a 29-line dispatcher
- Extract shared `list_cache_entries()` helper for cache directory iteration, used by `handle_list` and `handle_clean`

## Key decisions

- **Two-phase pipeline split**: The shared setup is split into resolve+cache-key (phase 1) and cache-state+prepare (phase 2) so that `simulate.rs` can inject `apply_ix_mutations` between them — mutations must run after cache key derivation but before account loading
- **Account decoder: helper functions, not registry**: 7 stable branches don't warrant a trait-based registry. Each helper returns `Option<...>` for fallthrough dispatch
- **Cache: `Vec<CacheEntry>`, not lazy iterator**: Cache entry count is always small; a collected Vec is simpler

## Test plan

- [x] `cargo test` — 540 unit + 27 integration tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Output is byte-identical (behavior-preserving refactoring verified by existing test suite)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — pure internal refactoring with no behavioral or output changes.