### PR TITLE
fix: label anchor cpi events with event authority

### DIFF
--- a/crates/sonar-idl/src/parser/indexed.rs
+++ b/crates/sonar-idl/src/parser/indexed.rs
@@ -14,6 +14,7 @@ use super::decode::{
 use super::{IdlParsedField, IdlParsedInstruction};
 
 pub(super) const EMIT_CPI_DISCRIMINATOR: [u8; 8] = [0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
+const CPI_EVENT_ACCOUNT_NAME: &str = "event_authority";
 
 #[derive(Debug, Clone)]
 pub struct IndexedIdl {
@@ -150,7 +151,7 @@ impl IndexedIdl {
         Ok(Some(IdlParsedInstruction {
             name: event_def.name.clone(),
             fields,
-            account_names: Vec::new(),
+            account_names: vec![CPI_EVENT_ACCOUNT_NAME.to_string()],
         }))
     }
 

--- a/crates/sonar-idl/src/parser/tests/event.rs
+++ b/crates/sonar-idl/src/parser/tests/event.rs
@@ -62,6 +62,7 @@ fn indexed_idl_parse_cpi_event_data_parses_event_fields() {
     assert_eq!(parsed.fields.len(), 1);
     assert_eq!(parsed.fields[0].name, "amount");
     assert_eq!(parsed.fields[0].value, json!(500u64));
+    assert_eq!(parsed.account_names, vec!["event_authority"]);
 }
 
 #[test]
@@ -98,4 +99,5 @@ fn indexed_idl_parse_cpi_event_data_parses_tuple_event_fields() {
     assert_eq!(parsed.fields[0].value, json!(9u64));
     assert_eq!(parsed.fields[1].name, "field_1");
     assert_eq!(parsed.fields[1].value, json!(7u64));
+    assert_eq!(parsed.account_names, vec!["event_authority"]);
 }


### PR DESCRIPTION
## Summary
- label parsed Anchor CPI event accounts as event_authority instead of falling back to generic account_1
- keep the change in the IDL parser so existing text rendering picks up the specific account name automatically
- add regression coverage for standard and tuple CPI event parsing

## Test Plan
- cargo fmt --check
- cargo check
- cargo clippy -- -D warnings
- cargo test