### PR TITLE
fix: preserve raw hex for partially decoded idl instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4106,6 +4106,7 @@ dependencies = [
  "anyhow",
  "heck",
  "hex",
+ "log",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/sonar-idl/Cargo.toml
+++ b/crates/sonar-idl/Cargo.toml
@@ -9,6 +9,7 @@ description = "Anchor IDL parsing and type resolution for Solana programs"
 anyhow = "1.0"
 heck = "0.5"
 hex = "0.4"
+log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 sha2 = "0.10.9"

--- a/crates/sonar-idl/src/indexed.rs
+++ b/crates/sonar-idl/src/indexed.rs
@@ -38,7 +38,6 @@ pub struct IdlParsedField {
 pub enum IdlInstructionFields {
     Parsed(Vec<IdlParsedField>),
     Unparsed(String),
-    Empty,
 }
 
 impl IdlInstructionFields {
@@ -56,7 +55,7 @@ impl Deref for IdlInstructionFields {
     fn deref(&self) -> &Self::Target {
         match self {
             Self::Parsed(fields) => fields.as_slice(),
-            Self::Unparsed(_) | Self::Empty => &[],
+            Self::Unparsed(_) => &[],
         }
     }
 }
@@ -150,7 +149,7 @@ impl IndexedIdl {
         let mut offset = idl_instruction.discriminator.as_ref().map_or(0, |d| d.len());
         let args_offset = offset;
         let fields = if idl_instruction.args.is_empty() {
-            IdlInstructionFields::Empty
+            IdlInstructionFields::Parsed(Vec::new())
         } else {
             match parse_instruction_args(data, &mut offset, &idl_instruction.args, self) {
                 Ok(fields) => IdlInstructionFields::Parsed(fields),
@@ -215,11 +214,7 @@ impl IndexedIdl {
                         value: raw_unparsed_value("event_data", &event_def.name, raw_data),
                     });
                 }
-                if raw_fields.is_empty() {
-                    IdlInstructionFields::Empty
-                } else {
-                    IdlInstructionFields::Parsed(raw_fields)
-                }
+                IdlInstructionFields::Parsed(raw_fields)
             }
         };
 

--- a/crates/sonar-idl/src/indexed.rs
+++ b/crates/sonar-idl/src/indexed.rs
@@ -33,14 +33,39 @@ pub struct IdlParsedField {
 }
 
 /// Field decode state for a matched IDL instruction.
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "status", rename_all = "snake_case")]
+///
+/// Serializes transparently: `Parsed` emits the field array directly,
+/// `Unparsed` emits the raw hex string. This matches the `ParsedInstructionFields`
+/// serialization used by the CLI output layer.
+#[derive(Debug, Clone)]
 pub enum IdlInstructionFields {
     Parsed(Vec<IdlParsedField>),
     Unparsed(String),
 }
 
