### PR TITLE
refactor(sonar-idl): remove --allow-partial flag from idl fetch/sync

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -57,7 +57,7 @@ sonar program-elf <BUFFER_ADDRESS> --rpc-url <RPC_URL> -o buffer.so
 
 ## IDL
 
-Manage Anchor IDLs (fetch/sync/address). By default, `idl fetch` and `idl sync` exit with a non-zero code if any program fails (not found or RPC error). stdout contains only successfully written file paths; failure details and a summary go to stderr. Use `--allow-partial` to exit 0 even when some programs fail.
+Manage Anchor IDLs (fetch/sync/address). `idl fetch` and `idl sync` always exit 0, even when some programs fail. stdout contains only successfully written file paths; failure details and a summary go to stderr. Use `--json` to get per-program status for programmatic consumption.
 
 ```bash
 # Fetch one IDL
@@ -65,9 +65,6 @@ sonar idl fetch <PROGRAM_ID> --rpc-url <RPC_URL>
 
 # Fetch multiple IDLs
 sonar idl fetch <PROGRAM_ID_1> <PROGRAM_ID_2> --rpc-url <RPC_URL> -o ./idls/
-
-# Allow partial success (exit 0 when some fail)
-sonar idl fetch <PROGRAM_ID_1> <PROGRAM_ID_2> --rpc-url <RPC_URL> --allow-partial
 
 # Sync using an existing IDL directory (scan `<PUBKEY>.json` names)
 sonar idl sync ./idls/ --rpc-url <RPC_URL>

--- a/src/cli/idl.rs
+++ b/src/cli/idl.rs
@@ -33,9 +33,6 @@ pub struct IdlFetchArgs {
     /// Output directory for IDL files
     #[arg(short = 'o', long = "output-dir", value_name = "DIR")]
     pub output_dir: Option<PathBuf>,
-    /// Exit 0 even when some IDLs are not found or fail (default: strict, exit non-zero on any failure)
-    #[arg(long = "allow-partial")]
-    pub allow_partial: bool,
 }
 
 #[derive(Args, Debug)]
@@ -48,9 +45,6 @@ pub struct IdlSyncArgs {
     /// Output directory for IDL files
     #[arg(short = 'o', long = "output-dir", value_name = "DIR")]
     pub output_dir: Option<PathBuf>,
-    /// Exit 0 even when some IDLs are not found or fail (default: strict, exit non-zero on any failure)
-    #[arg(long = "allow-partial")]
-    pub allow_partial: bool,
 }
 
 #[derive(Args, Debug)]

--- a/src/handlers/idl.rs
+++ b/src/handlers/idl.rs
@@ -42,13 +42,13 @@ pub(crate) fn handle(args: IdlArgs, json: bool) -> Result<()> {
 fn handle_fetch(args: IdlFetchArgs, json: bool) -> Result<()> {
     let program_ids = parse_program_ids(&args.programs)?;
     let output_dir = resolve_output_dir(args.output_dir, None);
-    fetch_and_write_idls(program_ids, args.rpc.rpc_url, output_dir, args.allow_partial, json)
+    fetch_and_write_idls(program_ids, args.rpc.rpc_url, output_dir, json)
 }
 
 fn handle_sync(args: IdlSyncArgs, json: bool) -> Result<()> {
     let (program_ids, default_output_dir) = collect_program_ids_from_sync_path(&args.path)?;
     let output_dir = resolve_output_dir(args.output_dir, default_output_dir.as_deref());
-    fetch_and_write_idls(program_ids, args.rpc.rpc_url, output_dir, args.allow_partial, json)
+    fetch_and_write_idls(program_ids, args.rpc.rpc_url, output_dir, json)
 }
 
 fn handle_address(args: IdlAddressArgs, json: bool) -> Result<()> {
@@ -86,7 +86,6 @@ fn fetch_and_write_idls(
     program_ids: Vec<Pubkey>,
     rpc_url: String,
     output_dir: PathBuf,
-    allow_partial: bool,
     json: bool,
 ) -> Result<()> {
     fs::create_dir_all(&output_dir)
@@ -165,15 +164,6 @@ fn fetch_and_write_idls(
             not_found.len(),
             errors.len()
         );
-
-        if !allow_partial {
-            return Err(anyhow::anyhow!(
-                "IDL fetch/sync had failures ({} fetched, {} not found, {} error). Use --allow-partial to exit 0 when some programs fail.",
-                fetched,
-                not_found.len(),
-                errors.len()
-            ));
-        }
     }
 
     Ok(())

--- a/tests/e2e_cli_output_streams.rs
+++ b/tests/e2e_cli_output_streams.rs
@@ -518,8 +518,9 @@ fn decode_signature_refresh_cache_forces_rpc_fetch_and_fails_on_bad_rpc() {
 }
 
 #[test]
-fn idl_fetch_failure_exits_nonzero() {
-    // Unreachable RPC causes fetch to fail for all programs
+fn idl_fetch_partial_failure_exits_zero() {
+    // Unreachable RPC causes fetch to fail for all programs, but partial
+    // failures are tolerated — the command still exits 0 and logs a summary.
     let mut cmd = cargo_bin_cmd!("sonar");
     cmd.arg("idl")
         .arg("fetch")
@@ -530,39 +531,13 @@ fn idl_fetch_failure_exits_nonzero() {
         .arg("-o")
         .arg(std::env::temp_dir());
 
-    let assert = cmd.assert().failure();
+    let assert = cmd.assert().success();
     let output = assert.get_output();
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    assert!(stdout.trim().is_empty(), "stdout should be empty on failure, got: {stdout}");
+    assert!(stdout.trim().is_empty(), "stdout should be empty when nothing fetched, got: {stdout}");
     assert!(stderr.contains("Summary:"), "expected Summary in stderr, got: {stderr}");
-    assert!(
-        stderr.to_lowercase().contains("error"),
-        "expected error info in stderr, got: {stderr}"
-    );
-}
-
-#[test]
-fn idl_fetch_allow_partial_exits_zero_on_failure() {
-    let mut cmd = cargo_bin_cmd!("sonar");
-    cmd.arg("idl")
-        .arg("fetch")
-        .arg("11111111111111111111111111111111")
-        .arg("--rpc-url")
-        .arg("http://127.0.0.1:1")
-        .arg("--allow-partial")
-        .arg("-o")
-        .arg(std::env::temp_dir());
-
-    let assert = cmd.assert().success();
-    let output = assert.get_output();
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        stderr.contains("Summary:"),
-        "expected Summary in stderr when allow-partial, got: {stderr}"
-    );
 }
 
 #[test]
@@ -578,7 +553,7 @@ fn idl_fetch_success_paths_go_to_stdout() {
         .arg("-o")
         .arg(std::env::temp_dir());
 
-    let assert = cmd.assert().failure();
+    let assert = cmd.assert().success();
     let output = assert.get_output();
     let stdout = String::from_utf8_lossy(&output.stdout);
     // No successful fetches -> stdout empty


### PR DESCRIPTION
## Summary
- Removes `--allow-partial` flag from `idl fetch` and `idl sync` subcommands
- Partial failures are now always tolerated (exit 0); failure details and a summary are still logged to stderr
- Callers needing per-program status can use `--json` to detect failures programmatically

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo test -- idl` — all IDL-related tests pass
- [ ] Verify `sonar idl fetch <INVALID_PUBKEY> --rpc-url <URL>` exits 0 and logs summary to stderr