### PR TITLE
refactor(sonar-sim): simplify public API with fluent Pipeline

### DIFF
--- a/crates/sonar-sim/README.md
+++ b/crates/sonar-sim/README.md
@@ -1,0 +1,117 @@
+# sonar-sim
+
+Solana transaction simulation engine powered by [LiteSVM](https://github.com/LiteSVM/litesvm).
+
+## Usage
+
+### Pipeline API
+
+```rust
+use sonar_sim::{Pipeline, Mutations, SimulationResult};
+
+let result = Pipeline::new("https://api.mainnet-beta.solana.com".into())
+    .parse(raw_tx)?           // base64 or base58 encoded transaction
+    .load_accounts()?         // fetches all referenced accounts via RPC
+    .execute()?;              // runs simulation, returns result with balance changes
+
+println!("success: {}", result.success);
+for change in &result.sol_changes {
+    println!("{}: {} -> {} ({:+})", change.account, change.before, change.after, change.change);
+}
+```
+
+### With Mutations
+
+```rust
+use sonar_sim::{Pipeline, Mutations};
+use sonar_sim::internals::{SolFunding, AccountOverride};
+
+let mutations = Mutations::builder()
+    .fund_sol(SolFunding { pubkey: wallet, amount_lamports: 1_000_000_000 })
+    .close_account(old_account)
+    .add_override(account_override)
+    .build();
+
+let result = Pipeline::new(rpc_url)
+    .parse(raw_tx)?
+    .load_accounts()?
+    .with_mutations(mutations)
+    .execute()?;
+```
+
+### Bundle Simulation
+
+```rust
+let results = Pipeline::new(rpc_url)
+    .parse_bundle(&[tx1, tx2, tx3])?
+    .load_accounts()?
+    .execute_bundle()?;        // Vec<SimulationResult>, stops on first failure
+```
+
+### Configuration
+
+```rust
+use std::sync::Arc;
+use sonar_sim::{Pipeline, AccountSource, FetchObserver};
+
+let result = Pipeline::new(rpc_url)
+    .with_source(Arc::new(my_local_source))   // check local accounts before RPC
+    .with_observer(Arc::new(my_observer))      // progress callbacks
+    .offline(true)                             // block all RPC calls
+    .verify_signatures(true)                   // default: false
+    .slot(123456)                              // override SVM slot
+    .timestamp(1700000000)                     // override SVM clock
+    .parse(raw_tx)?
+    .load_accounts()?
+    .execute()?;
+```
+
+### Intermediate State Access
+
+```rust
+let pipeline = Pipeline::new(rpc_url)
+    .parse(raw_tx)?;
+
+let parsed = pipeline.parsed().unwrap();  // access ParsedTransaction
+// inspect transaction before loading accounts...
+
+let pipeline = pipeline.load_accounts()?;
+let resolved = pipeline.resolved().unwrap();  // access ResolvedAccounts
+
+let result = pipeline.execute()?;
+```
+
+### Custom RPC Provider (Testing)
+
+```rust
+use std::sync::Arc;
+use sonar_sim::Pipeline;
+use sonar_sim::internals::FakeAccountProvider;
+
+let provider = Arc::new(FakeAccountProvider::from_accounts(vec![
+    (pubkey, account_data),
+]));
+
+let result = Pipeline::with_provider(provider)
+    .parse(raw_tx)?
+    .load_accounts()?
+    .execute()?;
+```
+
+## Public API
+
+| Export | Description |
+|--------|-------------|
+| `Pipeline` | Fluent simulation API |
+| `Mutations` | Consolidated mutation config |
+| `MutationsBuilder` | Builder for `Mutations` |
+| `SimulationResult` | Execution result with auto-computed balance changes |
+| `SolBalanceChange` | SOL balance change for an account |
+| `TokenBalanceChange` | Token balance change for an account |
+| `AccountSource` | Trait: provide accounts from local sources before RPC |
+| `FetchObserver` | Trait: receive account fetch lifecycle events |
+| `FetchEvent` | Enum: events emitted during account fetching |
+| `SonarSimError` | Error type |
+| `Result<T>` | Type alias for `Result<T, SonarSimError>` |
+
+For advanced/low-level access, use `sonar_sim::internals::*`.

--- a/crates/sonar-sim/README.md
+++ b/crates/sonar-sim/README.md
@@ -47,7 +47,7 @@ let bundle = Pipeline::new(rpc_url)
     .load_accounts()?
     .execute_bundle()?;        // BundleResult<Result<SimulationResult>>, fail-fast
 
-for result in &bundle.executed {
+for result in bundle.executed() {
     let sim = result.as_ref().unwrap();
     println!("success: {}", sim.success);
 }

--- a/crates/sonar-sim/README.md
+++ b/crates/sonar-sim/README.md
@@ -42,10 +42,18 @@ let result = Pipeline::new(rpc_url)
 ### Bundle Simulation
 
 ```rust
-let results = Pipeline::new(rpc_url)
+let bundle = Pipeline::new(rpc_url)
     .parse_bundle(&[tx1, tx2, tx3])?
     .load_accounts()?
-    .execute_bundle()?;        // Vec<SimulationResult>, stops on first failure
+    .execute_bundle()?;        // BundleResult<Result<SimulationResult>>, fail-fast
+
+for result in &bundle.executed {
+    let sim = result.as_ref().unwrap();
+    println!("success: {}", sim.success);
+}
+if bundle.skipped_count() > 0 {
+    println!("{} transactions were skipped due to prior failure", bundle.skipped_count());
+}
 ```
 
 ### Configuration

--- a/crates/sonar-sim/src/account_loader.rs
+++ b/crates/sonar-sim/src/account_loader.rs
@@ -301,22 +301,26 @@ fn expand_lookup_table(
     })?;
     let all_addresses = lookup_table.addresses.to_vec();
 
-    let writable_addresses = resolve_lookup_indexes(&all_addresses, &plan.writable_indexes)
-        .map_err(|e| SonarSimError::LookupTable {
-            table: Some(plan.account_key),
-            reason: format!(
-                "Failed to parse writable indexes for address lookup table `{}`: {e}",
-                plan.account_key
-            ),
-        })?;
-    let readonly_addresses = resolve_lookup_indexes(&all_addresses, &plan.readonly_indexes)
-        .map_err(|e| SonarSimError::LookupTable {
-            table: Some(plan.account_key),
-            reason: format!(
-                "Failed to parse readonly indexes for address lookup table `{}`: {e}",
-                plan.account_key
-            ),
-        })?;
+    let writable_addresses =
+        resolve_lookup_indexes(&all_addresses, &plan.writable_indexes, plan.account_key).map_err(
+            |e| SonarSimError::LookupTable {
+                table: Some(plan.account_key),
+                reason: format!(
+                    "Failed to parse writable indexes for address lookup table `{}`: {e}",
+                    plan.account_key
+                ),
+            },
+        )?;
+    let readonly_addresses =
+        resolve_lookup_indexes(&all_addresses, &plan.readonly_indexes, plan.account_key).map_err(
+            |e| SonarSimError::LookupTable {
+                table: Some(plan.account_key),
+                reason: format!(
+                    "Failed to parse readonly indexes for address lookup table `{}`: {e}",
+                    plan.account_key
+                ),
+            },
+        )?;
 
     Ok(ResolvedLookup {
         account_key: plan.account_key,
@@ -327,12 +331,16 @@ fn expand_lookup_table(
     })
 }
 
-fn resolve_lookup_indexes(addresses: &[Pubkey], indexes: &[u8]) -> Result<Vec<Pubkey>> {
+fn resolve_lookup_indexes(
+    addresses: &[Pubkey],
+    indexes: &[u8],
+    table_key: Pubkey,
+) -> Result<Vec<Pubkey>> {
     indexes
         .iter()
         .map(|idx| {
             addresses.get(*idx as usize).copied().ok_or_else(|| SonarSimError::LookupTable {
-                table: None,
+                table: Some(table_key),
                 reason: format!("Index {idx} out of address lookup table range"),
             })
         })
@@ -661,21 +669,28 @@ mod tests {
         let addr1 = Pubkey::new_unique();
         let addr2 = Pubkey::new_unique();
         let addresses = vec![addr0, addr1, addr2];
-        let result = resolve_lookup_indexes(&addresses, &[2, 0]).unwrap();
+        let table_key = Pubkey::new_unique();
+        let result = resolve_lookup_indexes(&addresses, &[2, 0], table_key).unwrap();
         assert_eq!(result, vec![addr2, addr0]);
     }
 
     #[test]
     fn resolve_lookup_indexes_out_of_bounds() {
         let addresses = vec![Pubkey::new_unique()];
-        let err = resolve_lookup_indexes(&addresses, &[5]).unwrap_err();
+        let table_key = Pubkey::new_unique();
+        let err = resolve_lookup_indexes(&addresses, &[5], table_key).unwrap_err();
         assert!(err.to_string().contains("out of"));
+        assert!(
+            matches!(err, SonarSimError::LookupTable { table: Some(t), .. } if t == table_key),
+            "error should include the table pubkey"
+        );
     }
 
     #[test]
     fn resolve_lookup_indexes_empty() {
         let addresses = vec![Pubkey::new_unique()];
-        let result = resolve_lookup_indexes(&addresses, &[]).unwrap();
+        let table_key = Pubkey::new_unique();
+        let result = resolve_lookup_indexes(&addresses, &[], table_key).unwrap();
         assert!(result.is_empty());
     }
 

--- a/crates/sonar-sim/src/balance_changes.rs
+++ b/crates/sonar-sim/src/balance_changes.rs
@@ -165,7 +165,6 @@ mod tests {
     use solana_sdk_ids::system_program;
     use spl_token::solana_program::program_option::COption;
     use spl_token::solana_program::program_pack::Pack;
-    use spl_token::solana_program::pubkey::Pubkey as ProgramPubkey;
     use spl_token::state::{Account as SplTokenAccount, AccountState};
 
     fn create_shared_account_with_lamports(lamports: u64) -> AccountSharedData {
@@ -185,8 +184,8 @@ mod tests {
         lamports: u64,
     ) -> AccountSharedData {
         let state = SplTokenAccount {
-            mint: ProgramPubkey::new_from_array(mint.to_bytes()),
-            owner: ProgramPubkey::new_from_array(token_owner.to_bytes()),
+            mint: crate::token_decode::to_program_pubkey(mint),
+            owner: crate::token_decode::to_program_pubkey(token_owner),
             amount,
             delegate: COption::None,
             state: AccountState::Initialized,
@@ -199,7 +198,7 @@ mod tests {
         AccountSharedData::from(Account {
             lamports,
             data,
-            owner: Pubkey::new_from_array(spl_token::ID.to_bytes()),
+            owner: crate::token_decode::to_pubkey(&spl_token::ID),
             executable: false,
             rent_epoch: 0,
         })

--- a/crates/sonar-sim/src/executor.rs
+++ b/crates/sonar-sim/src/executor.rs
@@ -403,7 +403,7 @@ impl<B: SvmBackend> SimulationRunner<B> {
     ///
     /// Takes pre/post account snapshots so that balance changes can be
     /// computed even when accounts are closed during execution.
-    pub fn execute(&mut self, tx: &VersionedTransaction) -> Result<SimulationResult> {
+    pub fn execute(&mut self, tx: &VersionedTransaction) -> Result<ExecutionResult> {
         let account_keys = self.collect_transaction_accounts(tx);
         let pre_accounts = self.snapshot_accounts(&account_keys);
 
@@ -412,13 +412,13 @@ impl<B: SvmBackend> SimulationRunner<B> {
         let post_accounts = self.snapshot_accounts(&account_keys);
 
         let simulation = match result {
-            TransactionResult::Ok(info) => SimulationResult {
+            TransactionResult::Ok(info) => ExecutionResult {
                 status: ExecutionStatus::Succeeded,
                 meta: convert_metadata(&info),
                 post_accounts,
                 pre_accounts,
             },
-            TransactionResult::Err(failure) => SimulationResult {
+            TransactionResult::Err(failure) => ExecutionResult {
                 status: ExecutionStatus::Failed(failure.err.to_string()),
                 meta: convert_metadata(&failure.meta),
                 post_accounts,
@@ -462,7 +462,7 @@ impl<B: SvmBackend> SimulationRunner<B> {
     pub fn execute_bundle(
         &mut self,
         txs: &[&VersionedTransaction],
-    ) -> Vec<Result<SimulationResult>> {
+    ) -> Vec<Result<ExecutionResult>> {
         let mut results = Vec::with_capacity(txs.len());
 
         for tx in txs {
@@ -507,7 +507,7 @@ impl<B: SvmBackend> SimulationRunner<B> {
 }
 
 #[derive(Debug, Clone)]
-pub struct SimulationResult {
+pub struct ExecutionResult {
     pub status: ExecutionStatus,
     pub meta: SimulationMetadata,
     pub post_accounts: HashMap<Pubkey, AccountSharedData>,

--- a/crates/sonar-sim/src/executor.rs
+++ b/crates/sonar-sim/src/executor.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use litesvm::LiteSVM;
 use litesvm::types::{TransactionMetadata, TransactionResult};
 use log::{info, warn};
-use solana_account::{Account, AccountSharedData, ReadableAccount};
+use solana_account::{AccountSharedData, ReadableAccount, WritableAccount};
 use solana_clock::Clock;
 use solana_loader_v3_interface::state::UpgradeableLoaderState;
 use solana_pubkey::Pubkey;
@@ -171,8 +171,8 @@ pub fn load_accounts<B: SvmBackend + ?Sized>(
     let mut ordered: Vec<_> = resolved.accounts.iter().collect();
     ordered.sort_by_key(|(_, account)| account_priority(account));
     for (pubkey, account) in ordered {
-        svm.set_account(*pubkey, Account::from(account.clone())).map_err(|e| {
-            SonarSimError::Svm { reason: format!("Failed to set account {}: {}", pubkey, e) }
+        svm.set_account(*pubkey, account.clone()).map_err(|e| SonarSimError::Svm {
+            reason: format!("Failed to set account {}: {}", pubkey, e),
         })?;
     }
     Ok(())
@@ -193,7 +193,7 @@ pub fn apply_account_closures<B: SvmBackend + ?Sized>(
             continue;
         }
         info!("Closing account {} (setting to zero lamports)", pubkey);
-        svm.set_account(*pubkey, Account::default()).map_err(|e| SonarSimError::Svm {
+        svm.set_account(*pubkey, AccountSharedData::default()).map_err(|e| SonarSimError::Svm {
             reason: format!("Failed to close account `{}`: {}", pubkey, e),
         })?;
     }
@@ -239,14 +239,16 @@ pub fn apply_overrides<B: SvmBackend + ?Sized>(
                     }
                 }
                 info!("Loading custom account {} => {}", pubkey, source_path.display());
-                svm.set_account(*pubkey, account.clone()).map_err(|e| SonarSimError::Svm {
-                    reason: format!(
-                        "Failed to set override account `{}`, path: {}: {}",
-                        pubkey,
-                        source_path.display(),
-                        e
-                    ),
-                })?;
+                svm.set_account(*pubkey, AccountSharedData::from(account.clone())).map_err(
+                    |e| SonarSimError::Svm {
+                        reason: format!(
+                            "Failed to set override account `{}`, path: {}: {}",
+                            pubkey,
+                            source_path.display(),
+                            e
+                        ),
+                    },
+                )?;
             }
         }
     }
@@ -263,14 +265,14 @@ pub fn apply_data_patches<B: SvmBackend + ?Sized>(
             .get_account(&patch.pubkey)
             .ok_or(SonarSimError::AccountNotFound { pubkey: patch.pubkey })?;
         let end = patch.offset + patch.data.len();
-        if end > account.data.len() {
+        if end > account.data().len() {
             return Err(SonarSimError::AccountData {
                 pubkey: Some(patch.pubkey),
                 reason: format!(
                     "Patch range [{}..{}) exceeds account data length {} for {}",
                     patch.offset,
                     end,
-                    account.data.len(),
+                    account.data().len(),
                     patch.pubkey
                 ),
             });
@@ -282,7 +284,7 @@ pub fn apply_data_patches<B: SvmBackend + ?Sized>(
             end,
             patch.data.len()
         );
-        account.data[patch.offset..end].copy_from_slice(&patch.data);
+        account.data_as_mut_slice()[patch.offset..end].copy_from_slice(&patch.data);
         svm.set_account(patch.pubkey, account).map_err(|e| SonarSimError::Svm {
             reason: format!("Failed to set patched account `{}`: {}", patch.pubkey, e),
         })?;
@@ -299,10 +301,10 @@ pub fn apply_slot<B: SvmBackend + ?Sized>(svm: &mut B, slot: u64) {
 /// Override the Clock sysvar's `unix_timestamp` field.
 pub fn apply_timestamp<B: SvmBackend + ?Sized>(svm: &mut B, ts: i64) -> Result<()> {
     let clock_id = Clock::id();
-    let clock_account = svm.get_account(&clock_id).ok_or_else(|| SonarSimError::Svm {
+    let mut clock_account = svm.get_account(&clock_id).ok_or_else(|| SonarSimError::Svm {
         reason: "Clock sysvar account not found in SVM".into(),
     })?;
-    let mut clock: Clock = bincode::deserialize(&clock_account.data).map_err(|e| {
+    let mut clock: Clock = bincode::deserialize(clock_account.data()).map_err(|e| {
         SonarSimError::Serialization { reason: format!("Failed to deserialize Clock sysvar: {e}") }
     })?;
     info!("Overriding Clock unix_timestamp: {} -> {}", clock.unix_timestamp, ts);
@@ -310,8 +312,8 @@ pub fn apply_timestamp<B: SvmBackend + ?Sized>(svm: &mut B, ts: i64) -> Result<(
     let data = bincode::serialize(&clock).map_err(|e| SonarSimError::Serialization {
         reason: format!("Failed to serialize modified Clock sysvar: {e}"),
     })?;
-    let updated_account = Account { data, ..clock_account };
-    svm.set_account(clock_id, updated_account).map_err(|e| SonarSimError::Svm {
+    clock_account.set_data_from_slice(&data);
+    svm.set_account(clock_id, clock_account).map_err(|e| SonarSimError::Svm {
         reason: format!("Failed to set modified Clock sysvar: {e}"),
     })?;
     Ok(())
@@ -391,6 +393,30 @@ impl<B: SvmBackend> PreparedSimulation<B> {
     }
 }
 
+/// Result of a bundle execution with fail-fast semantics.
+///
+/// The `executed` vec may be shorter than `total` if a transaction failed
+/// and remaining transactions were skipped.
+#[derive(Debug, Clone)]
+pub struct BundleResult<T> {
+    /// Results for transactions that were actually executed.
+    pub executed: Vec<T>,
+    /// Total number of transactions in the bundle input.
+    pub total: usize,
+}
+
+impl<T> BundleResult<T> {
+    /// How many transactions were never attempted due to a prior failure.
+    pub fn skipped_count(&self) -> usize {
+        self.total.saturating_sub(self.executed.len())
+    }
+
+    /// True if all transactions were attempted (even if some failed).
+    pub fn is_complete(&self) -> bool {
+        self.executed.len() == self.total
+    }
+}
+
 /// Mutable simulation engine that executes transactions on prepared state.
 pub struct SimulationRunner<B: SvmBackend = LiteSVM> {
     svm: B,
@@ -452,17 +478,21 @@ impl<B: SvmBackend> SimulationRunner<B> {
         let mut snapshot = HashMap::new();
         for key in keys {
             if let Some(account) = self.svm.get_account(key) {
-                snapshot.insert(*key, account.into());
+                snapshot.insert(*key, account);
             }
         }
         snapshot
     }
 
     /// Execute multiple transactions sequentially as a bundle.
+    ///
+    /// Uses fail-fast semantics: stops executing remaining transactions after
+    /// the first failure. Use [`BundleResult::skipped_count`] to detect how
+    /// many transactions were never attempted.
     pub fn execute_bundle(
         &mut self,
         txs: &[&VersionedTransaction],
-    ) -> Vec<Result<ExecutionResult>> {
+    ) -> BundleResult<Result<ExecutionResult>> {
         let mut results = Vec::with_capacity(txs.len());
 
         for tx in txs {
@@ -478,7 +508,7 @@ impl<B: SvmBackend> SimulationRunner<B> {
             }
         }
 
-        results
+        BundleResult { executed: results, total: txs.len() }
     }
 
     pub fn resolved_accounts(&self) -> &ResolvedAccounts {
@@ -558,6 +588,7 @@ fn account_priority(account: &AccountSharedData) -> u8 {
 mod tests {
     use super::*;
     use crate::test_utils::MockSvm;
+    use solana_account::Account;
     use solana_hash::Hash;
     use solana_keypair::Keypair;
     use solana_message::Message;
@@ -609,8 +640,9 @@ mod tests {
 
         let results = runner.execute_bundle(&tx_refs);
 
-        assert_eq!(results.len(), 2);
-        assert!(results.iter().all(|r| r.is_ok()));
+        assert_eq!(results.executed.len(), 2);
+        assert!(results.executed.iter().all(|r| r.is_ok()));
+        assert!(results.is_complete());
     }
 
     #[test]
@@ -634,8 +666,13 @@ mod tests {
 
         let results = runner.execute_bundle(&tx_refs);
 
-        assert_eq!(results.len(), 1, "bundle should stop after first failure");
-        assert!(matches!(results[0].as_ref().map(|r| &r.status), Ok(&ExecutionStatus::Failed(_))));
+        assert_eq!(results.executed.len(), 1, "bundle should stop after first failure");
+        assert!(matches!(
+            results.executed[0].as_ref().map(|r| &r.status),
+            Ok(&ExecutionStatus::Failed(_))
+        ));
+        assert_eq!(results.skipped_count(), 1);
+        assert!(!results.is_complete());
     }
 
     #[test]
@@ -657,9 +694,16 @@ mod tests {
             .into_runner();
 
         let results = runner.execute_bundle(&tx_refs);
-        assert_eq!(results.len(), 2);
-        assert!(matches!(results[0].as_ref().map(|r| &r.status), Ok(&ExecutionStatus::Succeeded)));
-        assert!(matches!(results[1].as_ref().map(|r| &r.status), Ok(&ExecutionStatus::Succeeded)));
+        assert_eq!(results.executed.len(), 2);
+        assert!(matches!(
+            results.executed[0].as_ref().map(|r| &r.status),
+            Ok(&ExecutionStatus::Succeeded)
+        ));
+        assert!(matches!(
+            results.executed[1].as_ref().map(|r| &r.status),
+            Ok(&ExecutionStatus::Succeeded)
+        ));
+        assert!(results.is_complete());
     }
 
     #[test]
@@ -949,7 +993,7 @@ mod tests {
         apply_data_patches(&mut svm, &patches).expect("should apply");
 
         let loaded = svm.get_account(&key).unwrap();
-        assert_eq!(loaded.data, vec![0, 0xAA, 0xBB, 0, 0]);
+        assert_eq!(loaded.data(), &[0, 0xAA, 0xBB, 0, 0]);
     }
 
     #[test]
@@ -974,7 +1018,7 @@ mod tests {
         apply_timestamp(&mut svm, 1_700_000_000).unwrap();
 
         let updated = svm.get_account(&Clock::id()).unwrap();
-        let updated_clock: Clock = bincode::deserialize(&updated.data).unwrap();
+        let updated_clock: Clock = bincode::deserialize(updated.data()).unwrap();
         assert_eq!(updated_clock.unix_timestamp, 1_700_000_000);
     }
 
@@ -1081,6 +1125,6 @@ mod tests {
         apply_account_closures(&mut svm, &[key]).expect("should close");
         // MockSvm stores the zero-lamport account (doesn't auto-remove like LiteSVM)
         let closed = svm.get_account(&key).unwrap();
-        assert_eq!(closed.lamports, 0);
+        assert_eq!(closed.lamports(), 0);
     }
 }

--- a/crates/sonar-sim/src/executor.rs
+++ b/crates/sonar-sim/src/executor.rs
@@ -399,13 +399,30 @@ impl<B: SvmBackend> PreparedSimulation<B> {
 /// and remaining transactions were skipped.
 #[derive(Debug, Clone)]
 pub struct BundleResult<T> {
-    /// Results for transactions that were actually executed.
-    pub executed: Vec<T>,
-    /// Total number of transactions in the bundle input.
-    pub total: usize,
+    executed: Vec<T>,
+    total: usize,
 }
 
 impl<T> BundleResult<T> {
+    pub(crate) fn new(executed: Vec<T>, total: usize) -> Self {
+        Self { executed, total }
+    }
+
+    /// Results for transactions that were actually executed.
+    pub fn executed(&self) -> &[T] {
+        &self.executed
+    }
+
+    /// Consume self and return the executed results.
+    pub fn into_executed(self) -> Vec<T> {
+        self.executed
+    }
+
+    /// Total number of transactions in the bundle input.
+    pub fn total(&self) -> usize {
+        self.total
+    }
+
     /// How many transactions were never attempted due to a prior failure.
     pub fn skipped_count(&self) -> usize {
         self.total.saturating_sub(self.executed.len())
@@ -508,7 +525,7 @@ impl<B: SvmBackend> SimulationRunner<B> {
             }
         }
 
-        BundleResult { executed: results, total: txs.len() }
+        BundleResult::new(results, txs.len())
     }
 
     pub fn resolved_accounts(&self) -> &ResolvedAccounts {
@@ -640,8 +657,8 @@ mod tests {
 
         let results = runner.execute_bundle(&tx_refs);
 
-        assert_eq!(results.executed.len(), 2);
-        assert!(results.executed.iter().all(|r| r.is_ok()));
+        assert_eq!(results.executed().len(), 2);
+        assert!(results.executed().iter().all(|r| r.is_ok()));
         assert!(results.is_complete());
     }
 
@@ -666,9 +683,9 @@ mod tests {
 
         let results = runner.execute_bundle(&tx_refs);
 
-        assert_eq!(results.executed.len(), 1, "bundle should stop after first failure");
+        assert_eq!(results.executed().len(), 1, "bundle should stop after first failure");
         assert!(matches!(
-            results.executed[0].as_ref().map(|r| &r.status),
+            results.executed()[0].as_ref().map(|r| &r.status),
             Ok(&ExecutionStatus::Failed(_))
         ));
         assert_eq!(results.skipped_count(), 1);
@@ -694,13 +711,13 @@ mod tests {
             .into_runner();
 
         let results = runner.execute_bundle(&tx_refs);
-        assert_eq!(results.executed.len(), 2);
+        assert_eq!(results.executed().len(), 2);
         assert!(matches!(
-            results.executed[0].as_ref().map(|r| &r.status),
+            results.executed()[0].as_ref().map(|r| &r.status),
             Ok(&ExecutionStatus::Succeeded)
         ));
         assert!(matches!(
-            results.executed[1].as_ref().map(|r| &r.status),
+            results.executed()[1].as_ref().map(|r| &r.status),
             Ok(&ExecutionStatus::Succeeded)
         ));
         assert!(results.is_complete());

--- a/crates/sonar-sim/src/funding/common.rs
+++ b/crates/sonar-sim/src/funding/common.rs
@@ -1,4 +1,4 @@
-use solana_account::Account;
+use solana_account::{AccountSharedData, ReadableAccount, WritableAccount};
 use solana_pubkey::Pubkey;
 use spl_token::solana_program::program_pack::Pack;
 
@@ -25,7 +25,7 @@ impl TokenAmountMut for spl_token_2022::state::Account {
 }
 
 pub(super) fn update_token_amount_account<T: TokenAmountMut>(
-    account: &mut Account,
+    account: &mut AccountSharedData,
     account_pubkey: &Pubkey,
     mint: &Pubkey,
     owner: &Pubkey,
@@ -33,19 +33,20 @@ pub(super) fn update_token_amount_account<T: TokenAmountMut>(
     decimals: u8,
     program_kind: TokenProgramKind,
 ) -> Result<PreparedTokenFunding> {
-    ensure_same_program(program_kind, &account.owner, "token account")?;
-    if account.data.len() < T::LEN {
+    ensure_same_program(program_kind, account.owner(), "token account", *account_pubkey)?;
+    if account.data().len() < T::LEN {
         return Err(SonarSimError::Token {
             account: Some(*account_pubkey),
             reason: format!(
                 "Token account data is smaller than expected: {} < {}",
-                account.data.len(),
+                account.data().len(),
                 T::LEN
             ),
         });
     }
 
-    let (account_bytes, _) = account.data.split_at_mut(T::LEN);
+    let data = account.data_as_mut_slice();
+    let (account_bytes, _) = data.split_at_mut(T::LEN);
     let mut parsed = T::unpack(account_bytes).map_err(|err| SonarSimError::Token {
         account: Some(*account_pubkey),
         reason: format!("Failed to unpack token account {account_pubkey}: {err}"),

--- a/crates/sonar-sim/src/funding/mod.rs
+++ b/crates/sonar-sim/src/funding/mod.rs
@@ -7,7 +7,7 @@ pub use sol::apply_sol_fundings;
 
 use std::collections::HashMap;
 
-use solana_account::{Account, AccountSharedData, ReadableAccount};
+use solana_account::{AccountSharedData, ReadableAccount};
 use solana_pubkey::Pubkey;
 use solana_rent::Rent;
 
@@ -144,7 +144,7 @@ fn prepare_single_token_funding(
         })?;
 
     if let Some(account) = lookup_account(resolved, extras, &request.account) {
-        ensure_same_program(program_kind, account.owner(), "token account")?;
+        ensure_same_program(program_kind, account.owner(), "token account", request.account)?;
     }
 
     Ok(PreparedTokenFunding {
@@ -184,7 +184,7 @@ fn apply_single_token_funding<B: SvmBackend + ?Sized>(
             .accounts
             .get(&funding.mint)
             .ok_or(SonarSimError::AccountNotFound { pubkey: funding.mint })?;
-        let created = match kind {
+        match kind {
             TokenProgramKind::Legacy => token_legacy::build_token_account(
                 &funding.account,
                 &funding.mint,
@@ -198,8 +198,7 @@ fn apply_single_token_funding<B: SvmBackend + ?Sized>(
                 mint_account,
                 &rent,
             )?,
-        };
-        Account::from(created)
+        }
     };
 
     let _ = match kind {
@@ -232,7 +231,7 @@ fn read_rent_from_svm<B: SvmBackend + ?Sized>(svm: &B) -> Result<Rent> {
     let rent_account = svm.get_account(&rent_id).ok_or_else(|| SonarSimError::Svm {
         reason: "Rent sysvar account not found in SVM".into(),
     })?;
-    bincode::deserialize(&rent_account.data).map_err(|e| SonarSimError::Serialization {
+    bincode::deserialize(rent_account.data()).map_err(|e| SonarSimError::Serialization {
         reason: format!("Failed to deserialize Rent sysvar: {e}"),
     })
 }
@@ -300,8 +299,8 @@ mod tests {
     use litesvm::LiteSVM;
     use solana_account::{Account, AccountSharedData, ReadableAccount};
     use solana_pubkey::Pubkey;
+    use spl_token::solana_program::program_option::COption;
     use spl_token::solana_program::program_pack::Pack;
-    use spl_token::solana_program::{program_option::COption, pubkey::Pubkey as ProgramPubkey};
     use spl_token::state::{Account as SplAccount, AccountState, Mint as SplMint};
 
     use crate::token_decode::{legacy_program_id, raw_to_ui_amount};
@@ -570,14 +569,14 @@ mod tests {
 
         let created = svm.get_account(&token).expect("token account should be created");
         let parsed = SplAccount::unpack(&created.data[..SplAccount::LEN]).unwrap();
-        assert_eq!(Pubkey::new_from_array(parsed.owner.to_bytes()), owner);
+        assert_eq!(crate::token_decode::to_pubkey(&parsed.owner), owner);
         assert_eq!(parsed.amount, 1_000_000);
     }
 
     fn spl_token_account_and_mint(mint: &Pubkey, owner: &Pubkey) -> (Account, Account) {
         let token_state = SplAccount {
-            mint: ProgramPubkey::new_from_array(mint.to_bytes()),
-            owner: ProgramPubkey::new_from_array(owner.to_bytes()),
+            mint: crate::token_decode::to_program_pubkey(mint),
+            owner: crate::token_decode::to_program_pubkey(owner),
             amount: 0,
             delegate: COption::None,
             state: AccountState::Initialized,

--- a/crates/sonar-sim/src/funding/sol.rs
+++ b/crates/sonar-sim/src/funding/sol.rs
@@ -33,7 +33,7 @@ fn apply_single_sol_funding<B: SvmBackend + ?Sized>(
     } else {
         let system_program_id = solana_sdk_ids::system_program::id();
         let new_account = AccountSharedData::new(lamports, 0, &system_program_id);
-        svm.set_account(funding.pubkey, new_account.into())
+        svm.set_account(funding.pubkey, new_account)
             .map_err(|e| SonarSimError::Svm { reason: e.to_string() })?;
     }
 

--- a/crates/sonar-sim/src/funding/token2022.rs
+++ b/crates/sonar-sim/src/funding/token2022.rs
@@ -1,13 +1,13 @@
 use solana_account::{Account, AccountSharedData, ReadableAccount};
 use solana_pubkey::Pubkey;
 use solana_rent::Rent;
-use spl_token::solana_program::{program_option::COption, pubkey::Pubkey as ProgramPubkey};
+use spl_token::solana_program::program_option::COption;
 use spl_token_2022::extension::{BaseStateWithExtensions, BaseStateWithExtensionsMut};
 use spl_token_2022::extension::{ExtensionType, StateWithExtensions, StateWithExtensionsMut};
 use spl_token_2022::state::{Account as Token2022Account, AccountState, Mint as Token2022Mint};
 
 use crate::error::{Result, SonarSimError};
-use crate::token_decode::{TokenProgramKind, token2022_program_id};
+use crate::token_decode::{TokenProgramKind, to_program_pubkey, token2022_program_id};
 use crate::types::PreparedTokenFunding;
 
 pub(super) fn build_token_account_with_extensions(
@@ -47,8 +47,8 @@ pub(super) fn build_token_account_with_extensions(
         })?;
 
     state.base = Token2022Account {
-        mint: ProgramPubkey::new_from_array(mint.to_bytes()),
-        owner: ProgramPubkey::new_from_array(owner.to_bytes()),
+        mint: to_program_pubkey(mint),
+        owner: to_program_pubkey(owner),
         amount: 0,
         delegate: COption::None,
         state: AccountState::Initialized,
@@ -79,7 +79,7 @@ pub(super) fn build_token_account_with_extensions(
 }
 
 pub(super) fn update_token_balance_in_account(
-    account: &mut Account,
+    account: &mut AccountSharedData,
     account_pubkey: &Pubkey,
     mint: &Pubkey,
     owner: &Pubkey,
@@ -112,7 +112,7 @@ mod tests {
     use spl_token_2022::state::{Account as Token2022Account, Mint as Token2022Mint};
 
     use super::*;
-    use crate::token_decode::token2022_program_id;
+    use crate::token_decode::{to_pubkey, token2022_program_id};
 
     fn mint_account_base_only() -> AccountSharedData {
         let mint = Token2022Mint {
@@ -218,23 +218,22 @@ mod tests {
         let token = Pubkey::new_unique();
         let owner = Pubkey::new_unique();
         let mint_account = mint_account_base_only();
-        let mut account = Account::from(
-            build_token_account_with_extensions(
-                &token,
-                &mint,
-                &owner,
-                &mint_account,
-                &Rent::default(),
-            )
-            .unwrap(),
-        );
+        let mut account = build_token_account_with_extensions(
+            &token,
+            &mint,
+            &owner,
+            &mint_account,
+            &Rent::default(),
+        )
+        .unwrap();
         let result =
             update_token_balance_in_account(&mut account, &token, &mint, &owner, 5_000_000, 6)
                 .unwrap();
         assert_eq!(result.amount_raw, 5_000_000);
         assert!((result.ui_amount - 5.0).abs() < f64::EPSILON);
 
-        let state = StateWithExtensions::<Token2022Account>::unpack(&account.data).expect("unpack");
+        let state =
+            StateWithExtensions::<Token2022Account>::unpack(account.data()).expect("unpack");
         assert_eq!(state.base.amount, 5_000_000);
     }
 
@@ -250,6 +249,6 @@ mod tests {
                 .unwrap();
         let state =
             StateWithExtensions::<Token2022Account>::unpack(account.data()).expect("unpack");
-        assert_eq!(Pubkey::new_from_array(state.base.owner.to_bytes()), owner);
+        assert_eq!(to_pubkey(&state.base.owner), owner);
     }
 }

--- a/crates/sonar-sim/src/funding/token_legacy.rs
+++ b/crates/sonar-sim/src/funding/token_legacy.rs
@@ -1,12 +1,12 @@
 use solana_account::{Account, AccountSharedData};
 use solana_pubkey::Pubkey;
 use solana_rent::Rent;
+use spl_token::solana_program::program_option::COption;
 use spl_token::solana_program::program_pack::Pack;
-use spl_token::solana_program::{program_option::COption, pubkey::Pubkey as ProgramPubkey};
 use spl_token::state::{Account as SplAccount, AccountState};
 
 use crate::error::{Result, SonarSimError};
-use crate::token_decode::{TokenProgramKind, legacy_program_id};
+use crate::token_decode::{TokenProgramKind, legacy_program_id, to_program_pubkey};
 use crate::types::PreparedTokenFunding;
 
 pub(super) fn build_token_account(
@@ -17,8 +17,8 @@ pub(super) fn build_token_account(
 ) -> Result<AccountSharedData> {
     let mut data = vec![0u8; SplAccount::LEN];
     let state = SplAccount {
-        mint: ProgramPubkey::new_from_array(mint.to_bytes()),
-        owner: ProgramPubkey::new_from_array(owner.to_bytes()),
+        mint: to_program_pubkey(mint),
+        owner: to_program_pubkey(owner),
         amount: 0,
         delegate: COption::None,
         state: AccountState::Initialized,
@@ -40,7 +40,7 @@ pub(super) fn build_token_account(
 }
 
 pub(super) fn update_token_balance_in_account(
-    account: &mut Account,
+    account: &mut AccountSharedData,
     account_pubkey: &Pubkey,
     mint: &Pubkey,
     owner: &Pubkey,
@@ -81,7 +81,7 @@ mod tests {
         assert_eq!(account.lamports(), rent.minimum_balance(SplAccount::LEN));
 
         let parsed = SplAccount::unpack(&account.data()[..SplAccount::LEN]).unwrap();
-        assert_eq!(Pubkey::new_from_array(parsed.mint.to_bytes()), mint);
+        assert_eq!(crate::token_decode::to_pubkey(&parsed.mint), mint);
         assert_eq!(parsed.amount, 0);
     }
 
@@ -90,8 +90,7 @@ mod tests {
         let mint = Pubkey::new_unique();
         let token = Pubkey::new_unique();
         let owner = Pubkey::new_unique();
-        let mut account =
-            Account::from(build_token_account(&token, &mint, &owner, &Rent::default()).unwrap());
+        let mut account = build_token_account(&token, &mint, &owner, &Rent::default()).unwrap();
         let result =
             update_token_balance_in_account(&mut account, &token, &mint, &owner, 42_000_000, 6)
                 .unwrap();
@@ -99,7 +98,7 @@ mod tests {
         assert_eq!(result.decimals, 6);
         assert!((result.ui_amount - 42.0).abs() < f64::EPSILON);
 
-        let parsed = SplAccount::unpack(&account.data[..SplAccount::LEN]).unwrap();
+        let parsed = SplAccount::unpack(&account.data()[..SplAccount::LEN]).unwrap();
         assert_eq!(parsed.amount, 42_000_000);
     }
 
@@ -108,13 +107,13 @@ mod tests {
         let mint = Pubkey::new_unique();
         let token = Pubkey::new_unique();
         let owner = Pubkey::new_unique();
-        let mut account = Account {
+        let mut account = AccountSharedData::from(solana_account::Account {
             lamports: 0,
             data: vec![0u8; 165],
             owner: token2022_program_id(),
             executable: false,
             rent_epoch: 0,
-        };
+        });
         let err = update_token_balance_in_account(&mut account, &token, &mint, &owner, 100, 6)
             .unwrap_err();
         assert!(err.to_string().contains("not owned by"));

--- a/crates/sonar-sim/src/internals.rs
+++ b/crates/sonar-sim/src/internals.rs
@@ -1,0 +1,80 @@
+//! Low-level building blocks for advanced consumers.
+//!
+//! Items here carry **no semver guarantees** — they may change in any release.
+//! Prefer the top-level `Pipeline` API for stable usage.
+
+// ── Transaction parsing ──
+
+pub use crate::transaction::{
+    parse_raw_transaction, apply_ix_account_appends, apply_ix_account_patches,
+    apply_ix_data_patches, build_lookup_locations,
+    AddressLookupPlan, LookupLocation, MessageAccountPlan, ParsedTransaction,
+    RawTransactionEncoding,
+};
+
+// ── Account loading ──
+
+pub use crate::account_fetcher::AccountFetcher;
+pub use crate::account_loader::AccountLoader;
+
+// ── Account types ──
+
+pub use crate::types::{
+    AccountDataPatch, AccountOverride, InstructionAccountAppend,
+    InstructionAccountPatch, InstructionDataPatch, ResolvedAccounts, ResolvedLookup,
+};
+
+// ── Funding ──
+
+pub use crate::types::{
+    PreparedTokenFunding, SolFunding, TokenAmount, TokenFunding,
+};
+pub use crate::funding::prepare_token_fundings;
+
+// ── Simulation types ──
+
+pub use crate::types::{ReturnData, SimulationMetadata};
+
+// ── Execution ──
+
+pub use crate::executor::{
+    ExecutionOptions, ExecutionStatus, PreparedSimulation,
+    SignatureVerification, SimulationOptions, SimulationOptionsBuilder,
+    ExecutionResult, SimulationRunner, StateMutationOptions,
+    apply_account_closures,
+};
+
+// ── Balance changes ──
+
+pub use crate::balance_changes::{
+    compute_sol_changes, compute_token_changes, extract_mint_decimals_combined,
+};
+
+// ── Token decoding ──
+
+pub use crate::token_decode::{
+    DecodedTokenAccount, TokenProgramKind, read_mint_decimals,
+    try_decode_token_account,
+};
+
+// ── RPC ──
+
+pub use crate::rpc_provider::{FakeAccountProvider, RpcAccountProvider, SolanaRpcProvider};
+pub use crate::svm_backend::SvmBackend;
+
+// ── Program identification ──
+
+pub use crate::known_programs::{is_litesvm_builtin_program, is_native_or_sysvar};
+
+// ── Traits and events ──
+
+pub use crate::types::{
+    AccountAppender, AccountSource, FetchEvent, FetchObserver,
+    FetchPolicy, RpcDecision,
+};
+
+// ── JSON-RPC types ──
+
+pub mod rpc_json {
+    pub use crate::rpc_json::*;
+}

--- a/crates/sonar-sim/src/internals.rs
+++ b/crates/sonar-sim/src/internals.rs
@@ -6,10 +6,9 @@
 // ── Transaction parsing ──
 
 pub use crate::transaction::{
-    parse_raw_transaction, apply_ix_account_appends, apply_ix_account_patches,
-    apply_ix_data_patches, build_lookup_locations,
     AddressLookupPlan, LookupLocation, MessageAccountPlan, ParsedTransaction,
-    RawTransactionEncoding,
+    RawTransactionEncoding, apply_ix_account_appends, apply_ix_account_patches,
+    apply_ix_data_patches, build_lookup_locations, parse_raw_transaction,
 };
 
 // ── Account loading ──
@@ -20,16 +19,14 @@ pub use crate::account_loader::AccountLoader;
 // ── Account types ──
 
 pub use crate::types::{
-    AccountDataPatch, AccountOverride, InstructionAccountAppend,
-    InstructionAccountPatch, InstructionDataPatch, ResolvedAccounts, ResolvedLookup,
+    AccountDataPatch, AccountOverride, InstructionAccountAppend, InstructionAccountPatch,
+    InstructionDataPatch, ResolvedAccounts, ResolvedLookup,
 };
 
 // ── Funding ──
 
-pub use crate::types::{
-    PreparedTokenFunding, SolFunding, TokenAmount, TokenFunding,
-};
 pub use crate::funding::prepare_token_fundings;
+pub use crate::types::{PreparedTokenFunding, SolFunding, TokenAmount, TokenFunding};
 
 // ── Simulation types ──
 
@@ -38,10 +35,9 @@ pub use crate::types::{ReturnData, SimulationMetadata};
 // ── Execution ──
 
 pub use crate::executor::{
-    ExecutionOptions, ExecutionStatus, PreparedSimulation,
-    SignatureVerification, SimulationOptions, SimulationOptionsBuilder,
-    ExecutionResult, SimulationRunner, StateMutationOptions,
-    apply_account_closures,
+    BundleResult, ExecutionOptions, ExecutionResult, ExecutionStatus, PreparedSimulation,
+    SignatureVerification, SimulationOptions, SimulationOptionsBuilder, SimulationRunner,
+    StateMutationOptions, apply_account_closures,
 };
 
 // ── Balance changes ──
@@ -53,8 +49,7 @@ pub use crate::balance_changes::{
 // ── Token decoding ──
 
 pub use crate::token_decode::{
-    DecodedTokenAccount, TokenProgramKind, read_mint_decimals,
-    try_decode_token_account,
+    DecodedTokenAccount, TokenProgramKind, read_mint_decimals, try_decode_token_account,
 };
 
 // ── RPC ──
@@ -69,8 +64,7 @@ pub use crate::known_programs::{is_litesvm_builtin_program, is_native_or_sysvar}
 // ── Traits and events ──
 
 pub use crate::types::{
-    AccountAppender, AccountSource, FetchEvent, FetchObserver,
-    FetchPolicy, RpcDecision,
+    AccountAppender, AccountSource, FetchEvent, FetchObserver, FetchPolicy, RpcDecision,
 };
 
 // ── JSON-RPC types ──

--- a/crates/sonar-sim/src/lib.rs
+++ b/crates/sonar-sim/src/lib.rs
@@ -17,22 +17,22 @@ pub(crate) mod funding;
 pub(crate) mod known_programs;
 pub mod mutations;
 pub(crate) mod pipeline;
+pub(crate) mod result;
 pub(crate) mod rpc_json;
 pub(crate) mod rpc_provider;
-pub(crate) mod result;
 pub(crate) mod svm_backend;
 #[cfg(test)]
 pub(crate) mod test_utils;
 pub(crate) mod token_decode;
-pub(crate) mod transaction;
 pub mod traits;
+pub(crate) mod transaction;
 pub(crate) mod types;
 
 // ── Public API ──
 
+pub use balance_changes::{SolBalanceChange, TokenBalanceChange};
 pub use error::{Result, SonarSimError};
 pub use mutations::{Mutations, MutationsBuilder};
 pub use pipeline::Pipeline;
 pub use result::SimulationResult;
-pub use balance_changes::{SolBalanceChange, TokenBalanceChange};
 pub use traits::{AccountSource, FetchEvent, FetchObserver};

--- a/crates/sonar-sim/src/lib.rs
+++ b/crates/sonar-sim/src/lib.rs
@@ -24,7 +24,6 @@ pub(crate) mod svm_backend;
 #[cfg(test)]
 pub(crate) mod test_utils;
 pub(crate) mod token_decode;
-pub mod traits;
 pub(crate) mod transaction;
 pub(crate) mod types;
 
@@ -35,4 +34,4 @@ pub use error::{Result, SonarSimError};
 pub use mutations::{Mutations, MutationsBuilder};
 pub use pipeline::Pipeline;
 pub use result::SimulationResult;
-pub use traits::{AccountSource, FetchEvent, FetchObserver};
+pub use types::{AccountSource, FetchEvent, FetchObserver};

--- a/crates/sonar-sim/src/lib.rs
+++ b/crates/sonar-sim/src/lib.rs
@@ -1,13 +1,12 @@
 //! sonar-sim: Solana transaction simulation engine powered by LiteSVM.
 //!
-//! # Stable Public API
+//! # Public API
 //!
-//! All items below constitute the stable facade of this crate.
-//! Internal modules are `pub(crate)` and may change without notice;
-//! external consumers should only depend on the re-exports listed here.
+//! The stable API consists of the items exported at the top level.
+//! For advanced/low-level access, use [`internals`].
 
 pub mod error;
-pub mod rpc_json;
+pub mod internals;
 
 pub(crate) mod account_dependencies;
 pub(crate) mod account_fetcher;
@@ -16,62 +15,24 @@ pub(crate) mod balance_changes;
 pub(crate) mod executor;
 pub(crate) mod funding;
 pub(crate) mod known_programs;
+pub mod mutations;
+pub(crate) mod pipeline;
+pub(crate) mod rpc_json;
 pub(crate) mod rpc_provider;
+pub(crate) mod result;
 pub(crate) mod svm_backend;
 #[cfg(test)]
 pub(crate) mod test_utils;
 pub(crate) mod token_decode;
 pub(crate) mod transaction;
+pub mod traits;
 pub(crate) mod types;
 
-// ── Error types ──
+// ── Public API ──
 
 pub use error::{Result, SonarSimError};
-
-// ── Types ──
-
-pub use token_decode::TokenProgramKind;
-pub use types::{
-    AccountAppender, AccountDataPatch, AccountOverride, AccountSource, FetchEvent, FetchObserver,
-    FetchPolicy, InstructionAccountAppend, InstructionAccountPatch, InstructionDataPatch,
-    PreparedTokenFunding, ResolvedAccounts, ResolvedLookup, ReturnData, RpcDecision,
-    SimulationMetadata, SolFunding, TokenAmount, TokenFunding,
-};
-
-// ── Transaction parsing ──
-
-pub use transaction::{
-    AddressLookupPlan, LookupLocation, MessageAccountPlan, ParsedTransaction,
-    RawTransactionEncoding, apply_ix_account_appends, apply_ix_account_patches,
-    apply_ix_data_patches, build_lookup_locations, parse_raw_transaction,
-};
-
-// ── Account loading ──
-
-pub use account_fetcher::AccountFetcher;
-pub use account_loader::AccountLoader;
-
-// ── RPC provider trait + implementations ──
-
-pub use rpc_provider::{FakeAccountProvider, RpcAccountProvider, SolanaRpcProvider};
-pub use svm_backend::SvmBackend;
-
-// ── Simulation execution ──
-
-pub use executor::{
-    ExecutionOptions, ExecutionStatus, PreparedSimulation, SignatureVerification,
-    SimulationOptions, SimulationOptionsBuilder, SimulationResult, SimulationRunner,
-    StateMutationOptions, apply_account_closures,
-};
-pub use known_programs::{is_litesvm_builtin_program, is_native_or_sysvar};
-
-// ── Balance change computation ──
-
-pub use balance_changes::{
-    SolBalanceChange, TokenBalanceChange, compute_sol_changes, compute_token_changes,
-    extract_mint_decimals_combined,
-};
-
-// ── Funding ──
-
-pub use funding::prepare_token_fundings;
+pub use mutations::{Mutations, MutationsBuilder};
+pub use pipeline::Pipeline;
+pub use result::SimulationResult;
+pub use balance_changes::{SolBalanceChange, TokenBalanceChange};
+pub use traits::{AccountSource, FetchEvent, FetchObserver};

--- a/crates/sonar-sim/src/mutations.rs
+++ b/crates/sonar-sim/src/mutations.rs
@@ -1,0 +1,147 @@
+// crates/sonar-sim/src/mutations.rs
+
+//! Consolidated mutation configuration for the simulation pipeline.
+
+use solana_pubkey::Pubkey;
+
+use crate::types::{
+    AccountDataPatch, AccountOverride, InstructionAccountAppend,
+    InstructionAccountPatch, InstructionDataPatch, SolFunding, TokenFunding,
+};
+
+/// All mutations to apply before simulation execution.
+///
+/// Combines both transaction-level mutations (instruction patches) and
+/// state-level mutations (account overrides, funding, closures).
+/// Construct via [`Mutations::builder()`] or [`Mutations::default()`].
+#[derive(Debug, Clone, Default)]
+pub struct Mutations {
+    pub(crate) account_overrides: Vec<AccountOverride>,
+    pub(crate) account_closures: Vec<Pubkey>,
+    pub(crate) sol_fundings: Vec<SolFunding>,
+    pub(crate) token_fundings: Vec<TokenFunding>,
+    pub(crate) account_data_patches: Vec<AccountDataPatch>,
+    pub(crate) ix_account_patches: Vec<InstructionAccountPatch>,
+    pub(crate) ix_account_appends: Vec<InstructionAccountAppend>,
+    pub(crate) ix_data_patches: Vec<InstructionDataPatch>,
+}
+
+impl Mutations {
+    pub fn builder() -> MutationsBuilder {
+        MutationsBuilder::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.account_overrides.is_empty()
+            && self.account_closures.is_empty()
+            && self.sol_fundings.is_empty()
+            && self.token_fundings.is_empty()
+            && self.account_data_patches.is_empty()
+            && self.ix_account_patches.is_empty()
+            && self.ix_account_appends.is_empty()
+            && self.ix_data_patches.is_empty()
+    }
+}
+
+/// Builder for [`Mutations`].
+#[derive(Debug, Clone, Default)]
+pub struct MutationsBuilder {
+    inner: Mutations,
+}
+
+impl MutationsBuilder {
+    pub fn add_override(mut self, account_override: AccountOverride) -> Self {
+        self.inner.account_overrides.push(account_override);
+        self
+    }
+
+    pub fn close_account(mut self, pubkey: Pubkey) -> Self {
+        self.inner.account_closures.push(pubkey);
+        self
+    }
+
+    pub fn fund_sol(mut self, funding: SolFunding) -> Self {
+        self.inner.sol_fundings.push(funding);
+        self
+    }
+
+    pub fn fund_token(mut self, funding: TokenFunding) -> Self {
+        self.inner.token_fundings.push(funding);
+        self
+    }
+
+    pub fn patch_account_data(mut self, patch: AccountDataPatch) -> Self {
+        self.inner.account_data_patches.push(patch);
+        self
+    }
+
+    pub fn patch_ix_account(mut self, patch: InstructionAccountPatch) -> Self {
+        self.inner.ix_account_patches.push(patch);
+        self
+    }
+
+    pub fn append_ix_account(mut self, append: InstructionAccountAppend) -> Self {
+        self.inner.ix_account_appends.push(append);
+        self
+    }
+
+    pub fn patch_ix_data(mut self, patch: InstructionDataPatch) -> Self {
+        self.inner.ix_data_patches.push(patch);
+        self
+    }
+
+    pub fn build(self) -> Mutations {
+        self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_mutations_are_empty() {
+        let m = Mutations::default();
+        assert!(m.is_empty());
+        assert!(m.account_overrides.is_empty());
+        assert!(m.account_closures.is_empty());
+        assert!(m.sol_fundings.is_empty());
+        assert!(m.token_fundings.is_empty());
+        assert!(m.account_data_patches.is_empty());
+        assert!(m.ix_account_patches.is_empty());
+        assert!(m.ix_account_appends.is_empty());
+        assert!(m.ix_data_patches.is_empty());
+    }
+
+    #[test]
+    fn builder_close_account() {
+        let pk = Pubkey::new_unique();
+        let m = Mutations::builder().close_account(pk).build();
+        assert_eq!(m.account_closures, vec![pk]);
+    }
+
+    #[test]
+    fn builder_fund_sol() {
+        let pk = Pubkey::new_unique();
+        let m = Mutations::builder()
+            .fund_sol(SolFunding { pubkey: pk, amount_lamports: 1_000_000 })
+            .build();
+        assert_eq!(m.sol_fundings.len(), 1);
+        assert_eq!(m.sol_fundings[0].pubkey, pk);
+        assert_eq!(m.sol_fundings[0].amount_lamports, 1_000_000);
+    }
+
+    #[test]
+    fn builder_chains_multiple_types() {
+        let pk1 = Pubkey::new_unique();
+        let pk2 = Pubkey::new_unique();
+        let m = Mutations::builder()
+            .close_account(pk1)
+            .fund_sol(SolFunding { pubkey: pk2, amount_lamports: 500 })
+            .close_account(pk2)
+            .build();
+        assert_eq!(m.account_closures.len(), 2);
+        assert_eq!(m.sol_fundings.len(), 1);
+        assert!(!m.is_empty());
+    }
+}

--- a/crates/sonar-sim/src/mutations.rs
+++ b/crates/sonar-sim/src/mutations.rs
@@ -5,8 +5,8 @@
 use solana_pubkey::Pubkey;
 
 use crate::types::{
-    AccountDataPatch, AccountOverride, InstructionAccountAppend,
-    InstructionAccountPatch, InstructionDataPatch, SolFunding, TokenFunding,
+    AccountDataPatch, AccountOverride, InstructionAccountAppend, InstructionAccountPatch,
+    InstructionDataPatch, SolFunding, TokenFunding,
 };
 
 /// All mutations to apply before simulation execution.

--- a/crates/sonar-sim/src/pipeline.rs
+++ b/crates/sonar-sim/src/pipeline.rs
@@ -1,0 +1,476 @@
+// crates/sonar-sim/src/pipeline.rs
+
+//! Fluent pipeline API for Solana transaction simulation.
+
+use std::sync::Arc;
+
+use solana_transaction::versioned::VersionedTransaction;
+
+use crate::account_loader::AccountLoader;
+use crate::error::{Result, SonarSimError};
+use crate::executor::{
+    ExecutionOptions, PreparedSimulation, SignatureVerification,
+    SimulationOptions, StateMutationOptions,
+};
+use crate::funding::prepare_token_fundings;
+use crate::mutations::Mutations;
+use crate::result::SimulationResult;
+use crate::rpc_provider::RpcAccountProvider;
+use crate::transaction::{
+    ParsedTransaction, apply_ix_account_appends, apply_ix_account_patches,
+    apply_ix_data_patches, parse_raw_transaction,
+};
+use crate::types::{AccountSource, FetchObserver, FetchPolicy, ResolvedAccounts, RpcDecision};
+
+// ── Internal offline policy ──
+
+struct OfflinePolicy;
+
+impl FetchPolicy for OfflinePolicy {
+    fn decide_rpc(&self, _unresolved: &[solana_pubkey::Pubkey]) -> RpcDecision {
+        RpcDecision::Deny
+    }
+}
+
+// ── Parsed state ──
+
+enum ParsedState {
+    Single(ParsedTransaction),
+    Bundle(Vec<ParsedTransaction>),
+}
+
+// ── Pipeline ──
+
+/// Fluent API for configuring and executing Solana transaction simulations.
+///
+/// # Usage
+///
+/// ```ignore
+/// let result = Pipeline::new(rpc_url)
+///     .parse(raw_tx)?
+///     .load_accounts()?
+///     .with_mutations(mutations)
+///     .execute()?;
+/// ```
+pub struct Pipeline {
+    // RPC config
+    rpc_url: Option<String>,
+    provider: Option<Arc<dyn RpcAccountProvider>>,
+    source: Option<Arc<dyn AccountSource>>,
+    observer: Option<Arc<dyn FetchObserver>>,
+    offline: bool,
+
+    // Execution config
+    verify_signatures: bool,
+    slot: Option<u64>,
+    timestamp: Option<i64>,
+
+    // Stage state
+    parsed: Option<ParsedState>,
+    loader: Option<AccountLoader>,
+    resolved: Option<ResolvedAccounts>,
+    mutations: Option<Mutations>,
+}
+
+impl std::fmt::Debug for Pipeline {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Pipeline")
+            .field("rpc_url", &self.rpc_url)
+            .field("offline", &self.offline)
+            .field("verify_signatures", &self.verify_signatures)
+            .field("slot", &self.slot)
+            .field("timestamp", &self.timestamp)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Pipeline {
+    /// Create a new pipeline with the given RPC URL.
+    pub fn new(rpc_url: String) -> Self {
+        Self {
+            rpc_url: Some(rpc_url),
+            provider: None,
+            source: None,
+            observer: None,
+            offline: false,
+            verify_signatures: false,
+            slot: None,
+            timestamp: None,
+            parsed: None,
+            loader: None,
+            resolved: None,
+            mutations: None,
+        }
+    }
+
+    /// Create a pipeline with a custom RPC account provider (useful for testing).
+    pub fn with_provider(provider: Arc<dyn RpcAccountProvider>) -> Self {
+        Self {
+            rpc_url: None,
+            provider: Some(provider),
+            source: None,
+            observer: None,
+            offline: false,
+            verify_signatures: false,
+            slot: None,
+            timestamp: None,
+            parsed: None,
+            loader: None,
+            resolved: None,
+            mutations: None,
+        }
+    }
+
+    // ── Config methods ──
+
+    /// Add a local account source (checked before RPC).
+    pub fn with_source(mut self, source: Arc<dyn AccountSource>) -> Self {
+        self.source = Some(source);
+        self
+    }
+
+    /// Add a fetch observer for progress reporting.
+    pub fn with_observer(mut self, observer: Arc<dyn FetchObserver>) -> Self {
+        self.observer = Some(observer);
+        self
+    }
+
+    /// Enable offline mode (blocks all RPC calls).
+    pub fn offline(mut self, offline: bool) -> Self {
+        self.offline = offline;
+        self
+    }
+
+    /// Enable/disable signature verification (default: disabled).
+    pub fn verify_signatures(mut self, verify: bool) -> Self {
+        self.verify_signatures = verify;
+        self
+    }
+
+    /// Set the SVM slot for simulation.
+    pub fn slot(mut self, slot: u64) -> Self {
+        self.slot = Some(slot);
+        self
+    }
+
+    /// Set the SVM clock timestamp for simulation.
+    pub fn timestamp(mut self, ts: i64) -> Self {
+        self.timestamp = Some(ts);
+        self
+    }
+
+    // ── Parse stage ──
+
+    /// Parse a single raw transaction (base64 or base58 encoded).
+    pub fn parse(mut self, raw_tx: &str) -> Result<Self> {
+        let parsed = parse_raw_transaction(raw_tx)?;
+        self.parsed = Some(ParsedState::Single(parsed));
+        Ok(self)
+    }
+
+    /// Parse multiple raw transactions as a bundle.
+    pub fn parse_bundle(mut self, raw_txs: &[&str]) -> Result<Self> {
+        let mut parsed = Vec::with_capacity(raw_txs.len());
+        for raw in raw_txs {
+            parsed.push(parse_raw_transaction(raw)?);
+        }
+        self.parsed = Some(ParsedState::Bundle(parsed));
+        Ok(self)
+    }
+
+    // ── Accessors ──
+
+    /// Access the parsed transaction (single-tx pipelines only).
+    pub fn parsed(&self) -> Option<&ParsedTransaction> {
+        match &self.parsed {
+            Some(ParsedState::Single(p)) => Some(p),
+            _ => None,
+        }
+    }
+
+    /// Access the resolved accounts (available after `load_accounts()`).
+    pub fn resolved(&self) -> Option<&ResolvedAccounts> {
+        self.resolved.as_ref()
+    }
+
+    // ── Load stage ──
+
+    /// Fetch all accounts referenced by the parsed transaction(s).
+    pub fn load_accounts(mut self) -> Result<Self> {
+        let parsed = self.parsed.as_ref().ok_or(SonarSimError::Validation {
+            reason: "parse() must be called before load_accounts()".into(),
+        })?;
+
+        let mut loader = if let Some(provider) = self.provider.clone() {
+            AccountLoader::with_provider(provider)
+        } else {
+            AccountLoader::new(
+                self.rpc_url
+                    .clone()
+                    .ok_or(SonarSimError::Validation {
+                        reason: "Pipeline requires either an RPC URL or a custom provider".into(),
+                    })?,
+            )?
+        };
+
+        if let Some(source) = &self.source {
+            loader = loader.with_source(source.clone());
+        }
+        if self.offline {
+            loader = loader.with_policy(Arc::new(OfflinePolicy));
+        }
+        if let Some(observer) = &self.observer {
+            loader = loader.with_observer(observer.clone());
+        }
+
+        let resolved = match parsed {
+            ParsedState::Single(p) => loader.load_for_transaction(&p.transaction)?,
+            ParsedState::Bundle(txs) => {
+                let refs: Vec<&VersionedTransaction> =
+                    txs.iter().map(|t| &t.transaction).collect();
+                loader.load_for_transactions(&refs)?
+            }
+        };
+
+        self.loader = Some(loader);
+        self.resolved = Some(resolved);
+        Ok(self)
+    }
+
+    // ── Mutations ──
+
+    /// Set mutations to apply before execution.
+    pub fn with_mutations(mut self, mutations: Mutations) -> Self {
+        self.mutations = Some(mutations);
+        self
+    }
+
+    // ── Execute stage ──
+
+    /// Execute a single transaction simulation.
+    pub fn execute(mut self) -> Result<SimulationResult> {
+        let parsed_state = self.parsed.take().ok_or(SonarSimError::Validation {
+            reason: "parse() must be called before execute()".into(),
+        })?;
+        let resolved = self.resolved.take().ok_or(SonarSimError::Validation {
+            reason: "load_accounts() must be called before execute()".into(),
+        })?;
+        let mut loader = self.loader.take().ok_or(SonarSimError::Validation {
+            reason: "load_accounts() must be called before execute()".into(),
+        })?;
+
+        let parsed = match parsed_state {
+            ParsedState::Single(p) => p,
+            ParsedState::Bundle(_) => {
+                return Err(SonarSimError::Validation {
+                    reason: "use execute_bundle() for bundle pipelines".into(),
+                });
+            }
+        };
+
+        let mutations = self.mutations.take().unwrap_or_default();
+        self.execute_inner(parsed.transaction, mutations, resolved, &mut loader)
+    }
+
+    /// Execute a bundle of transactions sequentially.
+    pub fn execute_bundle(mut self) -> Result<Vec<SimulationResult>> {
+        let parsed_state = self.parsed.take().ok_or(SonarSimError::Validation {
+            reason: "parse_bundle() must be called before execute_bundle()".into(),
+        })?;
+        let resolved = self.resolved.take().ok_or(SonarSimError::Validation {
+            reason: "load_accounts() must be called before execute_bundle()".into(),
+        })?;
+        let mut loader = self.loader.take().ok_or(SonarSimError::Validation {
+            reason: "load_accounts() must be called before execute_bundle()".into(),
+        })?;
+
+        let parsed_txs = match parsed_state {
+            ParsedState::Bundle(txs) => txs,
+            ParsedState::Single(_) => {
+                return Err(SonarSimError::Validation {
+                    reason: "use execute() for single-tx pipelines".into(),
+                });
+            }
+        };
+
+        let mutations = self.mutations.unwrap_or_default();
+
+        // Clone and mutate all transactions
+        let mut txs: Vec<VersionedTransaction> = Vec::with_capacity(parsed_txs.len());
+        for parsed in &parsed_txs {
+            let mut tx = parsed.transaction.clone();
+            if !mutations.ix_account_patches.is_empty() {
+                apply_ix_account_patches(&mut tx, &mutations.ix_account_patches)?;
+            }
+            if !mutations.ix_account_appends.is_empty() {
+                apply_ix_account_appends(&mut tx, &mutations.ix_account_appends)?;
+            }
+            if !mutations.ix_data_patches.is_empty() {
+                apply_ix_data_patches(&mut tx, &mutations.ix_data_patches)?;
+            }
+            txs.push(tx);
+        }
+
+        // Prepare token fundings
+        let prepared_fundings = if !mutations.token_fundings.is_empty() {
+            prepare_token_fundings(&mut loader, &resolved, &mutations.token_fundings)?
+        } else {
+            vec![]
+        };
+
+        // Build simulation options
+        let sim_opts = SimulationOptions {
+            execution: ExecutionOptions {
+                signature_verification: SignatureVerification::from(self.verify_signatures),
+                slot: self.slot,
+                timestamp: self.timestamp,
+            },
+            mutations: StateMutationOptions {
+                account_closures: mutations.account_closures,
+                overrides: mutations.account_overrides,
+                sol_fundings: mutations.sol_fundings,
+                token_fundings: prepared_fundings,
+                data_patches: mutations.account_data_patches,
+            },
+        };
+
+        let prepared = PreparedSimulation::prepare(resolved, sim_opts)?;
+        let mut runner = prepared.into_runner();
+
+        let tx_refs: Vec<&VersionedTransaction> = txs.iter().collect();
+        let exec_results = runner.execute_bundle(&tx_refs);
+
+        exec_results
+            .into_iter()
+            .map(|r| r.map(SimulationResult::from_execution))
+            .collect()
+    }
+
+    // ── Private helpers ──
+
+    fn execute_inner(
+        &self,
+        transaction: VersionedTransaction,
+        mutations: Mutations,
+        resolved: ResolvedAccounts,
+        loader: &mut AccountLoader,
+    ) -> Result<SimulationResult> {
+        let mut tx = transaction;
+
+        // Apply transaction-level mutations
+        if !mutations.ix_account_patches.is_empty() {
+            apply_ix_account_patches(&mut tx, &mutations.ix_account_patches)?;
+        }
+        if !mutations.ix_account_appends.is_empty() {
+            apply_ix_account_appends(&mut tx, &mutations.ix_account_appends)?;
+        }
+        if !mutations.ix_data_patches.is_empty() {
+            apply_ix_data_patches(&mut tx, &mutations.ix_data_patches)?;
+        }
+
+        // Prepare token fundings
+        let prepared_fundings = if !mutations.token_fundings.is_empty() {
+            prepare_token_fundings(loader, &resolved, &mutations.token_fundings)?
+        } else {
+            vec![]
+        };
+
+        // Build simulation options
+        let sim_opts = SimulationOptions {
+            execution: ExecutionOptions {
+                signature_verification: SignatureVerification::from(self.verify_signatures),
+                slot: self.slot,
+                timestamp: self.timestamp,
+            },
+            mutations: StateMutationOptions {
+                account_closures: mutations.account_closures,
+                overrides: mutations.account_overrides,
+                sol_fundings: mutations.sol_fundings,
+                token_fundings: prepared_fundings,
+                data_patches: mutations.account_data_patches,
+            },
+        };
+
+        let prepared = PreparedSimulation::prepare(resolved, sim_opts)?;
+        let mut runner = prepared.into_runner();
+        let exec_result = runner.execute(&tx)?;
+
+        Ok(SimulationResult::from_execution(exec_result))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Base64-encoded SOL transfer transaction (deterministic: payer=[1;32], recipient=[2;32])
+    const TEST_TX_BASE64: &str = "AYXl4tu2q/qsjwA+woUaYKC+uPuAozXJHsgxsZLux/8uXuN2z8P1tLt0wHkQImIfxXBjg3dT8ryk8D5BA6g+/QABAAEDiojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1wCAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAgIAAQwCAAAAgJaYAAAAAAA=";
+
+    #[test]
+    fn execute_before_parse_returns_validation_error() {
+        let pipeline = Pipeline::new("http://localhost:8899".into());
+        let result = pipeline.execute();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, SonarSimError::Validation { .. }));
+    }
+
+    #[test]
+    fn execute_before_load_returns_validation_error() {
+        let pipeline = Pipeline::new("http://localhost:8899".into())
+            .parse(TEST_TX_BASE64).unwrap();
+        let result = pipeline.execute();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, SonarSimError::Validation { .. }));
+    }
+
+    #[test]
+    fn load_before_parse_returns_validation_error() {
+        let pipeline = Pipeline::new("http://localhost:8899".into());
+        let result = pipeline.load_accounts();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, SonarSimError::Validation { .. }));
+    }
+
+    #[test]
+    fn parse_stores_transaction() {
+        let pipeline = Pipeline::new("http://localhost:8899".into())
+            .parse(TEST_TX_BASE64).unwrap();
+        assert!(pipeline.parsed().is_some());
+    }
+
+    #[test]
+    fn execute_bundle_on_single_returns_error() {
+        let pipeline = Pipeline::new("http://localhost:8899".into())
+            .parse(TEST_TX_BASE64).unwrap();
+        let result = pipeline.execute_bundle();
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), SonarSimError::Validation { .. }));
+    }
+
+    #[test]
+    fn execute_on_bundle_returns_error() {
+        let pipeline = Pipeline::new("http://localhost:8899".into())
+            .parse_bundle(&[TEST_TX_BASE64, TEST_TX_BASE64]).unwrap();
+        let result = pipeline.execute();
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), SonarSimError::Validation { .. }));
+    }
+
+    #[test]
+    fn parsed_returns_none_for_bundle() {
+        let pipeline = Pipeline::new("http://localhost:8899".into())
+            .parse_bundle(&[TEST_TX_BASE64]).unwrap();
+        assert!(pipeline.parsed().is_none());
+    }
+
+    #[test]
+    fn resolved_returns_none_before_load() {
+        let pipeline = Pipeline::new("http://localhost:8899".into())
+            .parse(TEST_TX_BASE64).unwrap();
+        assert!(pipeline.resolved().is_none());
+    }
+
+}

--- a/crates/sonar-sim/src/pipeline.rs
+++ b/crates/sonar-sim/src/pipeline.rs
@@ -332,10 +332,14 @@ impl Pipeline {
         let bundle = runner.execute_bundle(&tx_refs);
 
         // Map inner ExecutionResults to SimulationResults
-        let mapped =
-            bundle.executed.into_iter().map(|r| r.map(SimulationResult::from_execution)).collect();
+        let total = bundle.total();
+        let mapped = bundle
+            .into_executed()
+            .into_iter()
+            .map(|r| r.map(SimulationResult::from_execution))
+            .collect();
 
-        Ok(BundleResult { executed: mapped, total: bundle.total })
+        Ok(BundleResult::new(mapped, total))
     }
 
     // ── Private helpers ──
@@ -442,12 +446,13 @@ mod tests {
     #[test]
     fn bundle_result_skipped_and_complete() {
         let br: crate::executor::BundleResult<std::result::Result<(), String>> =
-            crate::executor::BundleResult { executed: vec![], total: 5 };
+            crate::executor::BundleResult::new(vec![], 5);
         assert_eq!(br.skipped_count(), 5);
         assert!(!br.is_complete());
+        assert_eq!(br.total(), 5);
+        assert!(br.executed().is_empty());
 
-        let br_full =
-            crate::executor::BundleResult { executed: vec![Ok::<_, String>(())], total: 1 };
+        let br_full = crate::executor::BundleResult::new(vec![Ok::<_, String>(())], 1);
         assert_eq!(br_full.skipped_count(), 0);
         assert!(br_full.is_complete());
     }

--- a/crates/sonar-sim/src/pipeline.rs
+++ b/crates/sonar-sim/src/pipeline.rs
@@ -8,17 +8,18 @@ use solana_transaction::versioned::VersionedTransaction;
 
 use crate::account_loader::AccountLoader;
 use crate::error::{Result, SonarSimError};
+use crate::executor::BundleResult;
 use crate::executor::{
-    ExecutionOptions, PreparedSimulation, SignatureVerification,
-    SimulationOptions, StateMutationOptions,
+    ExecutionOptions, PreparedSimulation, SignatureVerification, SimulationOptions,
+    StateMutationOptions,
 };
 use crate::funding::prepare_token_fundings;
 use crate::mutations::Mutations;
 use crate::result::SimulationResult;
 use crate::rpc_provider::RpcAccountProvider;
 use crate::transaction::{
-    ParsedTransaction, apply_ix_account_appends, apply_ix_account_patches,
-    apply_ix_data_patches, parse_raw_transaction,
+    ParsedTransaction, apply_ix_account_appends, apply_ix_account_patches, apply_ix_data_patches,
+    parse_raw_transaction,
 };
 use crate::types::{AccountSource, FetchObserver, FetchPolicy, ResolvedAccounts, RpcDecision};
 
@@ -85,10 +86,9 @@ impl std::fmt::Debug for Pipeline {
 }
 
 impl Pipeline {
-    /// Create a new pipeline with the given RPC URL.
-    pub fn new(rpc_url: String) -> Self {
+    fn default_state() -> Self {
         Self {
-            rpc_url: Some(rpc_url),
+            rpc_url: None,
             provider: None,
             source: None,
             observer: None,
@@ -103,22 +103,14 @@ impl Pipeline {
         }
     }
 
+    /// Create a new pipeline with the given RPC URL.
+    pub fn new(rpc_url: String) -> Self {
+        Self { rpc_url: Some(rpc_url), ..Self::default_state() }
+    }
+
     /// Create a pipeline with a custom RPC account provider (useful for testing).
     pub fn with_provider(provider: Arc<dyn RpcAccountProvider>) -> Self {
-        Self {
-            rpc_url: None,
-            provider: Some(provider),
-            source: None,
-            observer: None,
-            offline: false,
-            verify_signatures: false,
-            slot: None,
-            timestamp: None,
-            parsed: None,
-            loader: None,
-            resolved: None,
-            mutations: None,
-        }
+        Self { provider: Some(provider), ..Self::default_state() }
     }
 
     // ── Config methods ──
@@ -204,13 +196,9 @@ impl Pipeline {
         let mut loader = if let Some(provider) = self.provider.clone() {
             AccountLoader::with_provider(provider)
         } else {
-            AccountLoader::new(
-                self.rpc_url
-                    .clone()
-                    .ok_or(SonarSimError::Validation {
-                        reason: "Pipeline requires either an RPC URL or a custom provider".into(),
-                    })?,
-            )?
+            AccountLoader::new(self.rpc_url.clone().ok_or(SonarSimError::Validation {
+                reason: "Pipeline requires either an RPC URL or a custom provider".into(),
+            })?)?
         };
 
         if let Some(source) = &self.source {
@@ -226,8 +214,7 @@ impl Pipeline {
         let resolved = match parsed {
             ParsedState::Single(p) => loader.load_for_transaction(&p.transaction)?,
             ParsedState::Bundle(txs) => {
-                let refs: Vec<&VersionedTransaction> =
-                    txs.iter().map(|t| &t.transaction).collect();
+                let refs: Vec<&VersionedTransaction> = txs.iter().map(|t| &t.transaction).collect();
                 loader.load_for_transactions(&refs)?
             }
         };
@@ -273,7 +260,11 @@ impl Pipeline {
     }
 
     /// Execute a bundle of transactions sequentially.
-    pub fn execute_bundle(mut self) -> Result<Vec<SimulationResult>> {
+    ///
+    /// Returns a [`BundleResult`] containing results for all executed
+    /// transactions and the total count. Check [`BundleResult::skipped_count`]
+    /// to detect transactions that were never attempted due to a prior failure.
+    pub fn execute_bundle(mut self) -> Result<BundleResult<Result<SimulationResult>>> {
         let parsed_state = self.parsed.take().ok_or(SonarSimError::Validation {
             reason: "parse_bundle() must be called before execute_bundle()".into(),
         })?;
@@ -338,12 +329,13 @@ impl Pipeline {
         let mut runner = prepared.into_runner();
 
         let tx_refs: Vec<&VersionedTransaction> = txs.iter().collect();
-        let exec_results = runner.execute_bundle(&tx_refs);
+        let bundle = runner.execute_bundle(&tx_refs);
 
-        exec_results
-            .into_iter()
-            .map(|r| r.map(SimulationResult::from_execution))
-            .collect()
+        // Map inner ExecutionResults to SimulationResults
+        let mapped =
+            bundle.executed.into_iter().map(|r| r.map(SimulationResult::from_execution)).collect();
+
+        Ok(BundleResult { executed: mapped, total: bundle.total })
     }
 
     // ── Private helpers ──
@@ -417,8 +409,7 @@ mod tests {
 
     #[test]
     fn execute_before_load_returns_validation_error() {
-        let pipeline = Pipeline::new("http://localhost:8899".into())
-            .parse(TEST_TX_BASE64).unwrap();
+        let pipeline = Pipeline::new("http://localhost:8899".into()).parse(TEST_TX_BASE64).unwrap();
         let result = pipeline.execute();
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -436,24 +427,36 @@ mod tests {
 
     #[test]
     fn parse_stores_transaction() {
-        let pipeline = Pipeline::new("http://localhost:8899".into())
-            .parse(TEST_TX_BASE64).unwrap();
+        let pipeline = Pipeline::new("http://localhost:8899".into()).parse(TEST_TX_BASE64).unwrap();
         assert!(pipeline.parsed().is_some());
     }
 
     #[test]
     fn execute_bundle_on_single_returns_error() {
-        let pipeline = Pipeline::new("http://localhost:8899".into())
-            .parse(TEST_TX_BASE64).unwrap();
+        let pipeline = Pipeline::new("http://localhost:8899".into()).parse(TEST_TX_BASE64).unwrap();
         let result = pipeline.execute_bundle();
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), SonarSimError::Validation { .. }));
     }
 
     #[test]
+    fn bundle_result_skipped_and_complete() {
+        let br: crate::executor::BundleResult<std::result::Result<(), String>> =
+            crate::executor::BundleResult { executed: vec![], total: 5 };
+        assert_eq!(br.skipped_count(), 5);
+        assert!(!br.is_complete());
+
+        let br_full =
+            crate::executor::BundleResult { executed: vec![Ok::<_, String>(())], total: 1 };
+        assert_eq!(br_full.skipped_count(), 0);
+        assert!(br_full.is_complete());
+    }
+
+    #[test]
     fn execute_on_bundle_returns_error() {
         let pipeline = Pipeline::new("http://localhost:8899".into())
-            .parse_bundle(&[TEST_TX_BASE64, TEST_TX_BASE64]).unwrap();
+            .parse_bundle(&[TEST_TX_BASE64, TEST_TX_BASE64])
+            .unwrap();
         let result = pipeline.execute();
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), SonarSimError::Validation { .. }));
@@ -461,16 +464,14 @@ mod tests {
 
     #[test]
     fn parsed_returns_none_for_bundle() {
-        let pipeline = Pipeline::new("http://localhost:8899".into())
-            .parse_bundle(&[TEST_TX_BASE64]).unwrap();
+        let pipeline =
+            Pipeline::new("http://localhost:8899".into()).parse_bundle(&[TEST_TX_BASE64]).unwrap();
         assert!(pipeline.parsed().is_none());
     }
 
     #[test]
     fn resolved_returns_none_before_load() {
-        let pipeline = Pipeline::new("http://localhost:8899".into())
-            .parse(TEST_TX_BASE64).unwrap();
+        let pipeline = Pipeline::new("http://localhost:8899".into()).parse(TEST_TX_BASE64).unwrap();
         assert!(pipeline.resolved().is_none());
     }
-
 }

--- a/crates/sonar-sim/src/result.rs
+++ b/crates/sonar-sim/src/result.rs
@@ -37,8 +37,7 @@ impl SimulationResult {
     pub(crate) fn from_execution(exec: ExecutionResult) -> Self {
         // Compute balance changes from pre/post snapshots
         let sol_changes = compute_sol_changes(&exec.pre_accounts, &exec.post_accounts);
-        let mint_decimals =
-            extract_mint_decimals_combined(&exec.pre_accounts, &exec.post_accounts);
+        let mint_decimals = extract_mint_decimals_combined(&exec.pre_accounts, &exec.post_accounts);
         let token_changes =
             compute_token_changes(&exec.pre_accounts, &exec.post_accounts, &mint_decimals);
 
@@ -50,10 +49,7 @@ impl SimulationResult {
         let return_data = if exec.meta.return_data.data.is_empty() {
             None
         } else {
-            Some((
-                exec.meta.return_data.program_id.to_string(),
-                exec.meta.return_data.data,
-            ))
+            Some((exec.meta.return_data.program_id.to_string(), exec.meta.return_data.data))
         };
 
         Self {

--- a/crates/sonar-sim/src/result.rs
+++ b/crates/sonar-sim/src/result.rs
@@ -1,0 +1,70 @@
+// crates/sonar-sim/src/result.rs
+
+//! Public simulation result types with auto-computed balance changes.
+
+use solana_message::inner_instruction::InnerInstructionsList;
+
+pub use crate::balance_changes::{SolBalanceChange, TokenBalanceChange};
+use crate::balance_changes::{
+    compute_sol_changes, compute_token_changes, extract_mint_decimals_combined,
+};
+use crate::executor::{ExecutionResult, ExecutionStatus};
+
+/// Result of a single transaction simulation.
+///
+/// Balance changes are computed automatically from pre/post account snapshots.
+#[derive(Debug, Clone)]
+pub struct SimulationResult {
+    /// Whether the transaction executed successfully.
+    pub success: bool,
+    /// Error message if the transaction failed.
+    pub error: Option<String>,
+    /// Transaction execution logs.
+    pub logs: Vec<String>,
+    /// Compute units consumed.
+    pub compute_units: u64,
+    /// Return data as `(program_id, data)`, if any.
+    pub return_data: Option<(String, Vec<u8>)>,
+    /// Inner instructions emitted during execution.
+    pub inner_instructions: InnerInstructionsList,
+    /// SOL balance changes (sorted by absolute magnitude).
+    pub sol_changes: Vec<SolBalanceChange>,
+    /// Token balance changes (sorted by absolute magnitude).
+    pub token_changes: Vec<TokenBalanceChange>,
+}
+
+impl SimulationResult {
+    pub(crate) fn from_execution(exec: ExecutionResult) -> Self {
+        // Compute balance changes from pre/post snapshots
+        let sol_changes = compute_sol_changes(&exec.pre_accounts, &exec.post_accounts);
+        let mint_decimals =
+            extract_mint_decimals_combined(&exec.pre_accounts, &exec.post_accounts);
+        let token_changes =
+            compute_token_changes(&exec.pre_accounts, &exec.post_accounts, &mint_decimals);
+
+        let (success, error) = match exec.status {
+            ExecutionStatus::Succeeded => (true, None),
+            ExecutionStatus::Failed(e) => (false, Some(e)),
+        };
+
+        let return_data = if exec.meta.return_data.data.is_empty() {
+            None
+        } else {
+            Some((
+                exec.meta.return_data.program_id.to_string(),
+                exec.meta.return_data.data,
+            ))
+        };
+
+        Self {
+            success,
+            error,
+            logs: exec.meta.logs,
+            compute_units: exec.meta.compute_units_consumed,
+            return_data,
+            inner_instructions: exec.meta.inner_instructions,
+            sol_changes,
+            token_changes,
+        }
+    }
+}

--- a/crates/sonar-sim/src/svm_backend.rs
+++ b/crates/sonar-sim/src/svm_backend.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use litesvm::LiteSVM;
 use litesvm::types::TransactionResult;
-use solana_account::Account;
+use solana_account::{Account, AccountSharedData};
 use solana_pubkey::Pubkey;
 use solana_transaction::versioned::VersionedTransaction;
 
@@ -10,9 +10,15 @@ use solana_transaction::versioned::VersionedTransaction;
 /// Minimal simulation backend abstraction.
 ///
 /// This decouples executor/funding logic from a concrete SVM implementation.
+/// The trait uses `AccountSharedData` throughout; the `Account` ↔ `AccountSharedData`
+/// conversion is isolated to the LiteSVM implementation below.
 pub trait SvmBackend {
-    fn set_account(&mut self, pubkey: Pubkey, account: Account) -> std::result::Result<(), String>;
-    fn get_account(&self, pubkey: &Pubkey) -> Option<Account>;
+    fn set_account(
+        &mut self,
+        pubkey: Pubkey,
+        account: AccountSharedData,
+    ) -> std::result::Result<(), String>;
+    fn get_account(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
     fn add_program_from_file(
         &mut self,
         program_id: Pubkey,
@@ -23,12 +29,17 @@ pub trait SvmBackend {
 }
 
 impl SvmBackend for LiteSVM {
-    fn set_account(&mut self, pubkey: Pubkey, account: Account) -> std::result::Result<(), String> {
+    fn set_account(
+        &mut self,
+        pubkey: Pubkey,
+        account: AccountSharedData,
+    ) -> std::result::Result<(), String> {
+        let account: Account = account.into();
         LiteSVM::set_account(self, pubkey, account).map_err(|e| e.to_string())
     }
 
-    fn get_account(&self, pubkey: &Pubkey) -> Option<Account> {
-        LiteSVM::get_account(self, pubkey)
+    fn get_account(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
+        LiteSVM::get_account(self, pubkey).map(|a| a.into())
     }
 
     fn add_program_from_file(

--- a/crates/sonar-sim/src/test_utils.rs
+++ b/crates/sonar-sim/src/test_utils.rs
@@ -15,7 +15,6 @@ use solana_transaction::Transaction;
 use solana_transaction::versioned::VersionedTransaction;
 use spl_token::solana_program::program_option::COption;
 use spl_token::solana_program::program_pack::Pack;
-use spl_token::solana_program::pubkey::Pubkey as ProgramPubkey;
 use spl_token::state::{Account as SplAccount, AccountState};
 
 use crate::svm_backend::SvmBackend;
@@ -43,8 +42,8 @@ pub(crate) fn create_transfer_tx(
 
 pub(crate) fn make_token_account_data(mint: &Pubkey, token_owner: &Pubkey, amount: u64) -> Vec<u8> {
     let state = SplAccount {
-        mint: ProgramPubkey::new_from_array(mint.to_bytes()),
-        owner: ProgramPubkey::new_from_array(token_owner.to_bytes()),
+        mint: crate::token_decode::to_program_pubkey(mint),
+        owner: crate::token_decode::to_program_pubkey(token_owner),
         amount,
         delegate: COption::None,
         state: AccountState::Initialized,
@@ -71,7 +70,7 @@ pub(crate) fn make_token_account_shared_with(
     AccountSharedData::from(Account {
         lamports: 1,
         data,
-        owner: spl_token::ID,
+        owner: crate::token_decode::to_pubkey(&spl_token::ID),
         executable: false,
         rent_epoch: 0,
     })
@@ -80,7 +79,7 @@ pub(crate) fn make_token_account_shared_with(
 /// In-memory SVM backend for testing executor pipeline functions
 /// without spinning up a real LiteSVM instance.
 pub(crate) struct MockSvm {
-    pub accounts: HashMap<Pubkey, Account>,
+    pub accounts: HashMap<Pubkey, AccountSharedData>,
     pub slot: u64,
     /// When set, `set_account` returns this error string.
     pub fail_set_account: Option<String>,
@@ -99,13 +98,17 @@ impl MockSvm {
     }
 
     pub fn with_account(mut self, pubkey: Pubkey, account: Account) -> Self {
-        self.accounts.insert(pubkey, account);
+        self.accounts.insert(pubkey, AccountSharedData::from(account));
         self
     }
 }
 
 impl SvmBackend for MockSvm {
-    fn set_account(&mut self, pubkey: Pubkey, account: Account) -> std::result::Result<(), String> {
+    fn set_account(
+        &mut self,
+        pubkey: Pubkey,
+        account: AccountSharedData,
+    ) -> std::result::Result<(), String> {
         if let Some(ref msg) = self.fail_set_account {
             return Err(msg.clone());
         }
@@ -113,7 +116,7 @@ impl SvmBackend for MockSvm {
         Ok(())
     }
 
-    fn get_account(&self, pubkey: &Pubkey) -> Option<Account> {
+    fn get_account(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
         self.accounts.get(pubkey).cloned()
     }
 

--- a/crates/sonar-sim/src/token_decode.rs
+++ b/crates/sonar-sim/src/token_decode.rs
@@ -15,6 +15,24 @@ use spl_token::state::{Account as SplTokenAccount, Mint as SplMint};
 
 use crate::error::{Result, SonarSimError};
 
+// ── Pubkey conversion helpers ──
+//
+// SPL Token crates re-export `solana_program::pubkey::Pubkey` which is a
+// different type than `solana_pubkey::Pubkey` (same layout, different crate).
+// These helpers bridge the gap without the noisy `new_from_array(..to_bytes())`.
+
+/// Convert from SPL's `Pubkey` to `solana_pubkey::Pubkey`.
+#[inline]
+pub(crate) fn to_pubkey(p: &spl_token::solana_program::pubkey::Pubkey) -> Pubkey {
+    Pubkey::new_from_array(p.to_bytes())
+}
+
+/// Convert from `solana_pubkey::Pubkey` to SPL's `Pubkey`.
+#[inline]
+pub(crate) fn to_program_pubkey(p: &Pubkey) -> spl_token::solana_program::pubkey::Pubkey {
+    spl_token::solana_program::pubkey::Pubkey::new_from_array(p.to_bytes())
+}
+
 // ── Program identification ──
 
 /// Known SPL-compatible token programs.
@@ -57,11 +75,11 @@ impl fmt::Display for TokenProgramKind {
 }
 
 pub(crate) fn legacy_program_id() -> Pubkey {
-    Pubkey::new_from_array(spl_token::ID.to_bytes())
+    to_pubkey(&spl_token::ID)
 }
 
 pub(crate) fn token2022_program_id() -> Pubkey {
-    Pubkey::new_from_array(spl_token_2022::ID.to_bytes())
+    to_pubkey(&spl_token_2022::ID)
 }
 
 // ── Mint decimals ──
@@ -139,8 +157,8 @@ pub fn try_decode_token_account(
     }
     let parsed = SplTokenAccount::unpack(&data[..SplTokenAccount::LEN]).ok()?;
     Some(DecodedTokenAccount {
-        mint: Pubkey::new_from_array(parsed.mint.to_bytes()),
-        owner: Pubkey::new_from_array(parsed.owner.to_bytes()),
+        mint: to_pubkey(&parsed.mint),
+        owner: to_pubkey(&parsed.owner),
         amount: parsed.amount,
     })
 }
@@ -158,10 +176,11 @@ pub(crate) fn ensure_same_program(
     kind: TokenProgramKind,
     owner: &Pubkey,
     label: &str,
+    account: Pubkey,
 ) -> Result<()> {
     if owner != &kind.program_id() {
         return Err(SonarSimError::Token {
-            account: None,
+            account: Some(account),
             reason: format!("Provided {label} is not owned by {}", kind.program_name()),
         });
     }

--- a/crates/sonar-sim/src/token_decode.rs
+++ b/crates/sonar-sim/src/token_decode.rs
@@ -71,7 +71,7 @@ pub(crate) fn token2022_program_id() -> Pubkey {
 /// Returns an error when the account is not owned by a known token program
 /// or the data is malformed.  Both legacy and Token-2022 mints share the
 /// same base layout so a single unpack path handles both.
-pub(crate) fn read_mint_decimals(account: &impl ReadableAccount) -> Result<u8> {
+pub fn read_mint_decimals(account: &impl ReadableAccount) -> Result<u8> {
     if TokenProgramKind::from_owner(account.owner()).is_none() {
         return Err(SonarSimError::Token {
             account: None,
@@ -118,7 +118,7 @@ pub(crate) fn try_read_mint_decimals(data: &[u8], owner: &Pubkey) -> Option<u8> 
 
 /// Decoded fields from an SPL token account (works for both legacy and 2022).
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct DecodedTokenAccount {
+pub struct DecodedTokenAccount {
     pub mint: Pubkey,
     pub owner: Pubkey,
     pub amount: u64,
@@ -129,7 +129,7 @@ pub(crate) struct DecodedTokenAccount {
 /// Returns `None` when the owner is not a known token program or the data
 /// cannot be parsed.  The first 165 bytes are identical across legacy and
 /// Token-2022, so a single unpack path handles both.
-pub(crate) fn try_decode_token_account(
+pub fn try_decode_token_account(
     data: &[u8],
     program_owner: &Pubkey,
 ) -> Option<DecodedTokenAccount> {

--- a/crates/sonar-sim/src/traits.rs
+++ b/crates/sonar-sim/src/traits.rs
@@ -1,0 +1,3 @@
+//! Stable extension traits for customising the simulation pipeline.
+
+pub use crate::types::{AccountSource, FetchEvent, FetchObserver};

--- a/crates/sonar-sim/src/traits.rs
+++ b/crates/sonar-sim/src/traits.rs
@@ -1,3 +1,0 @@
-//! Stable extension traits for customising the simulation pipeline.
-
-pub use crate::types::{AccountSource, FetchEvent, FetchObserver};

--- a/src/cli/simulate.rs
+++ b/src/cli/simulate.rs
@@ -186,7 +186,7 @@ pub struct TransactionInputArgs {
     pub tx: Vec<String>,
 }
 
-pub use sonar_sim::{
+pub use sonar_sim::internals::{
     AccountDataPatch, AccountOverride, InstructionAccountAppend, InstructionAccountPatch,
     InstructionDataPatch, SolFunding, TokenAmount, TokenFunding,
 };

--- a/src/core/account_file.rs
+++ b/src/core/account_file.rs
@@ -13,7 +13,7 @@ use solana_sdk_ids::system_program;
 use solana_slot_hashes::SlotHashes;
 use solana_sysvar_id::SysvarId;
 
-use sonar_sim::ResolvedAccounts;
+use sonar_sim::internals::ResolvedAccounts;
 
 /// JSON structure for deserializing an account file (flat format).
 /// Supports the simple `{ "lamports": ..., "data": ... }` format.
@@ -148,13 +148,13 @@ pub(crate) fn dump_accounts_to_dir(
     let mut dumped_keys = HashSet::new();
 
     for (pubkey, account) in accounts {
-        if sonar_sim::is_native_or_sysvar(pubkey)
+        if sonar_sim::internals::is_native_or_sysvar(pubkey)
             && *pubkey != Clock::id()
             && *pubkey != SlotHashes::id()
         {
             continue;
         }
-        if sonar_sim::is_litesvm_builtin_program(pubkey) {
+        if sonar_sim::internals::is_litesvm_builtin_program(pubkey) {
             continue;
         }
 
@@ -171,8 +171,8 @@ pub(crate) fn dump_accounts_to_dir(
 
     for pubkey in required_keys {
         if dumped_keys.contains(&pubkey)
-            || sonar_sim::is_native_or_sysvar(&pubkey)
-            || sonar_sim::is_litesvm_builtin_program(&pubkey)
+            || sonar_sim::internals::is_native_or_sysvar(&pubkey)
+            || sonar_sim::internals::is_litesvm_builtin_program(&pubkey)
         {
             continue;
         }
@@ -221,7 +221,7 @@ mod tests {
     use std::path::PathBuf;
 
     use solana_account::AccountSharedData;
-    use sonar_sim::ResolvedLookup;
+    use sonar_sim::internals::ResolvedLookup;
 
     #[test]
     fn dump_accounts_writes_lookup_placeholders_for_missing_accounts() {

--- a/src/core/account_loader.rs
+++ b/src/core/account_loader.rs
@@ -5,7 +5,7 @@ use log::debug;
 use solana_account::AccountSharedData;
 use solana_pubkey::Pubkey;
 
-use sonar_sim::AccountLoader;
+use sonar_sim::internals::AccountLoader;
 
 use crate::core::idl_fetcher::IdlFetcher;
 use crate::utils::progress::Progress;
@@ -21,7 +21,7 @@ impl LocalDirSource {
     }
 }
 
-impl sonar_sim::AccountSource for LocalDirSource {
+impl sonar_sim::internals::AccountSource for LocalDirSource {
     fn resolve(&self, pubkeys: &[Pubkey]) -> sonar_sim::Result<HashMap<Pubkey, AccountSharedData>> {
         let mut found = HashMap::new();
         for key in pubkeys {
@@ -48,9 +48,9 @@ impl sonar_sim::AccountSource for LocalDirSource {
 /// Policy that denies RPC for all unresolved accounts.
 pub struct OfflinePolicy;
 
-impl sonar_sim::FetchPolicy for OfflinePolicy {
-    fn decide_rpc(&self, _unresolved: &[Pubkey]) -> sonar_sim::RpcDecision {
-        sonar_sim::RpcDecision::Deny
+impl sonar_sim::internals::FetchPolicy for OfflinePolicy {
+    fn decide_rpc(&self, _unresolved: &[Pubkey]) -> sonar_sim::internals::RpcDecision {
+        sonar_sim::internals::RpcDecision::Deny
     }
 }
 
@@ -65,9 +65,9 @@ impl CliProgressObserver {
     }
 }
 
-impl sonar_sim::FetchObserver for CliProgressObserver {
-    fn on_event(&self, event: &sonar_sim::FetchEvent) {
-        if let sonar_sim::FetchEvent::RpcProgress { pubkey, current, total } = event {
+impl sonar_sim::internals::FetchObserver for CliProgressObserver {
+    fn on_event(&self, event: &sonar_sim::internals::FetchEvent) {
+        if let sonar_sim::internals::FetchEvent::RpcProgress { pubkey, current, total } = event {
             self.progress
                 .set_message(format!("loading account {} ({}/{})", pubkey, current, total));
         }
@@ -77,13 +77,14 @@ impl sonar_sim::FetchObserver for CliProgressObserver {
 /// Observer that reports unresolved accounts when RPC is skipped by policy.
 pub struct OfflineWarningObserver;
 
-impl sonar_sim::FetchObserver for OfflineWarningObserver {
-    fn on_event(&self, event: &sonar_sim::FetchEvent) {
-        if let sonar_sim::FetchEvent::RpcSkippedByPolicy { missing } = event {
+impl sonar_sim::internals::FetchObserver for OfflineWarningObserver {
+    fn on_event(&self, event: &sonar_sim::internals::FetchEvent) {
+        if let sonar_sim::internals::FetchEvent::RpcSkippedByPolicy { missing } = event {
             let non_native: Vec<_> = missing
                 .iter()
                 .filter(|k| {
-                    !sonar_sim::is_native_or_sysvar(k) && !sonar_sim::is_litesvm_builtin_program(k)
+                    !sonar_sim::internals::is_native_or_sysvar(k)
+                        && !sonar_sim::internals::is_litesvm_builtin_program(k)
                 })
                 .collect();
             if !non_native.is_empty() {
@@ -157,9 +158,9 @@ mod tests {
     use solana_sysvar_id::SysvarId;
     use solana_transaction::Transaction;
     use solana_transaction::versioned::VersionedTransaction;
-    use sonar_sim::ResolvedAccounts;
-    use sonar_sim::{AccountAppender, AccountSource};
-    use sonar_sim::{FakeAccountProvider, RpcAccountProvider};
+    use sonar_sim::internals::ResolvedAccounts;
+    use sonar_sim::internals::{AccountAppender, AccountSource};
+    use sonar_sim::internals::{FakeAccountProvider, RpcAccountProvider};
 
     fn system_account(lamports: u64) -> Account {
         Account {

--- a/src/core/idl_fetcher.rs
+++ b/src/core/idl_fetcher.rs
@@ -7,7 +7,7 @@ use solana_account::{AccountSharedData, ReadableAccount};
 use solana_pubkey::Pubkey;
 
 use crate::utils::progress::Progress;
-use sonar_sim::{RpcAccountProvider, SolanaRpcProvider};
+use sonar_sim::internals::{RpcAccountProvider, SolanaRpcProvider};
 
 const MAX_ACCOUNTS_PER_REQUEST: usize = 100;
 
@@ -228,7 +228,7 @@ mod tests {
     use solana_pubkey::Pubkey;
 
     use super::{IdlFetcher, MAX_ACCOUNTS_PER_REQUEST, get_idl_address, parse_idl_account_data};
-    use sonar_sim::FakeAccountProvider;
+    use sonar_sim::internals::FakeAccountProvider;
 
     fn dummy_fetcher() -> IdlFetcher {
         IdlFetcher::with_provider(Arc::new(FakeAccountProvider::empty()), None)

--- a/src/core/rpc_client.rs
+++ b/src/core/rpc_client.rs
@@ -15,7 +15,7 @@ use solana_transaction_status_client_types::{
     EncodedConfirmedTransactionWithStatusMeta, TransactionStatus, UiTransactionEncoding,
 };
 
-use sonar_sim::rpc_json::{JsonRpcResponse, RpcAccountInfo, RpcResultValue};
+use sonar_sim::internals::rpc_json::{JsonRpcResponse, RpcAccountInfo, RpcResultValue};
 
 /// Lightweight Solana JSON-RPC client backed by `ureq`.
 pub struct RpcClient {

--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -1,8 +1,8 @@
-pub(crate) use sonar_sim::build_lookup_locations;
-pub use sonar_sim::{LookupLocation, MessageAccountPlan, RawTransactionEncoding};
+pub(crate) use sonar_sim::internals::build_lookup_locations;
+pub use sonar_sim::internals::{LookupLocation, MessageAccountPlan, RawTransactionEncoding};
 
 #[cfg(test)]
-use sonar_sim::AddressLookupPlan;
+use sonar_sim::internals::AddressLookupPlan;
 
 use crate::core::rpc_client::{GetTransactionConfig, RpcClient};
 use anyhow::{Context, Result, anyhow};
@@ -169,7 +169,7 @@ pub fn fetch_transaction_from_rpc(
 // ---------------------------------------------------------------------------
 
 pub fn parse_raw_transaction(raw: &str) -> Result<ParsedTransaction> {
-    let sim_parsed = sonar_sim::parse_raw_transaction(raw)?;
+    let sim_parsed = sonar_sim::internals::parse_raw_transaction(raw)?;
     let summary = TransactionSummary::from_transaction(
         &sim_parsed.transaction,
         &sim_parsed.account_plan,

--- a/src/handlers/common.rs
+++ b/src/handlers/common.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use solana_account::ReadableAccount;
 use solana_pubkey::Pubkey;
-use sonar_sim::{AccountLoader, ResolvedAccounts};
+use sonar_sim::internals::{AccountLoader, ResolvedAccounts};
 
 use crate::cli;
 use crate::core::cache::CacheLocation;
@@ -441,7 +441,7 @@ mod tests {
     use solana_account::{Account, AccountSharedData};
     use solana_pubkey::Pubkey;
     use solana_sdk_ids::system_program;
-    use sonar_sim::ResolvedAccounts;
+    use sonar_sim::internals::ResolvedAccounts;
     use std::collections::{HashMap, HashSet};
 
     fn executable_account() -> AccountSharedData {

--- a/src/handlers/simulate.rs
+++ b/src/handlers/simulate.rs
@@ -381,8 +381,15 @@ fn handle_bundle(
 
     let tx_refs: Vec<_> = parsed_txs.iter().map(|p| &p.transaction).collect();
     let bundle_results = runner.execute_bundle(&tx_refs);
+    if bundle_results.skipped_count() > 0 {
+        log::warn!(
+            "Bundle: {}/{} transactions skipped due to prior failure",
+            bundle_results.skipped_count(),
+            bundle_results.total(),
+        );
+    }
     let simulations: Vec<_> = bundle_results
-        .executed
+        .into_executed()
         .into_iter()
         .enumerate()
         .map(|(index, result)| {

--- a/src/handlers/simulate.rs
+++ b/src/handlers/simulate.rs
@@ -6,7 +6,7 @@ use crate::cli::{self, SimulateArgs, TransactionInputArgs};
 use crate::parsers::instruction::ParserRegistry;
 use crate::utils::progress::Progress;
 use crate::{core::account_file, core::transaction, output};
-use sonar_sim::{
+use sonar_sim::internals::{
     ExecutionOptions, PreparedSimulation, SimulationOptions, StateMutationOptions,
     apply_ix_account_appends, apply_ix_account_patches, apply_ix_data_patches,
     prepare_token_fundings,
@@ -26,9 +26,9 @@ fn parse_cli_args<T>(args: Vec<String>, parser: fn(&str) -> Result<T, String>) -
 /// the transaction summary so the renderer sees the updated state.
 fn apply_ix_mutations(
     parsed_tx: &mut transaction::ParsedTransaction,
-    ix_account_patches: &[sonar_sim::InstructionAccountPatch],
-    ix_account_appends: &[sonar_sim::InstructionAccountAppend],
-    ix_data_patches: &[sonar_sim::InstructionDataPatch],
+    ix_account_patches: &[sonar_sim::internals::InstructionAccountPatch],
+    ix_account_appends: &[sonar_sim::internals::InstructionAccountAppend],
+    ix_data_patches: &[sonar_sim::internals::InstructionDataPatch],
 ) -> Result<()> {
     if !ix_account_patches.is_empty() {
         parsed_tx.account_plan =
@@ -275,9 +275,9 @@ fn handle_bundle(
     rpc_url: &str,
     resolver_cache_location: Option<crate::core::cache::CacheLocation>,
     token_funding_requests: Vec<cli::TokenFunding>,
-    ix_account_patches: Vec<sonar_sim::InstructionAccountPatch>,
-    ix_account_appends: Vec<sonar_sim::InstructionAccountAppend>,
-    ix_data_patches: Vec<sonar_sim::InstructionDataPatch>,
+    ix_account_patches: Vec<sonar_sim::internals::InstructionAccountPatch>,
+    ix_account_appends: Vec<sonar_sim::internals::InstructionAccountAppend>,
+    ix_data_patches: Vec<sonar_sim::internals::InstructionDataPatch>,
     mut sim_opts: SimulationOptions,
     render_opts: &output::RenderOptions,
     parser_registry: &mut ParserRegistry,

--- a/src/handlers/simulate.rs
+++ b/src/handlers/simulate.rs
@@ -382,6 +382,7 @@ fn handle_bundle(
     let tx_refs: Vec<_> = parsed_txs.iter().map(|p| &p.transaction).collect();
     let bundle_results = runner.execute_bundle(&tx_refs);
     let simulations: Vec<_> = bundle_results
+        .executed
         .into_iter()
         .enumerate()
         .map(|(index, result)| {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -12,8 +12,8 @@ use anyhow::Result;
 use solana_pubkey::Pubkey;
 
 use crate::{core::transaction::ParsedTransaction, parsers::instruction::ParserRegistry};
-use sonar_sim::{
-    AccountOverride, PreparedTokenFunding, ResolvedAccounts, SimulationResult, SolFunding,
+use sonar_sim::internals::{
+    AccountOverride, ExecutionResult, PreparedTokenFunding, ResolvedAccounts, SolFunding,
 };
 
 use report::{BundleReport, LookupResolver, Report, TransactionSection};
@@ -46,7 +46,7 @@ pub struct RenderOptions {
 pub fn render(
     parsed: &ParsedTransaction,
     resolved: &ResolvedAccounts,
-    simulation: &SimulationResult,
+    simulation: &ExecutionResult,
     account_closures: &[Pubkey],
     overrides: &[AccountOverride],
     fundings: &[SolFunding],
@@ -131,7 +131,7 @@ pub fn render_bundle(
     parsed_txs: &[ParsedTransaction],
     total_tx_count: usize,
     resolved: &ResolvedAccounts,
-    simulations: &[SimulationResult],
+    simulations: &[ExecutionResult],
     account_closures: &[Pubkey],
     overrides: &[AccountOverride],
     fundings: &[SolFunding],

--- a/src/output/report.rs
+++ b/src/output/report.rs
@@ -12,9 +12,9 @@ use crate::core::transaction::{AccountReferenceSummary, AccountSourceSummary, Pa
 use crate::parsers::instruction::{
     ParsedInstruction, ParserRegistry, anchor_idl::is_anchor_cpi_event,
 };
-use sonar_sim::{
+use sonar_sim::internals::{
     AccountOverride, ExecutionStatus, PreparedTokenFunding, ResolvedAccounts, ResolvedLookup,
-    SimulationMetadata, SimulationResult, SolFunding, compute_sol_changes, compute_token_changes,
+    SimulationMetadata, ExecutionResult, SolFunding, compute_sol_changes, compute_token_changes,
     extract_mint_decimals_combined,
 };
 
@@ -85,7 +85,7 @@ impl BundleReport {
     pub(super) fn from_sources(
         parsed_txs: &[ParsedTransaction],
         resolved: &ResolvedAccounts,
-        simulations: &[SimulationResult],
+        simulations: &[ExecutionResult],
         account_closures: &[Pubkey],
         overrides: &[AccountOverride],
         fundings: &[SolFunding],
@@ -161,7 +161,7 @@ impl Report {
     pub(super) fn from_sources(
         parsed: &ParsedTransaction,
         resolved: &ResolvedAccounts,
-        simulation: &SimulationResult,
+        simulation: &ExecutionResult,
         account_closures: &[Pubkey],
         overrides: &[AccountOverride],
         fundings: &[SolFunding],
@@ -227,7 +227,7 @@ impl Report {
 /// `execute()`, which already reflect any SOL fundings applied during
 /// executor preparation.
 fn compute_balance_changes_for_single_tx(
-    simulation: &SimulationResult,
+    simulation: &ExecutionResult,
     balance_opts: BalanceChangeOptions,
 ) -> (Vec<SolBalanceChangeSection>, Vec<TokenBalanceChangeSection>) {
     let mut sol_changes = Vec::new();
@@ -279,7 +279,7 @@ fn compute_balance_changes_for_single_tx(
 /// - post_accounts: latest state for each account (last occurrence across all txs)
 fn compute_bundle_overall_balance_changes(
     resolved: &ResolvedAccounts,
-    simulations: &[SimulationResult],
+    simulations: &[ExecutionResult],
     balance_opts: BalanceChangeOptions,
 ) -> (Vec<SolBalanceChangeSection>, Vec<TokenBalanceChangeSection>) {
     if !balance_opts.show_balance_change || simulations.is_empty() {
@@ -753,7 +753,7 @@ pub(super) struct SimulationSection {
 }
 
 impl SimulationSection {
-    fn from_result(result: &SimulationResult) -> Self {
+    fn from_result(result: &ExecutionResult) -> Self {
         let (status, post_account_count) = match &result.status {
             ExecutionStatus::Succeeded => {
                 (SimulationStatusReport::Succeeded, result.post_accounts.len())

--- a/src/output/report.rs
+++ b/src/output/report.rs
@@ -13,8 +13,8 @@ use crate::parsers::instruction::{
     ParsedInstruction, ParserRegistry, anchor_idl::is_anchor_cpi_event,
 };
 use sonar_sim::internals::{
-    AccountOverride, ExecutionStatus, PreparedTokenFunding, ResolvedAccounts, ResolvedLookup,
-    SimulationMetadata, ExecutionResult, SolFunding, compute_sol_changes, compute_token_changes,
+    AccountOverride, ExecutionResult, ExecutionStatus, PreparedTokenFunding, ResolvedAccounts,
+    ResolvedLookup, SimulationMetadata, SolFunding, compute_sol_changes, compute_token_changes,
     extract_mint_decimals_combined,
 };
 

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -13,7 +13,7 @@ use crate::parsers::{
     instruction::{ParsedField, ParsedFieldValue, ParserRegistry},
     log_parser::{LogEntry, LogEntryWithDepth, parse_logs_by_instruction},
 };
-use sonar_sim::ResolvedAccounts;
+use sonar_sim::internals::ResolvedAccounts;
 
 use super::LogDisplayOptions;
 use super::report::{

--- a/src/parsers/instruction/mod.rs
+++ b/src/parsers/instruction/mod.rs
@@ -8,7 +8,7 @@ use solana_pubkey::Pubkey;
 use solana_sdk_ids::bpf_loader_upgradeable;
 
 use crate::core::transaction::InstructionSummary;
-use sonar_sim::ResolvedAccounts;
+use sonar_sim::internals::ResolvedAccounts;
 
 /// Represents a parsed instruction with human-readable data and account names
 #[derive(Debug, Clone, Serialize)]
@@ -357,7 +357,7 @@ mod tests {
     use solana_account::{Account, AccountSharedData};
     use solana_pubkey::Pubkey;
     use solana_sdk_ids::{bpf_loader_upgradeable, system_program};
-    use sonar_sim::ResolvedAccounts;
+    use sonar_sim::internals::ResolvedAccounts;
     use std::collections::HashMap;
     use std::path::PathBuf;
 


### PR DESCRIPTION
## Summary

- Replace ~40+ direct exports with an 11-item stable public API centered on a fluent `Pipeline` struct
- Add `Mutations` / `MutationsBuilder` to consolidate all mutation types into a single builder
- Add `SimulationResult` that auto-computes balance changes from pre/post account snapshots
- Move all internal types to `sonar_sim::internals::*` for power users (no semver guarantees)
- Migrate root sonar crate to use `internals` paths

### New API usage

```rust
let result = Pipeline::new(rpc_url)
    .with_source(local_dir_source)
    .with_observer(progress_observer)
    .offline(true)
    .parse(raw_tx)?
    .load_accounts()?
    .with_mutations(mutations)
    .execute()?;
```

### Public exports (11 items, down from ~40+)

`Pipeline`, `Mutations`, `MutationsBuilder`, `SimulationResult`, `SolBalanceChange`, `TokenBalanceChange`, `AccountSource`, `FetchObserver`, `FetchEvent`, `SonarSimError`, `Result`

## Test plan

- [x] All 787 workspace tests pass
- [x] Zero clippy warnings
- [x] 8 new pipeline validation tests (out-of-order errors, single/bundle dispatch)
- [x] 4 new mutations builder tests
- [x] Root crate compiles with all imports migrated to `internals` paths