+impl Serialize for IdlInstructionFields {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Parsed(fields) => fields.serialize(serializer),
+            Self::Unparsed(raw_hex) => serializer.serialize_str(raw_hex),
+        }
+    }
+}
+
 impl IdlInstructionFields {
+    /// Returns the parsed fields if decoding succeeded, or `None` for the unparsed variant.
+    ///
+    /// Prefer this over `Deref` when you need to distinguish "no args" from "failed to decode".
+    pub fn parsed_fields(&self) -> Option<&[IdlParsedField]> {
+        match self {
+            Self::Parsed(fields) => Some(fields),
+            Self::Unparsed(_) => None,
+        }
+    }
+
     pub fn raw_args_hex(&self) -> Option<&str> {
         match self {
             Self::Unparsed(raw_args_hex) => Some(raw_args_hex),
@@ -49,6 +74,9 @@ impl IdlInstructionFields {
     }
 }
 
+/// **Caution:** Returns an empty slice for `Unparsed`, which is indistinguishable from a
+/// zero-arg instruction. Use [`IdlInstructionFields::parsed_fields`] when you need to
+/// differentiate between "no arguments" and "failed to decode".
 impl Deref for IdlInstructionFields {
     type Target = [IdlParsedField];
 
@@ -153,9 +181,15 @@ impl IndexedIdl {
         } else {
             match parse_instruction_args(data, &mut offset, &idl_instruction.args, self) {
                 Ok(fields) => IdlInstructionFields::Parsed(fields),
-                Err(_) => IdlInstructionFields::Unparsed(hex::encode(
-                    data.get(args_offset..).unwrap_or_default(),
-                )),
+                Err(err) => {
+                    log::warn!(
+                        "IDL arg decode failed for instruction '{}': {err:#}",
+                        idl_instruction.name
+                    );
+                    IdlInstructionFields::Unparsed(hex::encode(
+                        data.get(args_offset..).unwrap_or_default(),
+                    ))
+                }
             }
         };
         let account_names = flatten_account_names(&idl_instruction.accounts);
@@ -200,9 +234,15 @@ impl IndexedIdl {
             Some(fields) => {
                 match parse_idl_fields_as_parsed_fields(data, &mut offset, fields, self) {
                     Ok(fields) => IdlInstructionFields::Parsed(fields),
-                    Err(_) => IdlInstructionFields::Unparsed(hex::encode(
-                        data.get(8 + disc_len..).unwrap_or_default(),
-                    )),
+                    Err(err) => {
+                        log::warn!(
+                            "IDL field decode failed for event '{}': {err:#}",
+                            event_def.name
+                        );
+                        IdlInstructionFields::Unparsed(hex::encode(
+                            data.get(8 + disc_len..).unwrap_or_default(),
+                        ))
+                    }
                 }
             }
             None => {

--- a/crates/sonar-idl/src/indexed.rs
+++ b/crates/sonar-idl/src/indexed.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ops::Deref;
 
 use anyhow::Result;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -20,7 +21,7 @@ const CPI_EVENT_ACCOUNT_NAME: &str = "event_authority";
 #[derive(Debug, Clone, Serialize)]
 pub struct IdlParsedInstruction {
     pub name: String,
-    pub fields: Vec<IdlParsedField>,
+    pub fields: IdlInstructionFields,
     pub account_names: Vec<String>,
 }
 
@@ -29,6 +30,35 @@ pub struct IdlParsedInstruction {
 pub struct IdlParsedField {
     pub name: String,
     pub value: Value,
+}
+
+/// Field decode state for a matched IDL instruction.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum IdlInstructionFields {
+    Parsed(Vec<IdlParsedField>),
+    Unparsed(String),
+    Empty,
+}
+
+impl IdlInstructionFields {
+    pub fn raw_args_hex(&self) -> Option<&str> {
+        match self {
+            Self::Unparsed(raw_args_hex) => Some(raw_args_hex),
+            _ => None,
+        }
+    }
+}
+
+impl Deref for IdlInstructionFields {
+    type Target = [IdlParsedField];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Parsed(fields) => fields.as_slice(),
+            Self::Unparsed(_) | Self::Empty => &[],
+        }
+    }
 }
 
 // ── Indexed IDL ──
@@ -118,7 +148,17 @@ impl IndexedIdl {
         };
 
         let mut offset = idl_instruction.discriminator.as_ref().map_or(0, |d| d.len());
-        let fields = parse_instruction_args(data, &mut offset, &idl_instruction.args, self)?;
+        let args_offset = offset;
+        let fields = if idl_instruction.args.is_empty() {
+            IdlInstructionFields::Empty
+        } else {
+            match parse_instruction_args(data, &mut offset, &idl_instruction.args, self) {
+                Ok(fields) => IdlInstructionFields::Parsed(fields),
+                Err(_) => IdlInstructionFields::Unparsed(hex::encode(
+                    data.get(args_offset..).unwrap_or_default(),
+                )),
+            }
+        };
         let account_names = flatten_account_names(&idl_instruction.accounts);
 
         Ok(Some(IdlParsedInstruction { name: idl_instruction.name.clone(), fields, account_names }))
@@ -158,7 +198,14 @@ impl IndexedIdl {
 
         let mut offset = 8 + disc_len;
         let fields = match type_fields.as_ref() {
-            Some(fields) => parse_idl_fields_as_parsed_fields(data, &mut offset, fields, self)?,
+            Some(fields) => {
+                match parse_idl_fields_as_parsed_fields(data, &mut offset, fields, self) {
+                    Ok(fields) => IdlInstructionFields::Parsed(fields),
+                    Err(_) => IdlInstructionFields::Unparsed(hex::encode(
+                        data.get(8 + disc_len..).unwrap_or_default(),
+                    )),
+                }
+            }
             None => {
                 let mut raw_fields = Vec::new();
                 if offset < data.len() {
@@ -168,7 +215,11 @@ impl IndexedIdl {
                         value: raw_unparsed_value("event_data", &event_def.name, raw_data),
                     });
                 }
-                raw_fields
+                if raw_fields.is_empty() {
+                    IdlInstructionFields::Empty
+                } else {
+                    IdlInstructionFields::Parsed(raw_fields)
+                }
             }
         };
 

--- a/crates/sonar-idl/src/lib.rs
+++ b/crates/sonar-idl/src/lib.rs
@@ -32,4 +32,6 @@ mod indexed;
 mod tests;
 
 pub use discriminator::sighash;
-pub use indexed::{IdlParsedField, IdlParsedInstruction, IndexedIdl, is_cpi_event_data};
+pub use indexed::{
+    IdlInstructionFields, IdlParsedField, IdlParsedInstruction, IndexedIdl, is_cpi_event_data,
+};

--- a/crates/sonar-idl/src/tests/event.rs
+++ b/crates/sonar-idl/src/tests/event.rs
@@ -1,7 +1,7 @@
 use serde_json::json;
 
 use crate::discriminator::sighash;
-use crate::indexed::{IndexedIdl, is_cpi_event_data};
+use crate::indexed::{IdlInstructionFields, IndexedIdl, is_cpi_event_data};
 
 use super::hello_anchor_indexed_idl;
 
@@ -67,6 +67,43 @@ fn indexed_idl_parse_cpi_event_data_parses_event_fields() {
     assert_eq!(parsed.fields[0].name, "amount");
     assert_eq!(parsed.fields[0].value, json!(500u64));
     assert_eq!(parsed.account_names, vec!["event_authority"]);
+}
+
+#[test]
+fn indexed_idl_parse_cpi_event_data_marks_fields_unparsed_on_decode_failure() {
+    let event_disc = sighash("event", "SwapComplete");
+
+    let indexed: IndexedIdl = serde_json::from_str(&format!(
+        r#"{{
+            "address": "11111111111111111111111111111111",
+            "metadata": {{ "name": "ev", "version": "0.1.0", "spec": "0.1.0" }},
+            "instructions": [],
+            "events": [{{
+                "name": "SwapComplete",
+                "discriminator": {:?},
+                "fields": [
+                    {{ "name": "amount_in", "type": "u64" }},
+                    {{ "name": "amount_out", "type": "u64" }}
+                ]
+            }}]
+        }}"#,
+        event_disc.to_vec()
+    ))
+    .unwrap();
+
+    // Build data with emit CPI prefix + event discriminator + only one u64 (truncated).
+    let mut data = vec![0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
+    data.extend_from_slice(&event_disc);
+    data.extend_from_slice(&42u64.to_le_bytes());
+    // Missing second u64 — decode should fail gracefully.
+
+    let parsed = indexed.parse_cpi_event_data(&data).unwrap().unwrap();
+    assert_eq!(parsed.name, "SwapComplete");
+    assert_eq!(parsed.account_names, vec!["event_authority"]);
+    assert!(matches!(
+        parsed.fields,
+        IdlInstructionFields::Unparsed(ref hex) if hex == &hex::encode(&42u64.to_le_bytes())
+    ));
 }
 
 #[test]

--- a/crates/sonar-idl/src/tests/instruction.rs
+++ b/crates/sonar-idl/src/tests/instruction.rs
@@ -2,7 +2,7 @@ use serde_json::{Value, json};
 
 use crate::discriminator::sighash;
 use crate::idl::*;
-use crate::indexed::IndexedIdl;
+use crate::indexed::{IdlInstructionFields, IndexedIdl};
 
 use super::hello_anchor_indexed_idl;
 
@@ -212,7 +212,7 @@ fn indexed_idl_parse_instruction_multiple_primitive_args() {
 }
 
 #[test]
-fn indexed_idl_parse_instruction_errors_when_a_required_arg_is_missing() {
+fn indexed_idl_parse_instruction_marks_fields_unparsed_when_a_required_arg_is_missing() {
     let indexed: IndexedIdl = serde_json::from_str(
         r#"{
             "address": "11111111111111111111111111111111",
@@ -234,8 +234,13 @@ fn indexed_idl_parse_instruction_errors_when_a_required_arg_is_missing() {
     let mut data = vec![4, 5, 6, 7, 8, 9, 10, 11];
     data.extend_from_slice(&123u32.to_le_bytes());
 
-    let err = indexed.parse_instruction(&data).unwrap_err();
-    assert!(err.to_string().contains("Insufficient data"));
+    let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
+    assert_eq!(parsed.name, "pair");
+    assert_eq!(parsed.account_names, Vec::<String>::new());
+    assert!(matches!(
+        parsed.fields,
+        IdlInstructionFields::Unparsed(raw_args_hex) if raw_args_hex == "7b000000"
+    ));
 }
 
 #[test]
@@ -274,7 +279,7 @@ fn indexed_idl_parse_instruction_with_defined_struct_arg() {
 }
 
 #[test]
-fn indexed_idl_parse_instruction_errors_when_a_defined_struct_field_is_missing() {
+fn indexed_idl_parse_instruction_marks_fields_unparsed_when_a_defined_struct_field_is_missing() {
     let indexed: IndexedIdl = serde_json::from_str(
         r#"{
             "address": "11111111111111111111111111111111",
@@ -302,8 +307,12 @@ fn indexed_idl_parse_instruction_errors_when_a_defined_struct_field_is_missing()
     let mut data = vec![10, 20, 30, 40, 50, 60, 70, 80];
     data.extend_from_slice(&100u32.to_le_bytes());
 
-    let err = indexed.parse_instruction(&data).unwrap_err();
-    assert!(err.to_string().contains("Insufficient data"));
+    let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
+    assert_eq!(parsed.name, "create");
+    assert!(matches!(
+        parsed.fields,
+        IdlInstructionFields::Unparsed(raw_args_hex) if raw_args_hex == "64000000"
+    ));
 }
 
 #[test]

--- a/crates/sonar-idl/src/tests/instruction.rs
+++ b/crates/sonar-idl/src/tests/instruction.rs
@@ -475,3 +475,28 @@ fn indexed_idl_find_instruction_ignores_missing_discriminator() {
     let found = indexed.find_instruction_by_discriminator(&[1, 2, 3, 4, 5, 6, 7, 8]);
     assert!(found.is_none());
 }
+
+#[test]
+fn indexed_idl_parse_instruction_returns_empty_fields_for_zero_arg_instruction() {
+    let indexed: IndexedIdl = serde_json::from_str(
+        r#"{
+            "address": "11111111111111111111111111111111",
+            "metadata": { "name": "t", "version": "0.1.0", "spec": "0.1.0" },
+            "instructions": [{
+                "name": "ping",
+                "discriminator": [9,9,9,9,9,9,9,9],
+                "accounts": [{ "name": "payer", "writable": true, "signer": true }],
+                "args": []
+            }],
+            "types": []
+        }"#,
+    )
+    .unwrap();
+
+    let data = vec![9, 9, 9, 9, 9, 9, 9, 9];
+
+    let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
+    assert_eq!(parsed.name, "ping");
+    assert!(matches!(parsed.fields, IdlInstructionFields::Parsed(ref fields) if fields.is_empty()));
+    assert_eq!(parsed.account_names, vec!["payer"]);
+}

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -31,6 +31,8 @@ const INDENT_L2: &str = "    ";
 
 /// Subdued gray for metadata columns (index labels, permission flags, account names).
 const DIM_GRAY: colored::CustomColor = colored::CustomColor { r: 128, g: 128, b: 128 };
+/// Warm amber for fallback raw hex when structured instruction decoding fails.
+const RAW_HEX_AMBER: colored::CustomColor = colored::CustomColor { r: 214, g: 154, b: 74 };
 
 pub(super) fn render_text(
     report: &Report,
@@ -547,6 +549,7 @@ fn render_instruction_details_text(
 
         // Try to parse the instruction
         if let Some(parsed) = &ix.parsed {
+            let use_raw_hex_fallback = should_render_raw_instruction_hex(&parsed.fields);
             println!(
                 "#{} {} {}",
                 outer_number.to_string().custom_color((229, 192, 123)),
@@ -570,11 +573,19 @@ fn render_instruction_details_text(
                 );
             }
 
-            if show_ix_data {
+            if use_raw_hex_fallback {
+                render_instruction_data_text_with_color(
+                    &current_data_indent,
+                    &ix.data,
+                    Some(RAW_HEX_AMBER),
+                );
+            } else if show_ix_data {
                 render_instruction_data_text(&current_data_indent, &ix.data);
             }
 
-            render_parsed_fields(&parsed.fields, &current_data_indent);
+            if !use_raw_hex_fallback {
+                render_parsed_fields(&parsed.fields, &current_data_indent);
+            }
         } else {
             println!(
                 "#{} {}",
@@ -597,6 +608,8 @@ fn render_instruction_details_text(
                 };
 
                 if let Some(parsed_inner) = &inner_ix.parsed {
+                    let use_raw_hex_fallback =
+                        should_render_raw_instruction_hex(&parsed_inner.fields);
                     println!(
                         "{}{} {} {}",
                         INDENT_L1,
@@ -620,11 +633,19 @@ fn render_instruction_details_text(
                         );
                     }
 
-                    if show_ix_data {
+                    if use_raw_hex_fallback {
+                        render_instruction_data_text_with_color(
+                            &current_inner_data_indent,
+                            &inner_ix.data,
+                            Some(RAW_HEX_AMBER),
+                        );
+                    } else if show_ix_data {
                         render_instruction_data_text(&current_inner_data_indent, &inner_ix.data);
                     }
 
-                    render_parsed_fields(&parsed_inner.fields, &current_inner_data_indent);
+                    if !use_raw_hex_fallback {
+                        render_parsed_fields(&parsed_inner.fields, &current_inner_data_indent);
+                    }
                 } else {
                     println!(
                         "{}{} {}",
@@ -882,5 +903,37 @@ fn render_parsed_fields(fields: &[ParsedField], indent: &str) {
 }
 
 fn render_instruction_data_text(indent: &str, data: &[u8]) {
-    println!("{}0x{} {} bytes", indent, hex::encode(data), data.len());
+    render_instruction_data_text_with_color(indent, data, None);
+}
+
+fn render_instruction_data_text_with_color(
+    indent: &str,
+    data: &[u8],
+    color: Option<colored::CustomColor>,
+) {
+    let line = format!("{}0x{} {} bytes", indent, hex::encode(data), data.len());
+    match color {
+        Some(color) => println!("{}", line.custom_color(color)),
+        None => println!("{line}"),
+    }
+}
+
+fn should_render_raw_instruction_hex(fields: &[ParsedField]) -> bool {
+    matches!(
+        fields,
+        [ParsedField { name, value: ParsedFieldValue::Text(raw_hex) }]
+            if name == "__raw_hex__" && !raw_hex.is_empty()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_render_raw_instruction_hex_for_unparsed_idl_fields() {
+        let fields = vec![ParsedField::text("__raw_hex__", "0025a16608ca3c00")];
+
+        assert!(should_render_raw_instruction_hex(&fields));
+    }
 }

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -549,7 +549,6 @@ fn render_instruction_details_text(
 
         // Try to parse the instruction
         if let Some(parsed) = &ix.parsed {
-            let use_raw_hex_fallback = should_render_raw_instruction_hex(&parsed.fields);
             println!(
                 "#{} {} {}",
                 outer_number.to_string().custom_color((229, 192, 123)),
@@ -573,19 +572,12 @@ fn render_instruction_details_text(
                 );
             }
 
-            if use_raw_hex_fallback {
-                render_instruction_data_text_with_color(
-                    &current_data_indent,
-                    &ix.data,
-                    Some(RAW_HEX_AMBER),
-                );
-            } else if show_ix_data {
-                render_instruction_data_text(&current_data_indent, &ix.data);
-            }
-
-            if !use_raw_hex_fallback {
-                render_parsed_fields(&parsed.fields, &current_data_indent);
-            }
+            render_instruction_data_and_fields(
+                &parsed.fields,
+                &current_data_indent,
+                &ix.data,
+                show_ix_data,
+            );
         } else {
             println!(
                 "#{} {}",
@@ -608,8 +600,6 @@ fn render_instruction_details_text(
                 };
 
                 if let Some(parsed_inner) = &inner_ix.parsed {
-                    let use_raw_hex_fallback =
-                        should_render_raw_instruction_hex(&parsed_inner.fields);
                     println!(
                         "{}{} {} {}",
                         INDENT_L1,
@@ -633,19 +623,12 @@ fn render_instruction_details_text(
                         );
                     }
 
-                    if use_raw_hex_fallback {
-                        render_instruction_data_text_with_color(
-                            &current_inner_data_indent,
-                            &inner_ix.data,
-                            Some(RAW_HEX_AMBER),
-                        );
-                    } else if show_ix_data {
-                        render_instruction_data_text(&current_inner_data_indent, &inner_ix.data);
-                    }
-
-                    if !use_raw_hex_fallback {
-                        render_parsed_fields(&parsed_inner.fields, &current_inner_data_indent);
-                    }
+                    render_instruction_data_and_fields(
+                        &parsed_inner.fields,
+                        &current_inner_data_indent,
+                        &inner_ix.data,
+                        show_ix_data,
+                    );
                 } else {
                     println!(
                         "{}{} {}",
@@ -902,24 +885,31 @@ fn render_parsed_fields(fields: &ParsedInstructionFields, indent: &str) {
     }
 }
 
-fn render_instruction_data_text(indent: &str, data: &[u8]) {
-    render_instruction_data_text_with_color(indent, data, None);
-}
-
-fn render_instruction_data_text_with_color(
+/// Render instruction data hex and/or parsed fields, choosing the raw-hex-amber
+/// fallback when structured decoding failed.
+fn render_instruction_data_and_fields(
+    fields: &ParsedInstructionFields,
     indent: &str,
     data: &[u8],
-    color: Option<colored::CustomColor>,
+    show_ix_data: bool,
 ) {
-    let line = format!("{}0x{} {} bytes", indent, hex::encode(data), data.len());
-    match color {
-        Some(color) => println!("{}", line.custom_color(color)),
-        None => println!("{line}"),
+    // Non-empty RawHex means IDL matched but arg decoding failed — show amber hex.
+    if let ParsedInstructionFields::RawHex(raw_hex) = fields {
+        if !raw_hex.is_empty() {
+            let line = format!("{}0x{} {} bytes", indent, hex::encode(data), data.len());
+            println!("{}", line.custom_color(RAW_HEX_AMBER));
+            return;
+        }
     }
+
+    if show_ix_data {
+        render_instruction_data_text(indent, data);
+    }
+    render_parsed_fields(fields, indent);
 }
 
-fn should_render_raw_instruction_hex(fields: &ParsedInstructionFields) -> bool {
-    matches!(fields, ParsedInstructionFields::RawHex(raw_hex) if !raw_hex.is_empty())
+fn render_instruction_data_text(indent: &str, data: &[u8]) {
+    println!("{}0x{} {} bytes", indent, hex::encode(data), data.len());
 }
 
 #[cfg(test)]
@@ -927,9 +917,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn should_render_raw_instruction_hex_for_unparsed_idl_fields() {
+    fn render_instruction_data_and_fields_uses_raw_hex_for_unparsed() {
+        // Verify the function returns early (no panic) for the RawHex variant.
+        // Stdout output is not captured here, but this exercises the code path.
         let fields = ParsedInstructionFields::RawHex("0025a16608ca3c00".to_string());
-
-        assert!(should_render_raw_instruction_hex(&fields));
+        render_instruction_data_and_fields(&fields, "  ", &[0, 37, 161, 102], false);
     }
 }

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -10,7 +10,7 @@ use solana_pubkey::Pubkey;
 use unicode_width::UnicodeWidthStr;
 
 use crate::parsers::{
-    instruction::{ParsedField, ParsedFieldValue, ParserRegistry},
+    instruction::{ParsedField, ParsedFieldValue, ParsedInstructionFields, ParserRegistry},
     log_parser::{LogEntry, LogEntryWithDepth, parse_logs_by_instruction},
 };
 use sonar_sim::internals::ResolvedAccounts;
@@ -889,10 +889,10 @@ impl Serialize for OrderedFields<'_> {
     }
 }
 
-fn render_parsed_fields(fields: &[ParsedField], indent: &str) {
-    if fields.is_empty() {
+fn render_parsed_fields(fields: &ParsedInstructionFields, indent: &str) {
+    let ParsedInstructionFields::Parsed(fields) = fields else {
         return;
-    }
+    };
 
     let ordered = OrderedFields(fields);
     let pretty = serde_json::to_string_pretty(&ordered).unwrap_or_else(|_| "{}".to_string());
@@ -918,12 +918,8 @@ fn render_instruction_data_text_with_color(
     }
 }
 
-fn should_render_raw_instruction_hex(fields: &[ParsedField]) -> bool {
-    matches!(
-        fields,
-        [ParsedField { name, value: ParsedFieldValue::Text(raw_hex) }]
-            if name == "__raw_hex__" && !raw_hex.is_empty()
-    )
+fn should_render_raw_instruction_hex(fields: &ParsedInstructionFields) -> bool {
+    matches!(fields, ParsedInstructionFields::RawHex(raw_hex) if !raw_hex.is_empty())
 }
 
 #[cfg(test)]
@@ -932,7 +928,7 @@ mod tests {
 
     #[test]
     fn should_render_raw_instruction_hex_for_unparsed_idl_fields() {
-        let fields = vec![ParsedField::text("__raw_hex__", "0025a16608ca3c00")];
+        let fields = ParsedInstructionFields::RawHex("0025a16608ca3c00".to_string());
 
         assert!(should_render_raw_instruction_hex(&fields));
     }

--- a/src/parsers/binary_reader.rs
+++ b/src/parsers/binary_reader.rs
@@ -270,7 +270,11 @@ mod tests {
         let data = [0u8; 4];
         let result = try_parse(&data, |reader| {
             let _ = reader.read_u32()?;
-            Ok(ParsedInstruction { name: "Test".into(), fields: vec![], account_names: vec![] })
+            Ok(ParsedInstruction {
+                name: "Test".into(),
+                fields: vec![].into(),
+                account_names: vec![],
+            })
         })
         .unwrap();
         assert!(result.is_some());
@@ -282,7 +286,11 @@ mod tests {
         let data = [0u8; 1]; // too short for u32
         let result = try_parse(&data, |reader| {
             let _ = reader.read_u32()?;
-            Ok(ParsedInstruction { name: "Test".into(), fields: vec![], account_names: vec![] })
+            Ok(ParsedInstruction {
+                name: "Test".into(),
+                fields: vec![].into(),
+                account_names: vec![],
+            })
         })
         .unwrap();
         assert!(result.is_none());

--- a/src/parsers/instruction/anchor_idl.rs
+++ b/src/parsers/instruction/anchor_idl.rs
@@ -10,7 +10,9 @@ use solana_pubkey::Pubkey;
 use sonar_idl::{IdlInstructionFields, IdlParsedInstruction};
 
 use crate::core::transaction::InstructionSummary;
-use crate::parsers::instruction::{InstructionParser, ParsedField, ParsedInstruction};
+use crate::parsers::instruction::{
+    InstructionParser, ParsedField, ParsedInstruction, ParsedInstructionFields,
+};
 
 // ── Re-exports from sonar-idl ──
 
@@ -20,11 +22,13 @@ pub use sonar_idl::IndexedIdl;
 
 fn to_parsed_instruction(idl_parsed: IdlParsedInstruction) -> ParsedInstruction {
     let fields = match idl_parsed.fields {
-        IdlInstructionFields::Parsed(fields) => {
-            fields.into_iter().map(|field| ParsedField::json(field.name, field.value)).collect()
-        }
+        IdlInstructionFields::Parsed(fields) => fields
+            .into_iter()
+            .map(|field| ParsedField::json(field.name, field.value))
+            .collect::<Vec<_>>()
+            .into(),
         IdlInstructionFields::Unparsed(raw_args_hex) => {
-            vec![ParsedField::text("__raw_hex__", raw_args_hex)]
+            ParsedInstructionFields::RawHex(raw_args_hex)
         }
     };
 

--- a/src/parsers/instruction/anchor_idl.rs
+++ b/src/parsers/instruction/anchor_idl.rs
@@ -26,7 +26,6 @@ fn to_parsed_instruction(idl_parsed: IdlParsedInstruction) -> ParsedInstruction 
         IdlInstructionFields::Unparsed(raw_args_hex) => {
             vec![ParsedField::text("__raw_hex__", raw_args_hex)]
         }
-        IdlInstructionFields::Empty => Vec::new(),
     };
 
     ParsedInstruction { name: idl_parsed.name, fields, account_names: idl_parsed.account_names }

--- a/src/parsers/instruction/anchor_idl.rs
+++ b/src/parsers/instruction/anchor_idl.rs
@@ -7,7 +7,7 @@
 
 use anyhow::Result;
 use solana_pubkey::Pubkey;
-use sonar_idl::IdlParsedInstruction;
+use sonar_idl::{IdlInstructionFields, IdlParsedInstruction};
 
 use crate::core::transaction::InstructionSummary;
 use crate::parsers::instruction::{InstructionParser, ParsedField, ParsedInstruction};
@@ -19,11 +19,15 @@ pub use sonar_idl::IndexedIdl;
 // ── Adapter: IDL model → CLI model ──
 
 fn to_parsed_instruction(idl_parsed: IdlParsedInstruction) -> ParsedInstruction {
-    let fields = idl_parsed
-        .fields
-        .into_iter()
-        .map(|field| ParsedField::json(field.name, field.value))
-        .collect();
+    let fields = match idl_parsed.fields {
+        IdlInstructionFields::Parsed(fields) => {
+            fields.into_iter().map(|field| ParsedField::json(field.name, field.value)).collect()
+        }
+        IdlInstructionFields::Unparsed(raw_args_hex) => {
+            vec![ParsedField::text("__raw_hex__", raw_args_hex)]
+        }
+        IdlInstructionFields::Empty => Vec::new(),
+    };
 
     ParsedInstruction { name: idl_parsed.name, fields, account_names: idl_parsed.account_names }
 }

--- a/src/parsers/instruction/associated_token_program.rs
+++ b/src/parsers/instruction/associated_token_program.rs
@@ -61,7 +61,7 @@ fn parse_create_instruction(
 
     Ok(Some(ParsedInstruction {
         name: instruction_name.to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names,
     }))
 }
@@ -84,7 +84,11 @@ fn parse_recover_nested_instruction(
     ];
     append_extra_account_names(&mut account_names, instruction.accounts.len(), 7);
 
-    Ok(Some(ParsedInstruction { name: "RecoverNested".to_string(), fields: vec![], account_names }))
+    Ok(Some(ParsedInstruction {
+        name: "RecoverNested".to_string(),
+        fields: vec![].into(),
+        account_names,
+    }))
 }
 
 fn append_extra_account_names(

--- a/src/parsers/instruction/compute_budget_program.rs
+++ b/src/parsers/instruction/compute_budget_program.rs
@@ -56,7 +56,7 @@ fn parse_unused_instruction(data: &[u8]) -> Result<Option<ParsedInstruction>> {
 
     Ok(Some(ParsedInstruction {
         name: "Unused".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names: vec![],
     }))
 }
@@ -74,7 +74,7 @@ fn parse_u32_instruction(
         let value = reader.read_u32()?;
         Ok(ParsedInstruction {
             name: name.to_string(),
-            fields: vec![ParsedField::text(field_name, value.to_string())],
+            fields: vec![ParsedField::text(field_name, value.to_string())].into(),
             account_names: vec![],
         })
     })
@@ -93,7 +93,7 @@ fn parse_u64_instruction(
         let value = reader.read_u64()?;
         Ok(ParsedInstruction {
             name: name.to_string(),
-            fields: vec![ParsedField::text(field_name, value.to_string())],
+            fields: vec![ParsedField::text(field_name, value.to_string())].into(),
             account_names: vec![],
         })
     })

--- a/src/parsers/instruction/memo_program.rs
+++ b/src/parsers/instruction/memo_program.rs
@@ -22,7 +22,11 @@ impl InstructionParser for MemoProgramParser {
         let account_names =
             (0..instruction.accounts.len()).map(|index| format!("signer_{}", index)).collect();
 
-        Ok(Some(ParsedInstruction { name: "Memo".to_string(), fields: memo_fields, account_names }))
+        Ok(Some(ParsedInstruction {
+            name: "Memo".to_string(),
+            fields: memo_fields.into(),
+            account_names,
+        }))
     }
 }
 

--- a/src/parsers/instruction/mod.rs
+++ b/src/parsers/instruction/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ops::Deref;
 
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -15,10 +16,54 @@ use sonar_sim::internals::ResolvedAccounts;
 pub struct ParsedInstruction {
     /// The instruction name (e.g., "Transfer", "CreateAccount")
     pub name: String,
-    /// Vector of parsed fields preserving order
-    pub fields: Vec<ParsedField>,
+    /// Parsed field state preserving either structured fields or raw hex fallback
+    pub fields: ParsedInstructionFields,
     /// Human-readable names for each account in the instruction
     pub account_names: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ParsedInstructionFields {
+    Parsed(Vec<ParsedField>),
+    RawHex(String),
+}
+
+impl From<Vec<ParsedField>> for ParsedInstructionFields {
+    fn from(fields: Vec<ParsedField>) -> Self {
+        Self::Parsed(fields)
+    }
+}
+
+impl Deref for ParsedInstructionFields {
+    type Target = [ParsedField];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Parsed(fields) => fields.as_slice(),
+            Self::RawHex(_) => &[],
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a ParsedInstructionFields {
+    type Item = &'a ParsedField;
+    type IntoIter = std::slice::Iter<'a, ParsedField>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.deref().iter()
+    }
+}
+
+impl Serialize for ParsedInstructionFields {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Parsed(fields) => fields.serialize(serializer),
+            Self::RawHex(raw_hex) => serializer.serialize_str(raw_hex),
+        }
+    }
 }
 
 /// Ordered parsed field entry
@@ -545,9 +590,10 @@ mod tests {
 
         assert_eq!(parsed.name, "swap_toc");
         assert_eq!(parsed.account_names, vec!["payer"]);
-        assert_eq!(parsed.fields.len(), 1);
-        assert_eq!(parsed.fields[0].name, "__raw_hex__");
-        assert_eq!(parsed.fields[0].value, "0025a16608ca3c00".to_string());
+        assert!(matches!(
+            parsed.fields,
+            ParsedInstructionFields::RawHex(raw_hex) if raw_hex == "0025a16608ca3c00"
+        ));
 
         std::fs::remove_file(idl_path).ok();
         std::fs::remove_dir_all(test_dir).ok();

--- a/src/parsers/instruction/mod.rs
+++ b/src/parsers/instruction/mod.rs
@@ -28,12 +28,27 @@ pub enum ParsedInstructionFields {
     RawHex(String),
 }
 
+impl ParsedInstructionFields {
+    /// Returns the parsed fields if decoding succeeded, or `None` for the raw hex variant.
+    ///
+    /// Prefer this over `Deref` when you need to distinguish "no fields" from "failed to decode".
+    pub fn parsed_fields(&self) -> Option<&[ParsedField]> {
+        match self {
+            Self::Parsed(fields) => Some(fields),
+            Self::RawHex(_) => None,
+        }
+    }
+}
+
 impl From<Vec<ParsedField>> for ParsedInstructionFields {
     fn from(fields: Vec<ParsedField>) -> Self {
         Self::Parsed(fields)
     }
 }
 
+/// **Caution:** Returns an empty slice for `RawHex`, which is indistinguishable from a
+/// zero-field instruction. Use [`ParsedInstructionFields::parsed_fields`] when you need to
+/// differentiate between "no fields" and "failed to decode".
 impl Deref for ParsedInstructionFields {
     type Target = [ParsedField];
 

--- a/src/parsers/instruction/mod.rs
+++ b/src/parsers/instruction/mod.rs
@@ -482,6 +482,76 @@ mod tests {
         std::fs::remove_file(existing_path).ok();
         std::fs::remove_dir_all(test_dir).ok();
     }
+
+    #[test]
+    fn parser_registry_marks_truncated_idl_args_as_raw_hex() {
+        let test_dir = std::env::temp_dir().join(format!(
+            "sonar-idl-unparsed-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock should be valid")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&test_dir).expect("create temp idl dir");
+
+        let program_id = Pubkey::new_unique();
+        let idl_path = test_dir.join(format!("{program_id}.json"));
+        std::fs::write(
+            &idl_path,
+            format!(
+                r#"{{
+                    "address": "{program_id}",
+                    "metadata": {{ "name": "demo", "version": "0.1.0", "spec": "0.1.0" }},
+                    "instructions": [{{
+                        "name": "swap_toc",
+                        "discriminator": [187, 201, 212, 51, 16, 155, 236, 60],
+                        "accounts": [{{ "name": "payer", "writable": true, "signer": true }}],
+                        "args": [
+                            {{ "name": "amount_in", "type": "u64" }},
+                            {{ "name": "slippage_bps", "type": "u16" }}
+                        ]
+                    }}],
+                    "types": []
+                }}"#
+            ),
+        )
+        .expect("write temp idl");
+
+        let instruction = crate::core::transaction::InstructionSummary {
+            index: 7,
+            program: crate::core::transaction::AccountReferenceSummary {
+                index: 0,
+                pubkey: Some(program_id.to_string()),
+                signer: false,
+                writable: false,
+                source: crate::core::transaction::AccountSourceSummary::Static,
+            },
+            accounts: vec![crate::core::transaction::AccountReferenceSummary {
+                index: 1,
+                pubkey: Some(Pubkey::new_unique().to_string()),
+                signer: true,
+                writable: true,
+                source: crate::core::transaction::AccountSourceSummary::Static,
+            }],
+            data: vec![187, 201, 212, 51, 16, 155, 236, 60, 0, 37, 161, 102, 8, 202, 60, 0]
+                .into_boxed_slice(),
+        };
+
+        let mut registry = ParserRegistry::new(Some(test_dir.clone()));
+        let parsed = registry
+            .parse_instruction(&instruction, &program_id)
+            .expect("expected parser registry to preserve instruction metadata");
+
+        assert_eq!(parsed.name, "swap_toc");
+        assert_eq!(parsed.account_names, vec!["payer"]);
+        assert_eq!(parsed.fields.len(), 1);
+        assert_eq!(parsed.fields[0].name, "__raw_hex__");
+        assert_eq!(parsed.fields[0].value, "0025a16608ca3c00".to_string());
+
+        std::fs::remove_file(idl_path).ok();
+        std::fs::remove_dir_all(test_dir).ok();
+    }
 }
 
 mod system_program;

--- a/src/parsers/instruction/system_program.rs
+++ b/src/parsers/instruction/system_program.rs
@@ -84,7 +84,7 @@ fn parse_transfer_instruction(
         let lamports = reader.read_u64()?;
         Ok(ParsedInstruction {
             name: "Transfer".to_string(),
-            fields: vec![ParsedField::text("lamports", lamports.to_string())],
+            fields: vec![ParsedField::text("lamports", lamports.to_string())].into(),
             account_names: vec!["funding_account".to_string(), "recipient_account".to_string()],
         })
     })
@@ -109,7 +109,8 @@ fn parse_create_account_instruction(
                 ParsedField::text("lamports", lamports.to_string()),
                 ParsedField::text("space", space.to_string()),
                 ParsedField::text("owner", owner.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec!["funding_account".to_string(), "new_account".to_string()],
         })
     })
@@ -128,7 +129,7 @@ fn parse_assign_instruction(
         let owner = reader.read_pubkey()?;
         Ok(ParsedInstruction {
             name: "Assign".to_string(),
-            fields: vec![ParsedField::text("owner", owner.to_string())],
+            fields: vec![ParsedField::text("owner", owner.to_string())].into(),
             account_names: vec!["assigned_account".to_string()],
         })
     })
@@ -157,7 +158,8 @@ fn parse_create_account_with_seed_instruction(
                 ParsedField::text("lamports", lamports.to_string()),
                 ParsedField::text("space", space.to_string()),
                 ParsedField::text("owner", owner.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec![
                 "funding_account".to_string(),
                 "created_account".to_string(),
@@ -174,7 +176,7 @@ fn parse_advance_nonce_account_instruction(
     // AdvanceNonceAccount has no instruction data
     Ok(Some(ParsedInstruction {
         name: "AdvanceNonceAccount".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names: vec![
             "nonce_account".to_string(),
             "recent_blockhashes_sysvar".to_string(),
@@ -196,7 +198,7 @@ fn parse_withdraw_nonce_account_instruction(
         let lamports = reader.read_u64()?;
         Ok(ParsedInstruction {
             name: "WithdrawNonceAccount".to_string(),
-            fields: vec![ParsedField::text("lamports", lamports.to_string())],
+            fields: vec![ParsedField::text("lamports", lamports.to_string())].into(),
             account_names: vec![
                 "nonce_account".to_string(),
                 "recipient_account".to_string(),
@@ -221,7 +223,7 @@ fn parse_initialize_nonce_account_instruction(
         let authorized = reader.read_pubkey()?;
         Ok(ParsedInstruction {
             name: "InitializeNonceAccount".to_string(),
-            fields: vec![ParsedField::text("authorized", authorized.to_string())],
+            fields: vec![ParsedField::text("authorized", authorized.to_string())].into(),
             account_names: vec![
                 "nonce_account".to_string(),
                 "recent_blockhashes_sysvar".to_string(),
@@ -244,7 +246,7 @@ fn parse_authorize_nonce_account_instruction(
         let authorized = reader.read_pubkey()?;
         Ok(ParsedInstruction {
             name: "AuthorizeNonceAccount".to_string(),
-            fields: vec![ParsedField::text("new_authorized", authorized.to_string())],
+            fields: vec![ParsedField::text("new_authorized", authorized.to_string())].into(),
             account_names: vec!["nonce_account".to_string(), "nonce_authority".to_string()],
         })
     })
@@ -263,7 +265,7 @@ fn parse_allocate_instruction(
         let space = reader.read_u64()?;
         Ok(ParsedInstruction {
             name: "Allocate".to_string(),
-            fields: vec![ParsedField::text("space", space.to_string())],
+            fields: vec![ParsedField::text("space", space.to_string())].into(),
             account_names: vec!["allocated_account".to_string()],
         })
     })
@@ -290,7 +292,8 @@ fn parse_allocate_with_seed_instruction(
                 ParsedField::text("seed", seed),
                 ParsedField::text("space", space.to_string()),
                 ParsedField::text("owner", owner.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec!["allocated_account".to_string(), "base_account".to_string()],
         })
     })
@@ -315,7 +318,8 @@ fn parse_assign_with_seed_instruction(
                 ParsedField::text("base", base.to_string()),
                 ParsedField::text("seed", seed),
                 ParsedField::text("owner", owner.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec!["assigned_account".to_string(), "base_account".to_string()],
         })
     })
@@ -341,7 +345,8 @@ fn parse_transfer_with_seed_instruction(
                 ParsedField::text("lamports", lamports.to_string()),
                 ParsedField::text("from_seed", from_seed),
                 ParsedField::text("from_owner", from_owner.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec![
                 "funding_account".to_string(),
                 "base_account".to_string(),
@@ -358,7 +363,7 @@ fn parse_upgrade_nonce_account_instruction(
     // UpgradeNonceAccount has no instruction data
     Ok(Some(ParsedInstruction {
         name: "UpgradeNonceAccount".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names: vec!["nonce_account".to_string()],
     }))
 }
@@ -382,7 +387,8 @@ fn parse_create_account_allow_prefund_instruction(
                 ParsedField::text("lamports", lamports.to_string()),
                 ParsedField::text("space", space.to_string()),
                 ParsedField::text("owner", owner.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec![
                 "new_account".to_string(),
                 "(optional) funding_account".to_string(),

--- a/src/parsers/instruction/token2022_program.rs
+++ b/src/parsers/instruction/token2022_program.rs
@@ -358,7 +358,7 @@ fn dispatch_table_instruction(
                 );
                 Ok(ParsedInstruction {
                     name: def.name.to_string(),
-                    fields: vec![ParsedField::text("amount", amount.to_string())],
+                    fields: vec![ParsedField::text("amount", amount.to_string())].into(),
                     account_names,
                 })
             })
@@ -382,7 +382,8 @@ fn dispatch_table_instruction(
                     fields: vec![
                         ParsedField::text("amount", amount.to_string()),
                         ParsedField::text("decimals", decimals.to_string()),
-                    ],
+                    ]
+                    .into(),
                     account_names,
                 })
             })
@@ -400,7 +401,7 @@ fn dispatch_table_instruction(
             );
             Ok(Some(ParsedInstruction {
                 name: def.name.to_string(),
-                fields: vec![],
+                fields: vec![].into(),
                 account_names,
             }))
         }
@@ -410,7 +411,7 @@ fn dispatch_table_instruction(
             }
             Ok(Some(ParsedInstruction {
                 name: def.name.to_string(),
-                fields: vec![],
+                fields: vec![].into(),
                 account_names: def.account_names.iter().map(|s| s.to_string()).collect(),
             }))
         }
@@ -453,7 +454,8 @@ fn parse_initialize_mint_instruction(
             fields: vec![
                 ParsedField::text("decimals", decimals.to_string()),
                 ParsedField::text("has_freeze_authority", has_freeze_authority.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec!["mint".to_string(), "rent_sysvar".to_string()],
         })
     })
@@ -470,7 +472,7 @@ fn parse_initialize_account_instruction(
 
     Ok(Some(ParsedInstruction {
         name: "InitializeAccount".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names: vec![
             "account".to_string(),
             "mint".to_string(),
@@ -497,7 +499,7 @@ fn parse_initialize_multisig_instruction(
         }
         Ok(ParsedInstruction {
             name: "InitializeMultisig".to_string(),
-            fields: vec![ParsedField::text("m", m.to_string())],
+            fields: vec![ParsedField::text("m", m.to_string())].into(),
             account_names,
         })
     })
@@ -535,7 +537,8 @@ fn parse_set_authority_instruction(
             fields: vec![
                 ParsedField::text("authority_type", authority_type.to_string()),
                 ParsedField::text("cleared", cleared.to_string()),
-            ],
+            ]
+            .into(),
             account_names,
         })
     })
@@ -553,7 +556,7 @@ fn parse_initialize_account2_instruction(
         let owner_pubkey = reader.read_pubkey_as_string()?;
         Ok(ParsedInstruction {
             name: "InitializeAccount2".to_string(),
-            fields: vec![ParsedField::text("owner", owner_pubkey)],
+            fields: vec![ParsedField::text("owner", owner_pubkey)].into(),
             account_names: vec![
                 "account".to_string(),
                 "mint".to_string(),
@@ -579,7 +582,7 @@ fn parse_initialize_account3_instruction(
         }
         Ok(ParsedInstruction {
             name: "InitializeAccount3".to_string(),
-            fields: vec![ParsedField::text("owner", owner_pubkey)],
+            fields: vec![ParsedField::text("owner", owner_pubkey)].into(),
             account_names,
         })
     })
@@ -602,7 +605,7 @@ fn parse_initialize_multisig2_instruction(
         }
         Ok(ParsedInstruction {
             name: "InitializeMultisig2".to_string(),
-            fields: vec![ParsedField::text("m", m.to_string())],
+            fields: vec![ParsedField::text("m", m.to_string())].into(),
             account_names,
         })
     })
@@ -628,7 +631,8 @@ fn parse_initialize_mint2_instruction(
             fields: vec![
                 ParsedField::text("decimals", decimals.to_string()),
                 ParsedField::text("has_freeze_authority", has_freeze_authority.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec!["mint".to_string()],
         })
     })
@@ -646,7 +650,7 @@ fn parse_amount_to_ui_amount_instruction(
         let amount = reader.read_u64()?;
         Ok(ParsedInstruction {
             name: "AmountToUiAmount".to_string(),
-            fields: vec![ParsedField::text("amount", amount.to_string())],
+            fields: vec![ParsedField::text("amount", amount.to_string())].into(),
             account_names: vec!["mint".to_string()],
         })
     })
@@ -669,7 +673,7 @@ fn parse_ui_amount_to_amount_instruction(
 
     Ok(Some(ParsedInstruction {
         name: "UiAmountToAmount".to_string(),
-        fields: vec![ParsedField::text("ui_amount", ui_amount)],
+        fields: vec![ParsedField::text("ui_amount", ui_amount)].into(),
         account_names: vec!["mint".to_string()],
     }))
 }
@@ -687,7 +691,7 @@ fn parse_initialize_mint_close_authority_instruction(
             close_authority.map_or_else(|| "none".to_string(), |pk| pk.to_string());
         Ok(ParsedInstruction {
             name: "InitializeMintCloseAuthority".to_string(),
-            fields: vec![ParsedField::text("close_authority", close_authority_value)],
+            fields: vec![ParsedField::text("close_authority", close_authority_value)].into(),
             account_names: vec!["mint".to_string()],
         })
     })
@@ -711,7 +715,7 @@ fn parse_transfer_fee_extension_instruction(
         5 => parse_transfer_fee_set_fee_instruction(payload, instruction),
         unknown => Ok(Some(ParsedInstruction {
             name: format!("TransferFeeExtension({unknown})"),
-            fields: vec![ParsedField::text("raw_extension_data", hex::encode(payload))],
+            fields: vec![ParsedField::text("raw_extension_data", hex::encode(payload))].into(),
             account_names: generate_generic_account_names(instruction.accounts.len()),
         })),
     }
@@ -742,7 +746,8 @@ fn parse_transfer_fee_initialize_instruction(
                 ),
                 ParsedField::text("transfer_fee_basis_points", bps.to_string()),
                 ParsedField::text("maximum_fee", maximum_fee.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec!["mint".to_string()],
         })
     })
@@ -783,7 +788,8 @@ fn parse_transfer_checked_with_fee_instruction(
                 ParsedField::text("amount", amount.to_string()),
                 ParsedField::text("decimals", decimals.to_string()),
                 ParsedField::text("fee", fee.to_string()),
-            ],
+            ]
+            .into(),
             account_names,
         })
     })
@@ -812,7 +818,7 @@ fn parse_transfer_fee_withdraw_from_mint_instruction(
 
     Ok(Some(ParsedInstruction {
         name: "WithdrawWithheldTokensFromMint".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names,
     }))
 }
@@ -842,7 +848,8 @@ fn parse_transfer_fee_withdraw_from_accounts_instruction(
 
     Ok(Some(ParsedInstruction {
         name: "WithdrawWithheldTokensFromAccounts".to_string(),
-        fields: vec![ParsedField::text("num_token_accounts", num_token_accounts.to_string())],
+        fields: vec![ParsedField::text("num_token_accounts", num_token_accounts.to_string())]
+            .into(),
         account_names,
     }))
 }
@@ -861,7 +868,7 @@ fn parse_transfer_fee_harvest_to_mint_instruction(
 
     Ok(Some(ParsedInstruction {
         name: "HarvestWithheldTokensToMint".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names,
     }))
 }
@@ -896,7 +903,8 @@ fn parse_transfer_fee_set_fee_instruction(
                     transfer_fee_basis_points.to_string(),
                 ),
                 ParsedField::text("maximum_fee", maximum_fee.to_string()),
-            ],
+            ]
+            .into(),
             account_names,
         })
     })
@@ -940,7 +948,8 @@ fn parse_reallocate_instruction(
         fields: vec![ParsedField::text(
             "extension_types",
             if extension_types.is_empty() { "none".to_string() } else { extension_types.join(",") },
-        )],
+        )]
+        .into(),
         account_names,
     }))
 }
@@ -954,7 +963,7 @@ fn parse_create_native_mint_instruction(
 
     Ok(Some(ParsedInstruction {
         name: "CreateNativeMint".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names: vec![
             "funding_account".to_string(),
             "native_mint".to_string(),
@@ -974,7 +983,7 @@ fn parse_initialize_permanent_delegate_instruction(
         let delegate = reader.read_pubkey_as_string()?;
         Ok(ParsedInstruction {
             name: "InitializePermanentDelegate".to_string(),
-            fields: vec![ParsedField::text("delegate", delegate)],
+            fields: vec![ParsedField::text("delegate", delegate)].into(),
             account_names: vec!["mint".to_string()],
         })
     })
@@ -995,7 +1004,7 @@ fn parse_withdraw_excess_lamports_instruction(
 
     Ok(Some(ParsedInstruction {
         name: "WithdrawExcessLamports".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names,
     }))
 }
@@ -1012,7 +1021,7 @@ fn parse_extension_prefix_instruction(
 
     Ok(Some(ParsedInstruction {
         name: name.to_string(),
-        fields,
+        fields: fields.into(),
         account_names: generate_generic_account_names(instruction.accounts.len()),
     }))
 }


### PR DESCRIPTION
## Summary
- preserve instruction/account metadata when Anchor IDL argument decoding is incomplete
- collapse partial-decode state into `IdlInstructionFields` and remove the extra lossy parse API
- render partially decoded instruction data as amber raw hex in text output

## Test Plan
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test