### PR TITLE
refactor(output): restructure terminal text rendering pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4106,6 +4106,7 @@ dependencies = [
  "anyhow",
  "heck",
  "hex",
+ "log",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/sonar-idl/Cargo.toml
+++ b/crates/sonar-idl/Cargo.toml
@@ -9,6 +9,7 @@ description = "Anchor IDL parsing and type resolution for Solana programs"
 anyhow = "1.0"
 heck = "0.5"
 hex = "0.4"
+log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 sha2 = "0.10.9"

--- a/crates/sonar-idl/src/indexed.rs
+++ b/crates/sonar-idl/src/indexed.rs
@@ -38,7 +38,6 @@ pub struct IdlParsedField {
 pub enum IdlInstructionFields {
     Parsed(Vec<IdlParsedField>),
     Unparsed(String),
-    Empty,
 }
 
 impl IdlInstructionFields {
@@ -56,7 +55,7 @@ impl Deref for IdlInstructionFields {
     fn deref(&self) -> &Self::Target {
         match self {
             Self::Parsed(fields) => fields.as_slice(),
-            Self::Unparsed(_) | Self::Empty => &[],
+            Self::Unparsed(_) => &[],
         }
     }
 }
@@ -150,7 +149,7 @@ impl IndexedIdl {
         let mut offset = idl_instruction.discriminator.as_ref().map_or(0, |d| d.len());
         let args_offset = offset;
         let fields = if idl_instruction.args.is_empty() {
-            IdlInstructionFields::Empty
+            IdlInstructionFields::Parsed(Vec::new())
         } else {
             match parse_instruction_args(data, &mut offset, &idl_instruction.args, self) {
                 Ok(fields) => IdlInstructionFields::Parsed(fields),
@@ -215,11 +214,7 @@ impl IndexedIdl {
                         value: raw_unparsed_value("event_data", &event_def.name, raw_data),
                     });
                 }
-                if raw_fields.is_empty() {
-                    IdlInstructionFields::Empty
-                } else {
-                    IdlInstructionFields::Parsed(raw_fields)
-                }
+                IdlInstructionFields::Parsed(raw_fields)
             }
         };
 

--- a/crates/sonar-idl/src/indexed.rs
+++ b/crates/sonar-idl/src/indexed.rs
@@ -33,14 +33,39 @@ pub struct IdlParsedField {
 }
 
 /// Field decode state for a matched IDL instruction.
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "status", rename_all = "snake_case")]
+///
+/// Serializes transparently: `Parsed` emits the field array directly,
+/// `Unparsed` emits the raw hex string. This matches the `ParsedInstructionFields`
+/// serialization used by the CLI output layer.
+#[derive(Debug, Clone)]
 pub enum IdlInstructionFields {
     Parsed(Vec<IdlParsedField>),
     Unparsed(String),
 }
 
+impl Serialize for IdlInstructionFields {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Parsed(fields) => fields.serialize(serializer),
+            Self::Unparsed(raw_hex) => serializer.serialize_str(raw_hex),
+        }
+    }
+}
+
 impl IdlInstructionFields {
+    /// Returns the parsed fields if decoding succeeded, or `None` for the unparsed variant.
+    ///
+    /// Prefer this over `Deref` when you need to distinguish "no args" from "failed to decode".
+    pub fn parsed_fields(&self) -> Option<&[IdlParsedField]> {
+        match self {
+            Self::Parsed(fields) => Some(fields),
+            Self::Unparsed(_) => None,
+        }
+    }
+
     pub fn raw_args_hex(&self) -> Option<&str> {
         match self {
             Self::Unparsed(raw_args_hex) => Some(raw_args_hex),
@@ -49,6 +74,9 @@ impl IdlInstructionFields {
     }
 }
 
+/// **Caution:** Returns an empty slice for `Unparsed`, which is indistinguishable from a
+/// zero-arg instruction. Use [`IdlInstructionFields::parsed_fields`] when you need to
+/// differentiate between "no arguments" and "failed to decode".
 impl Deref for IdlInstructionFields {
     type Target = [IdlParsedField];
 
@@ -153,9 +181,15 @@ impl IndexedIdl {
         } else {
             match parse_instruction_args(data, &mut offset, &idl_instruction.args, self) {
                 Ok(fields) => IdlInstructionFields::Parsed(fields),
-                Err(_) => IdlInstructionFields::Unparsed(hex::encode(
-                    data.get(args_offset..).unwrap_or_default(),
-                )),
+                Err(err) => {
+                    log::warn!(
+                        "IDL arg decode failed for instruction '{}': {err:#}",
+                        idl_instruction.name
+                    );
+                    IdlInstructionFields::Unparsed(hex::encode(
+                        data.get(args_offset..).unwrap_or_default(),
+                    ))
+                }
             }
         };
         let account_names = flatten_account_names(&idl_instruction.accounts);
@@ -200,9 +234,15 @@ impl IndexedIdl {
             Some(fields) => {
                 match parse_idl_fields_as_parsed_fields(data, &mut offset, fields, self) {
                     Ok(fields) => IdlInstructionFields::Parsed(fields),
-                    Err(_) => IdlInstructionFields::Unparsed(hex::encode(
-                        data.get(8 + disc_len..).unwrap_or_default(),
-                    )),
+                    Err(err) => {
+                        log::warn!(
+                            "IDL field decode failed for event '{}': {err:#}",
+                            event_def.name
+                        );
+                        IdlInstructionFields::Unparsed(hex::encode(
+                            data.get(8 + disc_len..).unwrap_or_default(),
+                        ))
+                    }
                 }
             }
             None => {

--- a/crates/sonar-idl/src/indexed.rs
+++ b/crates/sonar-idl/src/indexed.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ops::Deref;
 
 use anyhow::Result;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -20,7 +21,7 @@ const CPI_EVENT_ACCOUNT_NAME: &str = "event_authority";
 #[derive(Debug, Clone, Serialize)]
 pub struct IdlParsedInstruction {
     pub name: String,
-    pub fields: Vec<IdlParsedField>,
+    pub fields: IdlInstructionFields,
     pub account_names: Vec<String>,
 }
 
@@ -29,6 +30,35 @@ pub struct IdlParsedInstruction {
 pub struct IdlParsedField {
     pub name: String,
     pub value: Value,
+}
+
+/// Field decode state for a matched IDL instruction.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum IdlInstructionFields {
+    Parsed(Vec<IdlParsedField>),
+    Unparsed(String),
+    Empty,
+}
+
+impl IdlInstructionFields {
+    pub fn raw_args_hex(&self) -> Option<&str> {
+        match self {
+            Self::Unparsed(raw_args_hex) => Some(raw_args_hex),
+            _ => None,
+        }
+    }
+}
+
+impl Deref for IdlInstructionFields {
+    type Target = [IdlParsedField];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Parsed(fields) => fields.as_slice(),
+            Self::Unparsed(_) | Self::Empty => &[],
+        }
+    }
 }
 
 // ── Indexed IDL ──
@@ -118,7 +148,17 @@ impl IndexedIdl {
         };
 
         let mut offset = idl_instruction.discriminator.as_ref().map_or(0, |d| d.len());
-        let fields = parse_instruction_args(data, &mut offset, &idl_instruction.args, self)?;
+        let args_offset = offset;
+        let fields = if idl_instruction.args.is_empty() {
+            IdlInstructionFields::Empty
+        } else {
+            match parse_instruction_args(data, &mut offset, &idl_instruction.args, self) {
+                Ok(fields) => IdlInstructionFields::Parsed(fields),
+                Err(_) => IdlInstructionFields::Unparsed(hex::encode(
+                    data.get(args_offset..).unwrap_or_default(),
+                )),
+            }
+        };
         let account_names = flatten_account_names(&idl_instruction.accounts);
 
         Ok(Some(IdlParsedInstruction { name: idl_instruction.name.clone(), fields, account_names }))
@@ -158,7 +198,14 @@ impl IndexedIdl {
 
         let mut offset = 8 + disc_len;
         let fields = match type_fields.as_ref() {
-            Some(fields) => parse_idl_fields_as_parsed_fields(data, &mut offset, fields, self)?,
+            Some(fields) => {
+                match parse_idl_fields_as_parsed_fields(data, &mut offset, fields, self) {
+                    Ok(fields) => IdlInstructionFields::Parsed(fields),
+                    Err(_) => IdlInstructionFields::Unparsed(hex::encode(
+                        data.get(8 + disc_len..).unwrap_or_default(),
+                    )),
+                }
+            }
             None => {
                 let mut raw_fields = Vec::new();
                 if offset < data.len() {
@@ -168,7 +215,11 @@ impl IndexedIdl {
                         value: raw_unparsed_value("event_data", &event_def.name, raw_data),
                     });
                 }
-                raw_fields
+                if raw_fields.is_empty() {
+                    IdlInstructionFields::Empty
+                } else {
+                    IdlInstructionFields::Parsed(raw_fields)
+                }
             }
         };
 

--- a/crates/sonar-idl/src/lib.rs
+++ b/crates/sonar-idl/src/lib.rs
@@ -32,4 +32,6 @@ mod indexed;
 mod tests;
 
 pub use discriminator::sighash;
-pub use indexed::{IdlParsedField, IdlParsedInstruction, IndexedIdl, is_cpi_event_data};
+pub use indexed::{
+    IdlInstructionFields, IdlParsedField, IdlParsedInstruction, IndexedIdl, is_cpi_event_data,
+};

--- a/crates/sonar-idl/src/tests/event.rs
+++ b/crates/sonar-idl/src/tests/event.rs
@@ -1,7 +1,7 @@
 use serde_json::json;
 
 use crate::discriminator::sighash;
-use crate::indexed::{IndexedIdl, is_cpi_event_data};
+use crate::indexed::{IdlInstructionFields, IndexedIdl, is_cpi_event_data};
 
 use super::hello_anchor_indexed_idl;
 
@@ -67,6 +67,43 @@ fn indexed_idl_parse_cpi_event_data_parses_event_fields() {
     assert_eq!(parsed.fields[0].name, "amount");
     assert_eq!(parsed.fields[0].value, json!(500u64));
     assert_eq!(parsed.account_names, vec!["event_authority"]);
+}
+
+#[test]
+fn indexed_idl_parse_cpi_event_data_marks_fields_unparsed_on_decode_failure() {
+    let event_disc = sighash("event", "SwapComplete");
+
+    let indexed: IndexedIdl = serde_json::from_str(&format!(
+        r#"{{
+            "address": "11111111111111111111111111111111",
+            "metadata": {{ "name": "ev", "version": "0.1.0", "spec": "0.1.0" }},
+            "instructions": [],
+            "events": [{{
+                "name": "SwapComplete",
+                "discriminator": {:?},
+                "fields": [
+                    {{ "name": "amount_in", "type": "u64" }},
+                    {{ "name": "amount_out", "type": "u64" }}
+                ]
+            }}]
+        }}"#,
+        event_disc.to_vec()
+    ))
+    .unwrap();
+
+    // Build data with emit CPI prefix + event discriminator + only one u64 (truncated).
+    let mut data = vec![0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
+    data.extend_from_slice(&event_disc);
+    data.extend_from_slice(&42u64.to_le_bytes());
+    // Missing second u64 — decode should fail gracefully.
+
+    let parsed = indexed.parse_cpi_event_data(&data).unwrap().unwrap();
+    assert_eq!(parsed.name, "SwapComplete");
+    assert_eq!(parsed.account_names, vec!["event_authority"]);
+    assert!(matches!(
+        parsed.fields,
+        IdlInstructionFields::Unparsed(ref hex) if hex == &hex::encode(&42u64.to_le_bytes())
+    ));
 }
 
 #[test]

--- a/crates/sonar-idl/src/tests/instruction.rs
+++ b/crates/sonar-idl/src/tests/instruction.rs
@@ -2,7 +2,7 @@ use serde_json::{Value, json};
 
 use crate::discriminator::sighash;
 use crate::idl::*;
-use crate::indexed::IndexedIdl;
+use crate::indexed::{IdlInstructionFields, IndexedIdl};
 
 use super::hello_anchor_indexed_idl;
 
@@ -212,7 +212,7 @@ fn indexed_idl_parse_instruction_multiple_primitive_args() {
 }
 
 #[test]
-fn indexed_idl_parse_instruction_errors_when_a_required_arg_is_missing() {
+fn indexed_idl_parse_instruction_marks_fields_unparsed_when_a_required_arg_is_missing() {
     let indexed: IndexedIdl = serde_json::from_str(
         r#"{
             "address": "11111111111111111111111111111111",
@@ -234,8 +234,13 @@ fn indexed_idl_parse_instruction_errors_when_a_required_arg_is_missing() {
     let mut data = vec![4, 5, 6, 7, 8, 9, 10, 11];
     data.extend_from_slice(&123u32.to_le_bytes());
 
-    let err = indexed.parse_instruction(&data).unwrap_err();
-    assert!(err.to_string().contains("Insufficient data"));
+    let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
+    assert_eq!(parsed.name, "pair");
+    assert_eq!(parsed.account_names, Vec::<String>::new());
+    assert!(matches!(
+        parsed.fields,
+        IdlInstructionFields::Unparsed(raw_args_hex) if raw_args_hex == "7b000000"
+    ));
 }
 
 #[test]
@@ -274,7 +279,7 @@ fn indexed_idl_parse_instruction_with_defined_struct_arg() {
 }
 
 #[test]
-fn indexed_idl_parse_instruction_errors_when_a_defined_struct_field_is_missing() {
+fn indexed_idl_parse_instruction_marks_fields_unparsed_when_a_defined_struct_field_is_missing() {
     let indexed: IndexedIdl = serde_json::from_str(
         r#"{
             "address": "11111111111111111111111111111111",
@@ -302,8 +307,12 @@ fn indexed_idl_parse_instruction_errors_when_a_defined_struct_field_is_missing()
     let mut data = vec![10, 20, 30, 40, 50, 60, 70, 80];
     data.extend_from_slice(&100u32.to_le_bytes());
 
-    let err = indexed.parse_instruction(&data).unwrap_err();
-    assert!(err.to_string().contains("Insufficient data"));
+    let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
+    assert_eq!(parsed.name, "create");
+    assert!(matches!(
+        parsed.fields,
+        IdlInstructionFields::Unparsed(raw_args_hex) if raw_args_hex == "64000000"
+    ));
 }
 
 #[test]

--- a/crates/sonar-idl/src/tests/instruction.rs
+++ b/crates/sonar-idl/src/tests/instruction.rs
@@ -475,3 +475,28 @@ fn indexed_idl_find_instruction_ignores_missing_discriminator() {
     let found = indexed.find_instruction_by_discriminator(&[1, 2, 3, 4, 5, 6, 7, 8]);
     assert!(found.is_none());
 }
+
+#[test]
+fn indexed_idl_parse_instruction_returns_empty_fields_for_zero_arg_instruction() {
+    let indexed: IndexedIdl = serde_json::from_str(
+        r#"{
+            "address": "11111111111111111111111111111111",
+            "metadata": { "name": "t", "version": "0.1.0", "spec": "0.1.0" },
+            "instructions": [{
+                "name": "ping",
+                "discriminator": [9,9,9,9,9,9,9,9],
+                "accounts": [{ "name": "payer", "writable": true, "signer": true }],
+                "args": []
+            }],
+            "types": []
+        }"#,
+    )
+    .unwrap();
+
+    let data = vec![9, 9, 9, 9, 9, 9, 9, 9];
+
+    let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
+    assert_eq!(parsed.name, "ping");
+    assert!(matches!(parsed.fields, IdlInstructionFields::Parsed(ref fields) if fields.is_empty()));
+    assert_eq!(parsed.account_names, vec!["payer"]);
+}

--- a/src/handlers/account.rs
+++ b/src/handlers/account.rs
@@ -76,6 +76,7 @@ pub(crate) fn handle(args: AccountArgs, json: bool) -> Result<()> {
             &account_type,
             &output,
             metadata_output.as_ref(),
+            &mut std::io::stdout().lock(),
         )?;
     }
 

--- a/src/handlers/simulate.rs
+++ b/src/handlers/simulate.rs
@@ -253,14 +253,17 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
     );
 
     progress.finish();
+    let ctx = output::SimulationContext {
+        account_closures: runner.account_closures(),
+        overrides: runner.overrides(),
+        fundings: runner.sol_fundings(),
+        token_fundings: runner.token_fundings(),
+    };
     output::render(
         &parsed_tx,
         runner.resolved_accounts(),
         &simulation,
-        runner.account_closures(),
-        runner.overrides(),
-        runner.sol_fundings(),
-        runner.token_fundings(),
+        &ctx,
         &mut parser_registry,
         &render_opts,
     )?;
@@ -417,15 +420,18 @@ fn handle_bundle(
         .collect();
 
     progress.finish();
+    let ctx = output::SimulationContext {
+        account_closures: runner.account_closures(),
+        overrides: runner.overrides(),
+        fundings: runner.sol_fundings(),
+        token_fundings: runner.token_fundings(),
+    };
     output::render_bundle(
         &updated_txs,
         total_tx_count,
         runner.resolved_accounts(),
         &simulations,
-        runner.account_closures(),
-        runner.overrides(),
-        runner.sol_fundings(),
-        runner.token_fundings(),
+        &ctx,
         parser_registry,
         render_opts,
     )?;

--- a/src/output/account_text.rs
+++ b/src/output/account_text.rs
@@ -1,14 +1,17 @@
 //! Colored text rendering for the `account` subcommand.
 
+use std::io::Write;
+
 use anyhow::Result;
 use colored::Colorize;
 use serde_json::Value;
 
-use super::terminal::render_section_title;
+use super::fmt::format_with_commas;
+use super::terminal::write_section_title;
+use super::theme::DIM_GRAY;
 
 const INDENT: &str = "  ";
 const INDENT_L2: &str = "    ";
-const DIM_GRAY: colored::CustomColor = colored::CustomColor { r: 128, g: 128, b: 128 };
 const INFO_LABEL_WIDTH: usize = 12;
 
 const WRAPPER_FIELDS: &[&str] = &["lamports", "space", "owner", "executable", "rentEpoch"];
@@ -21,20 +24,22 @@ pub(crate) fn render_account_text(
     account_type: &str,
     decoded: &Value,
     metadata: Option<&Value>,
+    w: &mut impl Write,
 ) -> Result<()> {
-    render_account_info(pubkey, account);
-    render_account_data(account_type, decoded, METADATA_SKIP_FIELDS);
+    render_account_info(pubkey, account, w);
+    render_account_data(account_type, decoded, METADATA_SKIP_FIELDS, w);
 
     if let Some(meta) = metadata {
-        render_metadata_section(meta);
+        render_metadata_section(meta, w);
     }
 
-    println!();
+    let _ = writeln!(w);
+    w.flush()?;
     Ok(())
 }
 
-fn render_account_info(pubkey: &str, account: &solana_account::Account) {
-    render_section_title("Account Info");
+fn render_account_info(pubkey: &str, account: &solana_account::Account, w: &mut impl Write) {
+    write_section_title(w, "Account Info");
 
     let sol = account.lamports as f64 / 1_000_000_000.0;
     let owner_str = account.owner.to_string();
@@ -43,24 +48,30 @@ fn render_account_info(pubkey: &str, account: &solana_account::Account) {
         None => owner_str,
     };
 
-    print_info_row("Address", pubkey);
+    print_info_row("Address", pubkey, w);
     print_info_row(
         "Balance",
         &format!("{:.9} SOL ({} lamports)", sol, format_with_commas(account.lamports)),
+        w,
     );
-    print_info_row("Owner", &owner_display);
-    print_info_row("Space", &format!("{} bytes", format_with_commas(account.data.len() as u64)));
-    print_info_row("Executable", if account.executable { "Yes" } else { "No" });
+    print_info_row("Owner", &owner_display, w);
+    print_info_row("Space", &format!("{} bytes", format_with_commas(account.data.len() as u64)), w);
+    print_info_row("Executable", if account.executable { "Yes" } else { "No" }, w);
 }
 
-fn print_info_row(label: &str, value: &str) {
+fn print_info_row(label: &str, value: &str, w: &mut impl Write) {
     let padded = format!("{:<w$}", label, w = INFO_LABEL_WIDTH);
-    println!("{}{}   {}", INDENT, padded.custom_color(DIM_GRAY), value);
+    let _ = writeln!(w, "{}{}   {}", INDENT, padded.custom_color(DIM_GRAY), value);
 }
 
-fn render_account_data(account_type: &str, decoded: &Value, extra_skip: &[&str]) {
+fn render_account_data(
+    account_type: &str,
+    decoded: &Value,
+    extra_skip: &[&str],
+    w: &mut impl Write,
+) {
     if account_type == "Address Lookup Table" {
-        render_lookup_table_data(decoded);
+        render_lookup_table_data(decoded, w);
         return;
     }
 
@@ -77,48 +88,53 @@ fn render_account_data(account_type: &str, decoded: &Value, extra_skip: &[&str])
             .collect()
     };
 
-    render_section_title(&format!("Account Data ({})", account_type));
+    write_section_title(w, &format!("Account Data ({})", account_type));
 
     if let Some(obj) = data.as_object() {
-        render_kv_pairs(obj, INDENT, &skip);
+        render_kv_pairs(obj, INDENT, &skip, w);
     }
 
     if let Some(exts) = extensions {
         if !exts.is_empty() {
-            render_section_title("Extensions");
-            render_extensions(exts);
+            write_section_title(w, "Extensions");
+            render_extensions(exts, w);
         }
     }
 }
 
-fn render_metadata_section(metadata: &Value) {
+fn render_metadata_section(metadata: &Value, w: &mut impl Write) {
     let data = metadata.get("data").unwrap_or(metadata);
 
-    render_section_title("Metaplex Metadata");
+    write_section_title(w, "Metaplex Metadata");
 
     if let Some(obj) = data.as_object() {
-        render_kv_pairs(obj, INDENT, &[]);
+        render_kv_pairs(obj, INDENT, &[], w);
     }
 }
 
-fn render_lookup_table_data(decoded: &Value) {
+fn render_lookup_table_data(decoded: &Value, w: &mut impl Write) {
     let data = decoded.get("data").unwrap_or(decoded);
 
-    render_section_title("Account Data (Address Lookup Table)");
+    write_section_title(w, "Account Data (Address Lookup Table)");
 
     if let Some(meta) = data.get("meta") {
         if let Some(obj) = meta.as_object() {
-            render_kv_pairs(obj, INDENT, &["_padding"]);
+            render_kv_pairs(obj, INDENT, &["_padding"], w);
         }
     }
 
     if let Some(Value::Array(addresses)) = data.get("addresses") {
-        render_section_title(&format!("Addresses ({})", addresses.len()));
-        render_address_list(addresses);
+        write_section_title(w, &format!("Addresses ({})", addresses.len()));
+        render_address_list(addresses, w);
     }
 }
 
-fn render_kv_pairs(obj: &serde_json::Map<String, Value>, indent: &str, skip_keys: &[&str]) {
+fn render_kv_pairs(
+    obj: &serde_json::Map<String, Value>,
+    indent: &str,
+    skip_keys: &[&str],
+    w: &mut impl Write,
+) {
     let entries: Vec<_> = obj.iter().filter(|(k, _)| !skip_keys.contains(&k.as_str())).collect();
 
     if entries.is_empty() {
@@ -131,30 +147,36 @@ fn render_kv_pairs(obj: &serde_json::Map<String, Value>, indent: &str, skip_keys
         let padded_key = format!("{:<w$}", key, w = max_key_len);
         match val {
             Value::Object(inner) if !inner.is_empty() => {
-                println!("{}{}", indent, padded_key.custom_color(DIM_GRAY));
+                let _ = writeln!(w, "{}{}", indent, padded_key.custom_color(DIM_GRAY));
                 let nested = format!("{}  ", indent);
-                render_kv_pairs(inner, &nested, &[]);
+                render_kv_pairs(inner, &nested, &[], w);
             }
             Value::Array(arr) if !arr.is_empty() && arr.iter().all(Value::is_object) => {
-                println!("{}{}", indent, padded_key.custom_color(DIM_GRAY));
+                let _ = writeln!(w, "{}{}", indent, padded_key.custom_color(DIM_GRAY));
                 let nested = format!("{}  ", indent);
                 for (i, item) in arr.iter().enumerate() {
                     if let Some(inner_obj) = item.as_object() {
                         let label = format!("[{}]", i + 1).custom_color(DIM_GRAY).to_string();
-                        println!("{}{}", nested, label);
+                        let _ = writeln!(w, "{}{}", nested, label);
                         let deep = format!("{}  ", nested);
-                        render_kv_pairs(inner_obj, &deep, &[]);
+                        render_kv_pairs(inner_obj, &deep, &[], w);
                     }
                 }
             }
             _ => {
-                println!("{}{}   {}", indent, padded_key.custom_color(DIM_GRAY), format_value(val));
+                let _ = writeln!(
+                    w,
+                    "{}{}   {}",
+                    indent,
+                    padded_key.custom_color(DIM_GRAY),
+                    format_value(val)
+                );
             }
         }
     }
 }
 
-fn render_address_list(addresses: &[Value]) {
+fn render_address_list(addresses: &[Value], w: &mut impl Write) {
     if addresses.is_empty() {
         return;
     }
@@ -164,29 +186,29 @@ fn render_address_list(addresses: &[Value]) {
     for (i, addr) in addresses.iter().enumerate() {
         if let Some(s) = addr.as_str() {
             let label = format!("[{:>w$}]", i, w = index_width).custom_color(DIM_GRAY).to_string();
-            println!("{}{} {}", INDENT, label, s);
+            let _ = writeln!(w, "{}{} {}", INDENT, label, s);
         }
     }
 }
 
-fn render_extensions(extensions: &[Value]) {
+fn render_extensions(extensions: &[Value], w: &mut impl Write) {
     for (i, ext) in extensions.iter().enumerate() {
         if i > 0 {
-            println!();
+            let _ = writeln!(w);
         }
 
         let type_name = ext.get("type").and_then(Value::as_str).unwrap_or("Unknown");
 
         let label = format!("[{}]", i + 1).custom_color(DIM_GRAY);
-        println!("{}{} {}", INDENT, label, type_name.bold());
+        let _ = writeln!(w, "{}{} {}", INDENT, label, type_name.bold());
 
         if let Some(data) = ext.get("data") {
             if let Some(obj) = data.as_object() {
                 if !obj.is_empty() {
-                    render_kv_pairs(obj, INDENT_L2, &[]);
+                    render_kv_pairs(obj, INDENT_L2, &[], w);
                 }
             } else if data.is_null() {
-                println!("{}(unsupported)", INDENT_L2);
+                let _ = writeln!(w, "{}(unsupported)", INDENT_L2);
             }
         }
     }
@@ -194,13 +216,7 @@ fn render_extensions(extensions: &[Value]) {
 
 fn format_value(value: &Value) -> String {
     match value {
-        Value::String(s) => {
-            if s.len() > 120 {
-                format!("{}…", &s[..120])
-            } else {
-                s.to_string()
-            }
-        }
+        Value::String(s) => super::fmt::truncate_display(s, 120),
         Value::Number(n) => n.to_string(),
         Value::Bool(b) => b.to_string(),
         Value::Null => "\u{2013}".to_string(),
@@ -210,18 +226,6 @@ fn format_value(value: &Value) -> String {
         }
         Value::Object(_) => serde_json::to_string(value).unwrap_or_else(|_| "{}".to_string()),
     }
-}
-
-fn format_with_commas(n: u64) -> String {
-    let s = n.to_string();
-    let mut result = String::new();
-    for (i, c) in s.chars().rev().enumerate() {
-        if i > 0 && i % 3 == 0 {
-            result.push(',');
-        }
-        result.push(c);
-    }
-    result.chars().rev().collect()
 }
 
 fn known_program_name(pubkey: &str) -> Option<&'static str> {

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -1,0 +1,86 @@
+//! Shared formatting utilities for terminal output.
+
+/// Format a number with comma separators for readability (e.g. `1000000` → `1,000,000`).
+pub(crate) fn format_with_commas(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}
+
+/// Truncate a display string to `limit` characters, appending `…` if truncated.
+/// Safe for multi-byte UTF-8 — slices on char boundaries.
+pub(crate) fn truncate_display(value: &str, limit: usize) -> String {
+    if value.len() <= limit {
+        value.to_string()
+    } else {
+        // Find the largest char boundary <= limit (equivalent to floor_char_boundary,
+        // which requires Rust 1.93+).
+        let mut end = limit;
+        while end > 0 && !value.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &value[..end])
+    }
+}
+
+/// Truncate a signature to `prefix…suffix` form (e.g. `AbcDef...xyzXYZ`).
+pub(crate) fn truncate_sig(sig: &str, prefix_len: usize) -> String {
+    if sig.len() <= prefix_len * 2 + 3 {
+        sig.to_string()
+    } else {
+        format!("{}...{}", &sig[..prefix_len], &sig[sig.len() - prefix_len..])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_with_commas_basic() {
+        assert_eq!(format_with_commas(0), "0");
+        assert_eq!(format_with_commas(999), "999");
+        assert_eq!(format_with_commas(1_000), "1,000");
+        assert_eq!(format_with_commas(1_000_000), "1,000,000");
+    }
+
+    #[test]
+    fn truncate_display_within_limit() {
+        assert_eq!(truncate_display("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_display_at_limit() {
+        assert_eq!(truncate_display("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_display_over_limit() {
+        assert_eq!(truncate_display("hello world", 5), "hello…");
+    }
+
+    #[test]
+    fn truncate_display_multibyte_safe() {
+        // 3-byte chars: "café" is c(1) a(1) f(1) é(2 bytes)
+        let s = "café";
+        let result = truncate_display(s, 4);
+        // Should not panic; truncates at char boundary
+        assert!(result.ends_with('…') || result == s);
+    }
+
+    #[test]
+    fn truncate_sig_short() {
+        assert_eq!(truncate_sig("abcdef", 3), "abcdef");
+    }
+
+    #[test]
+    fn truncate_sig_long() {
+        assert_eq!(truncate_sig("abcdefghijklmnop", 3), "abc...nop");
+    }
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,8 +1,11 @@
 mod account_text;
+mod fmt;
 mod json;
 mod report;
+mod table;
 pub(crate) mod terminal;
 mod text;
+mod theme;
 
 pub(crate) use account_text::render_account_text;
 pub(crate) use json::print_json;
@@ -42,15 +45,19 @@ pub struct RenderOptions {
     pub log_opts: LogDisplayOptions,
 }
 
-#[allow(clippy::too_many_arguments)]
+/// Grouped simulation context arguments that are always passed together.
+pub struct SimulationContext<'a> {
+    pub account_closures: &'a [Pubkey],
+    pub overrides: &'a [AccountOverride],
+    pub fundings: &'a [SolFunding],
+    pub token_fundings: &'a [PreparedTokenFunding],
+}
+
 pub fn render(
     parsed: &ParsedTransaction,
     resolved: &ResolvedAccounts,
     simulation: &ExecutionResult,
-    account_closures: &[Pubkey],
-    overrides: &[AccountOverride],
-    fundings: &[SolFunding],
-    token_fundings: &[PreparedTokenFunding],
+    ctx: &SimulationContext,
     parser_registry: &mut ParserRegistry,
     opts: &RenderOptions,
 ) -> Result<()> {
@@ -58,10 +65,7 @@ pub fn render(
         parsed,
         resolved,
         simulation,
-        account_closures,
-        overrides,
-        fundings,
-        token_fundings,
+        ctx,
         parser_registry,
         opts.verify_signatures,
         opts.balance_opts,
@@ -69,6 +73,7 @@ pub fn render(
     if opts.json {
         json::render_json(&report)
     } else {
+        let mut stdout = std::io::stdout().lock();
         text::render_text(
             &report,
             resolved,
@@ -76,6 +81,7 @@ pub fn render(
             opts.show_ix_data,
             opts.show_ix_detail,
             opts.log_opts,
+            &mut stdout,
         )
     }
 }
@@ -96,20 +102,20 @@ pub fn render_transaction_only(
         println!("{json}");
         Ok(())
     } else {
+        let mut stdout = std::io::stdout().lock();
         text::render_transaction_section_text(
             &transaction,
             resolved,
             parser_registry,
             show_ix_data,
             bundle_info,
-        );
-        Ok(())
+            &mut stdout,
+        )
     }
 }
 
 /// Render multiple decoded transactions as a single JSON array `[{...}, {...}]`.
 /// Used for bundle decode with `--json`; output is a valid JSON document parseable by jq.
-#[allow(clippy::too_many_arguments)]
 pub fn render_decode_bundle_json(
     parsed_txs: &[ParsedTransaction],
     resolved: &ResolvedAccounts,
@@ -126,16 +132,12 @@ pub fn render_decode_bundle_json(
 }
 
 /// Render multiple transaction simulation results (bundle simulation).
-#[allow(clippy::too_many_arguments)]
 pub fn render_bundle(
     parsed_txs: &[ParsedTransaction],
     total_tx_count: usize,
     resolved: &ResolvedAccounts,
     simulations: &[ExecutionResult],
-    account_closures: &[Pubkey],
-    overrides: &[AccountOverride],
-    fundings: &[SolFunding],
-    token_fundings: &[PreparedTokenFunding],
+    ctx: &SimulationContext,
     parser_registry: &mut ParserRegistry,
     opts: &RenderOptions,
 ) -> Result<()> {
@@ -143,10 +145,7 @@ pub fn render_bundle(
         parsed_txs,
         resolved,
         simulations,
-        account_closures,
-        overrides,
-        fundings,
-        token_fundings,
+        ctx,
         parser_registry,
         opts.verify_signatures,
         opts.balance_opts,
@@ -155,6 +154,7 @@ pub fn render_bundle(
     if opts.json {
         json::render_bundle_json(&bundle_report)
     } else {
+        let mut stdout = std::io::stdout().lock();
         text::render_bundle_text(
             &bundle_report,
             total_tx_count,
@@ -162,6 +162,7 @@ pub fn render_bundle(
             opts.show_ix_data,
             opts.show_ix_detail,
             opts.log_opts,
+            &mut stdout,
         )
     }
 }

--- a/src/output/report.rs
+++ b/src/output/report.rs
@@ -13,12 +13,11 @@ use crate::parsers::instruction::{
     ParsedInstruction, ParserRegistry, anchor_idl::is_anchor_cpi_event,
 };
 use sonar_sim::internals::{
-    AccountOverride, ExecutionResult, ExecutionStatus, PreparedTokenFunding, ResolvedAccounts,
-    ResolvedLookup, SimulationMetadata, SolFunding, compute_sol_changes, compute_token_changes,
-    extract_mint_decimals_combined,
+    AccountOverride, ExecutionResult, ExecutionStatus, ResolvedAccounts, ResolvedLookup,
+    SimulationMetadata, compute_sol_changes, compute_token_changes, extract_mint_decimals_combined,
 };
 
-use super::BalanceChangeOptions;
+use super::{BalanceChangeOptions, SimulationContext};
 
 #[derive(Serialize)]
 pub(super) struct Report {
@@ -81,15 +80,11 @@ pub(super) struct BundleTransactionReport {
 }
 
 impl BundleReport {
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn from_sources(
         parsed_txs: &[ParsedTransaction],
         resolved: &ResolvedAccounts,
         simulations: &[ExecutionResult],
-        account_closures: &[Pubkey],
-        overrides: &[AccountOverride],
-        fundings: &[SolFunding],
-        token_fundings: &[PreparedTokenFunding],
+        ctx: &SimulationContext,
         parser_registry: &mut ParserRegistry,
         verify_signatures: bool,
         balance_opts: BalanceChangeOptions,
@@ -114,10 +109,11 @@ impl BundleReport {
             })
             .collect();
 
-        let account_closures = closures_to_sections(account_closures);
-        let overrides = overrides.iter().map(override_to_section).collect();
+        let account_closures = closures_to_sections(ctx.account_closures);
+        let overrides = ctx.overrides.iter().map(override_to_section).collect();
 
-        let fundings = fundings
+        let fundings = ctx
+            .fundings
             .iter()
             .map(|entry| SolFundingSection {
                 pubkey: entry.pubkey.to_string(),
@@ -125,7 +121,8 @@ impl BundleReport {
             })
             .collect();
 
-        let token_fundings = token_fundings
+        let token_fundings = ctx
+            .token_fundings
             .iter()
             .map(|entry| TokenSolFundingSection {
                 account: entry.account.to_string(),
@@ -136,7 +133,6 @@ impl BundleReport {
             })
             .collect();
 
-        // Compute overall bundle balance changes (first tx pre -> last successful tx post)
         let (sol_balance_changes, token_balance_changes) =
             if balance_opts.show_balance_change && !simulations.is_empty() {
                 compute_bundle_overall_balance_changes(resolved, simulations, balance_opts)
@@ -157,15 +153,11 @@ impl BundleReport {
 }
 
 impl Report {
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn from_sources(
         parsed: &ParsedTransaction,
         resolved: &ResolvedAccounts,
         simulation: &ExecutionResult,
-        account_closures: &[Pubkey],
-        overrides: &[AccountOverride],
-        fundings: &[SolFunding],
-        token_fundings: &[PreparedTokenFunding],
+        ctx: &SimulationContext,
         parser_registry: &mut ParserRegistry,
         verify_signatures: bool,
         balance_opts: BalanceChangeOptions,
@@ -179,8 +171,8 @@ impl Report {
             verify_signatures,
         );
         let simulation_section = SimulationSection::from_result(simulation);
-        let account_closures = closures_to_sections(account_closures);
-        let overrides = overrides.iter().map(override_to_section).collect();
+        let account_closures = closures_to_sections(ctx.account_closures);
+        let overrides = ctx.overrides.iter().map(override_to_section).collect();
         let (sol_balance_changes, token_balance_changes) =
             if matches!(simulation.status, ExecutionStatus::Succeeded)
                 && balance_opts.show_balance_change
@@ -190,14 +182,16 @@ impl Report {
                 (Vec::new(), Vec::new())
             };
 
-        let fundings = fundings
+        let fundings = ctx
+            .fundings
             .iter()
             .map(|entry| SolFundingSection {
                 pubkey: entry.pubkey.to_string(),
                 amount_lamports: entry.amount_lamports,
             })
             .collect();
-        let token_fundings = token_fundings
+        let token_fundings = ctx
+            .token_fundings
             .iter()
             .map(|entry| TokenSolFundingSection {
                 account: entry.account.to_string(),

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -1,0 +1,202 @@
+//! Minimal table writer for aligned, per-cell-colored terminal output.
+
+use std::io::Write;
+
+use colored::Colorize;
+use unicode_width::UnicodeWidthStr;
+
+/// Column alignment.
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+pub(crate) enum Align {
+    Left,
+    Right,
+}
+
+/// A single table cell: plain text for width calculation + optional color.
+pub(crate) struct Cell {
+    text: String,
+    color: Option<(u8, u8, u8)>,
+}
+
+impl Cell {
+    /// Uncolored cell.
+    pub(crate) fn plain(text: &str) -> Self {
+        Self { text: text.to_string(), color: None }
+    }
+
+    /// Cell with an RGB color applied.
+    pub(crate) fn colored(text: &str, color: (u8, u8, u8)) -> Self {
+        Self { text: text.to_string(), color: Some(color) }
+    }
+
+    fn display_width(&self) -> usize {
+        UnicodeWidthStr::width(self.text.as_str())
+    }
+}
+
+/// Column definition.
+struct Column {
+    align: Align,
+}
+
+/// A table that auto-sizes columns and writes aligned, colored rows.
+///
+/// ```text
+/// let mut table = TableWriter::new("  ")
+///     .column(Align::Left)
+///     .column(Align::Right);
+/// table.row(vec![Cell::plain("hello"), Cell::colored("+1", (0,255,0))]);
+/// table.print(&mut std::io::stdout().lock());
+/// ```
+pub(crate) struct TableWriter {
+    columns: Vec<Column>,
+    rows: Vec<Vec<Cell>>,
+    indent: String,
+    max_width: Option<usize>,
+}
+
+impl TableWriter {
+    pub(crate) fn new(indent: &str) -> Self {
+        Self { columns: Vec::new(), rows: Vec::new(), indent: indent.to_string(), max_width: None }
+    }
+
+    /// Add a column definition. Call once per column, in order.
+    pub(crate) fn column(mut self, align: Align) -> Self {
+        self.columns.push(Column { align });
+        self
+    }
+
+    /// Set maximum total line width. Columns exceeding this are truncated.
+    pub(crate) fn max_width(mut self, width: usize) -> Self {
+        self.max_width = Some(width);
+        self
+    }
+
+    /// Push a row of cells. Must have the same number of cells as columns.
+    pub(crate) fn row(&mut self, cells: Vec<Cell>) {
+        debug_assert_eq!(cells.len(), self.columns.len(), "cell count must match column count");
+        self.rows.push(cells);
+    }
+
+    /// Compute per-column widths from the data.
+    fn column_widths(&self) -> Vec<usize> {
+        let mut widths = vec![0usize; self.columns.len()];
+        for row in &self.rows {
+            for (i, cell) in row.iter().enumerate() {
+                widths[i] = widths[i].max(cell.display_width());
+            }
+        }
+
+        // If max_width is set, shrink the widest column(s) to fit.
+        if let Some(max) = self.max_width {
+            let indent_width = UnicodeWidthStr::width(self.indent.as_str());
+            // 2 chars gap between columns
+            let gaps = if self.columns.is_empty() { 0 } else { (self.columns.len() - 1) * 2 };
+            let total: usize = widths.iter().sum::<usize>() + indent_width + gaps;
+            if total > max {
+                let overflow = total - max;
+                // Find the widest column and shrink it
+                if let Some((widest_idx, widest)) =
+                    widths.iter().enumerate().max_by_key(|(_, w)| **w)
+                {
+                    let min_col = 12; // never shrink below 12 chars
+                    let new_width = (*widest).saturating_sub(overflow).max(min_col);
+                    widths[widest_idx] = new_width;
+                }
+            }
+        }
+
+        widths
+    }
+
+    /// Write the table to a writer.
+    pub(crate) fn print(&self, w: &mut impl Write) {
+        let widths = self.column_widths();
+
+        for row in &self.rows {
+            let _ = write!(w, "{}", self.indent);
+            for (i, cell) in row.iter().enumerate() {
+                if i > 0 {
+                    let _ = write!(w, "  ");
+                }
+                let width = widths.get(i).copied().unwrap_or(0);
+                let text = if cell.display_width() > width {
+                    // Truncate to fit column width
+                    super::fmt::truncate_display(&cell.text, width.saturating_sub(1))
+                } else {
+                    cell.text.clone()
+                };
+                let align = self.columns.get(i).map(|c| c.align).unwrap_or(Align::Left);
+                let formatted = match align {
+                    Align::Left => format!("{:<width$}", text, width = width),
+                    Align::Right => format!("{:>width$}", text, width = width),
+                };
+                match cell.color {
+                    Some(color) => {
+                        let _ = write!(w, "{}", formatted.custom_color(color));
+                    }
+                    None => {
+                        let _ = write!(w, "{}", formatted);
+                    }
+                }
+            }
+            let _ = writeln!(w);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_alignment() {
+        colored::control::set_override(false);
+        let mut table = TableWriter::new("  ").column(Align::Left).column(Align::Right);
+        table.row(vec![Cell::plain("a"), Cell::plain("1")]);
+        table.row(vec![Cell::plain("bbb"), Cell::plain("22")]);
+
+        let mut buf = Vec::new();
+        table.print(&mut buf);
+        let output = String::from_utf8(buf).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines[0], "  a     1");
+        assert_eq!(lines[1], "  bbb  22");
+    }
+
+    #[test]
+    fn colored_cells_align_correctly() {
+        colored::control::set_override(false);
+        let mut table = TableWriter::new("").column(Align::Left).column(Align::Left);
+        table.row(vec![Cell::colored("short", (255, 0, 0)), Cell::plain("x")]);
+        table.row(vec![Cell::colored("longer", (0, 255, 0)), Cell::plain("y")]);
+
+        let mut buf = Vec::new();
+        table.print(&mut buf);
+        let output = String::from_utf8(buf).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        // "short " should be padded to match "longer"
+        assert_eq!(lines[0], "short   x");
+        assert_eq!(lines[1], "longer  y");
+    }
+
+    #[test]
+    fn max_width_truncates_widest_column() {
+        colored::control::set_override(false);
+        let mut table = TableWriter::new("")
+            .column(Align::Left)
+            .column(Align::Left)
+            .max_width(25);
+        // col0: 20 chars, col1: 5 chars → total 20+2+5 = 27, overflow = 2
+        table.row(vec![Cell::plain("a]234567890123456789"), Cell::plain("hello")]);
+
+        let mut buf = Vec::new();
+        table.print(&mut buf);
+        let output = String::from_utf8(buf).unwrap();
+        // The widest column (col0) should be truncated to fit
+        let first_line = output.lines().next().unwrap();
+        let display_width = UnicodeWidthStr::width(first_line);
+        assert!(display_width <= 25, "line too wide: {} ({})", first_line, display_width);
+    }
+}

--- a/src/output/terminal.rs
+++ b/src/output/terminal.rs
@@ -1,15 +1,18 @@
+use std::io::Write;
+
 use colored::Colorize;
 use unicode_width::UnicodeWidthStr;
 
-/// Get effective terminal width for text rendering.
-/// Falls back to 80 when width detection is unavailable.
-fn terminal_width() -> usize {
-    terminal_size::terminal_size().map(|(width, _)| (width.0 as usize).clamp(60, 120)).unwrap_or(80)
+/// Detect the real terminal width, returning `None` when stdout is not a TTY
+/// (piped, redirected, or captured).  Clamped to 60–120.
+pub(crate) fn terminal_width() -> Option<usize> {
+    terminal_size::terminal_size().map(|(width, _)| (width.0 as usize).clamp(60, 120))
 }
 
 /// Header content width with one-space side margins.
+/// Falls back to 80 when width detection is unavailable.
 fn header_content_width() -> usize {
-    terminal_width().saturating_sub(2).max(1)
+    terminal_width().unwrap_or(80).saturating_sub(2).max(1)
 }
 
 fn build_section_title_block(title: &str, width: usize) -> String {
@@ -27,9 +30,9 @@ fn build_section_title_block(title: &str, width: usize) -> String {
     )
 }
 
-/// Render a section title with centered text flanked by `-` lines.
-pub(crate) fn render_section_title(title: &str) {
-    print!("{}", build_section_title_block(title, header_content_width()));
+/// Write a section title with centered text flanked by `─` lines.
+pub(crate) fn write_section_title(w: &mut impl Write, title: &str) {
+    let _ = write!(w, "{}", build_section_title_block(title, header_content_width()));
 }
 
 #[cfg(test)]

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -31,6 +31,8 @@ const INDENT_L2: &str = "    ";
 
 /// Subdued gray for metadata columns (index labels, permission flags, account names).
 const DIM_GRAY: colored::CustomColor = colored::CustomColor { r: 128, g: 128, b: 128 };
+/// Warm amber for fallback raw hex when structured instruction decoding fails.
+const RAW_HEX_AMBER: colored::CustomColor = colored::CustomColor { r: 214, g: 154, b: 74 };
 
 pub(super) fn render_text(
     report: &Report,
@@ -547,6 +549,7 @@ fn render_instruction_details_text(
 
         // Try to parse the instruction
         if let Some(parsed) = &ix.parsed {
+            let use_raw_hex_fallback = should_render_raw_instruction_hex(&parsed.fields);
             println!(
                 "#{} {} {}",
                 outer_number.to_string().custom_color((229, 192, 123)),
@@ -570,11 +573,19 @@ fn render_instruction_details_text(
                 );
             }
 
-            if show_ix_data {
+            if use_raw_hex_fallback {
+                render_instruction_data_text_with_color(
+                    &current_data_indent,
+                    &ix.data,
+                    Some(RAW_HEX_AMBER),
+                );
+            } else if show_ix_data {
                 render_instruction_data_text(&current_data_indent, &ix.data);
             }
 
-            render_parsed_fields(&parsed.fields, &current_data_indent);
+            if !use_raw_hex_fallback {
+                render_parsed_fields(&parsed.fields, &current_data_indent);
+            }
         } else {
             println!(
                 "#{} {}",
@@ -597,6 +608,8 @@ fn render_instruction_details_text(
                 };
 
                 if let Some(parsed_inner) = &inner_ix.parsed {
+                    let use_raw_hex_fallback =
+                        should_render_raw_instruction_hex(&parsed_inner.fields);
                     println!(
                         "{}{} {} {}",
                         INDENT_L1,
@@ -620,11 +633,19 @@ fn render_instruction_details_text(
                         );
                     }
 
-                    if show_ix_data {
+                    if use_raw_hex_fallback {
+                        render_instruction_data_text_with_color(
+                            &current_inner_data_indent,
+                            &inner_ix.data,
+                            Some(RAW_HEX_AMBER),
+                        );
+                    } else if show_ix_data {
                         render_instruction_data_text(&current_inner_data_indent, &inner_ix.data);
                     }
 
-                    render_parsed_fields(&parsed_inner.fields, &current_inner_data_indent);
+                    if !use_raw_hex_fallback {
+                        render_parsed_fields(&parsed_inner.fields, &current_inner_data_indent);
+                    }
                 } else {
                     println!(
                         "{}{} {}",
@@ -882,5 +903,37 @@ fn render_parsed_fields(fields: &[ParsedField], indent: &str) {
 }
 
 fn render_instruction_data_text(indent: &str, data: &[u8]) {
-    println!("{}0x{} {} bytes", indent, hex::encode(data), data.len());
+    render_instruction_data_text_with_color(indent, data, None);
+}
+
+fn render_instruction_data_text_with_color(
+    indent: &str,
+    data: &[u8],
+    color: Option<colored::CustomColor>,
+) {
+    let line = format!("{}0x{} {} bytes", indent, hex::encode(data), data.len());
+    match color {
+        Some(color) => println!("{}", line.custom_color(color)),
+        None => println!("{line}"),
+    }
+}
+
+fn should_render_raw_instruction_hex(fields: &[ParsedField]) -> bool {
+    matches!(
+        fields,
+        [ParsedField { name, value: ParsedFieldValue::Text(raw_hex) }]
+            if name == "__raw_hex__" && !raw_hex.is_empty()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_render_raw_instruction_hex_for_unparsed_idl_fields() {
+        let fields = vec![ParsedField::text("__raw_hex__", "0025a16608ca3c00")];
+
+        assert!(should_render_raw_instruction_hex(&fields));
+    }
 }

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -549,7 +549,6 @@ fn render_instruction_details_text(
 
         // Try to parse the instruction
         if let Some(parsed) = &ix.parsed {
-            let use_raw_hex_fallback = should_render_raw_instruction_hex(&parsed.fields);
             println!(
                 "#{} {} {}",
                 outer_number.to_string().custom_color((229, 192, 123)),
@@ -573,19 +572,12 @@ fn render_instruction_details_text(
                 );
             }
 
-            if use_raw_hex_fallback {
-                render_instruction_data_text_with_color(
-                    &current_data_indent,
-                    &ix.data,
-                    Some(RAW_HEX_AMBER),
-                );
-            } else if show_ix_data {
-                render_instruction_data_text(&current_data_indent, &ix.data);
-            }
-
-            if !use_raw_hex_fallback {
-                render_parsed_fields(&parsed.fields, &current_data_indent);
-            }
+            render_instruction_data_and_fields(
+                &parsed.fields,
+                &current_data_indent,
+                &ix.data,
+                show_ix_data,
+            );
         } else {
             println!(
                 "#{} {}",
@@ -608,8 +600,6 @@ fn render_instruction_details_text(
                 };
 
                 if let Some(parsed_inner) = &inner_ix.parsed {
-                    let use_raw_hex_fallback =
-                        should_render_raw_instruction_hex(&parsed_inner.fields);
                     println!(
                         "{}{} {} {}",
                         INDENT_L1,
@@ -633,19 +623,12 @@ fn render_instruction_details_text(
                         );
                     }
 
-                    if use_raw_hex_fallback {
-                        render_instruction_data_text_with_color(
-                            &current_inner_data_indent,
-                            &inner_ix.data,
-                            Some(RAW_HEX_AMBER),
-                        );
-                    } else if show_ix_data {
-                        render_instruction_data_text(&current_inner_data_indent, &inner_ix.data);
-                    }
-
-                    if !use_raw_hex_fallback {
-                        render_parsed_fields(&parsed_inner.fields, &current_inner_data_indent);
-                    }
+                    render_instruction_data_and_fields(
+                        &parsed_inner.fields,
+                        &current_inner_data_indent,
+                        &inner_ix.data,
+                        show_ix_data,
+                    );
                 } else {
                     println!(
                         "{}{} {}",
@@ -902,24 +885,31 @@ fn render_parsed_fields(fields: &ParsedInstructionFields, indent: &str) {
     }
 }
 
-fn render_instruction_data_text(indent: &str, data: &[u8]) {
-    render_instruction_data_text_with_color(indent, data, None);
-}
-
-fn render_instruction_data_text_with_color(
+/// Render instruction data hex and/or parsed fields, choosing the raw-hex-amber
+/// fallback when structured decoding failed.
+fn render_instruction_data_and_fields(
+    fields: &ParsedInstructionFields,
     indent: &str,
     data: &[u8],
-    color: Option<colored::CustomColor>,
+    show_ix_data: bool,
 ) {
-    let line = format!("{}0x{} {} bytes", indent, hex::encode(data), data.len());
-    match color {
-        Some(color) => println!("{}", line.custom_color(color)),
-        None => println!("{line}"),
+    // Non-empty RawHex means IDL matched but arg decoding failed — show amber hex.
+    if let ParsedInstructionFields::RawHex(raw_hex) = fields {
+        if !raw_hex.is_empty() {
+            let line = format!("{}0x{} {} bytes", indent, hex::encode(data), data.len());
+            println!("{}", line.custom_color(RAW_HEX_AMBER));
+            return;
+        }
     }
+
+    if show_ix_data {
+        render_instruction_data_text(indent, data);
+    }
+    render_parsed_fields(fields, indent);
 }
 
-fn should_render_raw_instruction_hex(fields: &ParsedInstructionFields) -> bool {
-    matches!(fields, ParsedInstructionFields::RawHex(raw_hex) if !raw_hex.is_empty())
+fn render_instruction_data_text(indent: &str, data: &[u8]) {
+    println!("{}0x{} {} bytes", indent, hex::encode(data), data.len());
 }
 
 #[cfg(test)]
@@ -927,9 +917,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn should_render_raw_instruction_hex_for_unparsed_idl_fields() {
+    fn render_instruction_data_and_fields_uses_raw_hex_for_unparsed() {
+        // Verify the function returns early (no panic) for the RawHex variant.
+        // Stdout output is not captured here, but this exercises the code path.
         let fields = ParsedInstructionFields::RawHex("0025a16608ca3c00".to_string());
-
-        assert!(should_render_raw_instruction_hex(&fields));
+        render_instruction_data_and_fields(&fields, "  ", &[0, 37, 161, 102], false);
     }
 }

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::str::FromStr;
 
 use anyhow::Result;
@@ -15,12 +16,14 @@ use crate::parsers::{
 };
 use sonar_sim::internals::ResolvedAccounts;
 
+use super::fmt::{format_with_commas, truncate_display, truncate_sig};
 use super::LogDisplayOptions;
 use super::report::{
-    BundleReport, BundleTransactionReport, InstructionAccountEntry, Report, SimulationSection,
+    BundleReport, InstructionAccountEntry, Report, SimulationSection,
     SimulationStatusReport, SolBalanceChangeSection, TokenBalanceChangeSection, TransactionSection,
 };
-use super::terminal::render_section_title;
+use super::terminal::{terminal_width, write_section_title};
+use super::theme::{COLOR_BLUE, COLOR_GOLD, COLOR_GREEN, COLOR_RED, DIM_GRAY, RAW_HEX_AMBER};
 
 /// Single indentation unit (2 spaces).
 const INDENT: &str = "  ";
@@ -29,11 +32,6 @@ const INDENT_L1: &str = INDENT;
 /// Indentation for inner items (level 2 = 4 spaces).
 const INDENT_L2: &str = "    ";
 
-/// Subdued gray for metadata columns (index labels, permission flags, account names).
-const DIM_GRAY: colored::CustomColor = colored::CustomColor { r: 128, g: 128, b: 128 };
-/// Warm amber for fallback raw hex when structured instruction decoding fails.
-const RAW_HEX_AMBER: colored::CustomColor = colored::CustomColor { r: 214, g: 154, b: 74 };
-
 pub(super) fn render_text(
     report: &Report,
     resolved: &ResolvedAccounts,
@@ -41,39 +39,34 @@ pub(super) fn render_text(
     show_ix_data: bool,
     show_ix_detail: bool,
     log_opts: LogDisplayOptions,
+    w: &mut impl Write,
 ) -> Result<()> {
-    // Summary header (status + CU)
-    render_summary_header(&report.simulation, &report.transaction);
+    render_summary_header(&report.simulation, &report.transaction, w);
 
-    // Execution Trace (also show when failed without runtime logs)
     if !report.simulation.logs.is_empty()
         || matches!(&report.simulation.status, SimulationStatusReport::Failed { .. })
     {
-        render_section_title("Execution Trace");
-        render_execution_trace_section(&report.simulation, log_opts);
+        write_section_title(w, "Execution Trace");
+        render_execution_trace_section(&report.simulation, log_opts, w);
     }
 
-    // Instruction Details
     if show_ix_detail {
-        render_section_title("Instruction Details");
-        render_instruction_details_text(&report.transaction, resolved, show_ix_data);
+        write_section_title(w, "Instruction Details");
+        render_instruction_details_text(&report.transaction, resolved, show_ix_data, w);
     }
 
-    // SOL Balance Changes
     if !report.sol_balance_changes.is_empty() {
-        render_section_title("SOL Balance Changes");
-        render_sol_balance_changes(&report.sol_balance_changes, "");
+        write_section_title(w, "SOL Balance Changes");
+        render_sol_balance_changes(&report.sol_balance_changes, "", w);
     }
 
-    // Token Balance Changes
     if !report.token_balance_changes.is_empty() {
-        render_section_title("Token Balance Changes");
-        render_token_balance_changes(&report.token_balance_changes, "");
+        write_section_title(w, "Token Balance Changes");
+        render_token_balance_changes(&report.token_balance_changes, "", w);
     }
 
-    // Final empty line
-    println!();
-
+    let _ = writeln!(w);
+    w.flush()?;
     Ok(())
 }
 
@@ -84,11 +77,10 @@ pub(super) fn render_bundle_text(
     show_ix_data: bool,
     show_ix_detail: bool,
     log_opts: LogDisplayOptions,
+    w: &mut impl Write,
 ) -> Result<()> {
-    // Bundle summary header (status + per-TX overview)
-    render_bundle_summary_header(bundle, total_count);
+    render_bundle_summary_header(bundle, total_count, w);
 
-    // Execution Trace (per-TX): render TX with logs, or failed TX without logs.
     let has_logs_or_failed = bundle.transactions.iter().any(|t| {
         !t.simulation.logs.is_empty()
             || matches!(&t.simulation.status, SimulationStatusReport::Failed { .. })
@@ -100,33 +92,30 @@ pub(super) fn render_bundle_text(
             if !should_render {
                 continue;
             }
-            render_section_title(&format!("Execution Trace: TX {}/{}", i + 1, total_count));
-            render_bundle_transaction_trace(tx_report, log_opts);
+            write_section_title(w, &format!("Execution Trace: TX {}/{}", i + 1, total_count));
+            render_execution_trace_section(&tx_report.simulation, log_opts, w);
         }
     }
 
-    // Instruction Details (per-TX)
     if show_ix_detail {
         for (i, tx_report) in bundle.transactions.iter().enumerate() {
-            render_section_title(&format!("Instruction Details: TX {}/{}", i + 1, total_count));
-            render_bundle_transaction_ix_detail(tx_report, resolved, show_ix_data);
+            write_section_title(w, &format!("Instruction Details: TX {}/{}", i + 1, total_count));
+            render_instruction_details_text(&tx_report.transaction, resolved, show_ix_data, w);
         }
     }
 
-    // SOL Balance Changes
     if !bundle.sol_balance_changes.is_empty() {
-        render_section_title("SOL Balance Changes");
-        render_sol_balance_changes(&bundle.sol_balance_changes, INDENT_L1);
+        write_section_title(w, "SOL Balance Changes");
+        render_sol_balance_changes(&bundle.sol_balance_changes, INDENT_L1, w);
     }
 
-    // Token Balance Changes
     if !bundle.token_balance_changes.is_empty() {
-        render_section_title("Token Balance Changes");
-        render_token_balance_changes(&bundle.token_balance_changes, INDENT_L1);
+        write_section_title(w, "Token Balance Changes");
+        render_token_balance_changes(&bundle.token_balance_changes, INDENT_L1, w);
     }
 
-    println!();
-
+    let _ = writeln!(w);
+    w.flush()?;
     Ok(())
 }
 
@@ -136,33 +125,38 @@ pub(super) fn render_transaction_section_text(
     _parser_registry: &mut ParserRegistry,
     show_ix_data: bool,
     bundle_info: Option<(usize, usize)>,
-) {
-    // Build TX suffix for bundle mode, e.g. ": TX 1/3"
+    w: &mut impl Write,
+) -> Result<()> {
     let tx_suffix = match bundle_info {
         Some((index, total)) => format!(": TX {}/{}", index, total),
         None => String::new(),
     };
 
-    render_section_title(&format!("Decoded Instructions{}", tx_suffix));
-    render_instruction_details_text(transaction, resolved, show_ix_data);
+    write_section_title(w, &format!("Decoded Instructions{}", tx_suffix));
+    render_instruction_details_text(transaction, resolved, show_ix_data, w);
 
-    // Address Lookup Tables (only if present)
     if !transaction.lookups.is_empty() {
-        render_section_title(&format!("Address Lookup Tables{}", tx_suffix));
-        render_lookup_tables_text(transaction);
+        write_section_title(w, &format!("Address Lookup Tables{}", tx_suffix));
+        render_lookup_tables_text(transaction, w);
     }
 
-    // Account list at the end
-    render_section_title(&format!("Account List{}", tx_suffix));
-    render_account_list_text(transaction, resolved);
+    write_section_title(w, &format!("Account List{}", tx_suffix));
+    render_account_list_text(transaction, resolved, w);
 
-    // Final empty line for consistent CLI output termination.
-    println!();
+    let _ = writeln!(w);
+    w.flush()?;
+    Ok(())
 }
 
-/// Render the bundle summary header showing overall status and per-transaction compact rows.
-fn render_bundle_summary_header(bundle: &BundleReport, total_count: usize) {
-    // Determine overall bundle status
+// ---------------------------------------------------------------------------
+// Bundle summary
+// ---------------------------------------------------------------------------
+
+fn render_bundle_summary_header(
+    bundle: &BundleReport,
+    total_count: usize,
+    w: &mut impl Write,
+) {
     let succeeded = bundle
         .transactions
         .iter()
@@ -182,7 +176,6 @@ fn render_bundle_summary_header(bundle: &BundleReport, total_count: usize) {
         "~  PARTIAL".to_string()
     };
 
-    // Total CU consumed across all transactions
     let total_cu: u64 =
         bundle.transactions.iter().map(|t| t.simulation.compute_units_consumed).sum();
 
@@ -193,12 +186,11 @@ fn render_bundle_summary_header(bundle: &BundleReport, total_count: usize) {
         total_count,
         format_with_commas(total_cu)
     );
-    render_section_title(&summary_text);
+    write_section_title(w, &summary_text);
 
     let tx_col_width = total_count.to_string().len().max(2);
     const CU_COL_WIDTH: usize = 12;
 
-    // Per-transaction compact rows
     for (i, tx_report) in bundle.transactions.iter().enumerate() {
         let idx = i + 1;
         let status_icon = match &tx_report.simulation.status {
@@ -216,7 +208,8 @@ fn render_bundle_summary_header(bundle: &BundleReport, total_count: usize) {
             .map(|s| truncate_sig(s, 6))
             .unwrap_or_else(|| "<no-sig>".to_string());
 
-        println!(
+        let _ = writeln!(
+            w,
             "{}TX {:>tx_w$}/{:<tx_w$}  {}  CU: {:>cu_w$} / {:>cu_w$} ({:>3}%)  {}",
             INDENT_L1,
             idx,
@@ -231,9 +224,9 @@ fn render_bundle_summary_header(bundle: &BundleReport, total_count: usize) {
         );
     }
 
-    // Render skipped transactions
     for i in bundle.transactions.len()..total_count {
-        println!(
+        let _ = writeln!(
+            w,
             "{}TX {:>tx_w$}/{:<tx_w$}  »  SKIPPED",
             INDENT_L1,
             i + 1,
@@ -243,30 +236,20 @@ fn render_bundle_summary_header(bundle: &BundleReport, total_count: usize) {
     }
 }
 
-fn render_bundle_transaction_trace(
-    tx_report: &BundleTransactionReport,
-    log_opts: LogDisplayOptions,
-) {
-    render_execution_trace_section(&tx_report.simulation, log_opts);
-}
+// ---------------------------------------------------------------------------
+// Single-TX summary
+// ---------------------------------------------------------------------------
 
-fn render_bundle_transaction_ix_detail(
-    tx_report: &BundleTransactionReport,
-    resolved: &ResolvedAccounts,
-    show_ix_data: bool,
+fn render_summary_header(
+    simulation: &SimulationSection,
+    transaction: &TransactionSection,
+    w: &mut impl Write,
 ) {
-    render_instruction_details_text(&tx_report.transaction, resolved, show_ix_data);
-}
-
-/// Render the summary header showing status and compute units (displayed first).
-fn render_summary_header(simulation: &SimulationSection, transaction: &TransactionSection) {
-    // For failed transactions, don't print the error reason
     let status_str = match &simulation.status {
         SimulationStatusReport::Succeeded => "✓ SUCCESS".to_string(),
         SimulationStatusReport::Failed { .. } => "✗ FAILED".to_string(),
     };
 
-    // Try to extract compute unit limit from SetComputeUnitLimit instruction
     let cu_limit = extract_compute_unit_limit(transaction).unwrap_or(200_000);
     let cu_used = simulation.compute_units_consumed;
     let percentage =
@@ -280,10 +263,9 @@ fn render_summary_header(simulation: &SimulationSection, transaction: &Transacti
         percentage,
         transaction.size_bytes
     );
-    render_section_title(&result_text);
+    write_section_title(w, &result_text);
 }
 
-/// Extract compute unit limit from SetComputeUnitLimit instruction if present.
 fn extract_compute_unit_limit(transaction: &TransactionSection) -> Option<u64> {
     for ix in &transaction.instructions {
         if let Some(parsed) = &ix.parsed {
@@ -310,253 +292,250 @@ fn extract_compute_unit_limit(transaction: &TransactionSection) -> Option<u64> {
     None
 }
 
-/// Format a number with comma separators for readability.
-fn format_with_commas(n: u64) -> String {
-    let s = n.to_string();
-    let mut result = String::new();
-    for (i, c) in s.chars().rev().enumerate() {
-        if i > 0 && i % 3 == 0 {
-            result.push(',');
-        }
-        result.push(c);
-    }
-    result.chars().rev().collect()
-}
+// ---------------------------------------------------------------------------
+// Execution trace / logs
+// ---------------------------------------------------------------------------
 
-/// Render execution trace section with centered header.
-fn render_execution_trace_section(simulation: &SimulationSection, log_opts: LogDisplayOptions) {
+fn render_execution_trace_section(
+    simulation: &SimulationSection,
+    log_opts: LogDisplayOptions,
+    w: &mut impl Write,
+) {
     if simulation.logs.is_empty() {
-        render_no_trace_hint(simulation, INDENT_L1);
+        if let SimulationStatusReport::Failed { error } = &simulation.status {
+            let _ = writeln!(w, "{}↳ Failed before program invocation: {}", INDENT_L1, error);
+        }
         return;
     }
 
     if log_opts.raw_log {
         for line in &simulation.logs {
-            println!("{}", line);
+            let _ = writeln!(w, "{}", line);
         }
     } else {
-        render_logs_structured(&simulation.logs);
+        render_logs_structured(&simulation.logs, w);
     }
 }
 
-fn render_no_trace_hint(simulation: &SimulationSection, indent: &str) {
-    if let SimulationStatusReport::Failed { error } = &simulation.status {
-        println!("{}↳ Failed before program invocation: {}", indent, error);
-    }
-}
+fn render_logs_structured(logs: &[String], w: &mut impl Write) {
+    let instruction_logs = parse_logs_by_instruction(logs);
 
-fn render_sol_balance_changes(sol_changes: &[SolBalanceChangeSection], indent: &str) {
-    let rows: Vec<_> = sol_changes
-        .iter()
-        .map(|c| {
-            let sol_before = c.before as f64 / 1_000_000_000.0;
-            let sol_after = c.after as f64 / 1_000_000_000.0;
-            let sign = if c.change >= 0 { "+" } else { "" };
-            let col_delta = format!("{}{:.9}", sign, c.change_sol);
-            let col_before = format!("{:.9}", sol_before);
-            let col_after = format!("{:.9}", sol_after);
-            let color = if c.change >= 0 { (152, 195, 121) } else { (224, 108, 117) };
-            (c.account.as_str(), col_delta, col_before, col_after, color)
-        })
-        .collect();
-
-    let w_account = rows.iter().map(|r| r.0.len()).max().unwrap_or(0);
-    let w_delta = rows.iter().map(|r| r.1.len()).max().unwrap_or(0);
-    let w_before = rows.iter().map(|r| r.2.len()).max().unwrap_or(0);
-
-    for (col_account, col_delta, col_before, col_after, color) in &rows {
-        println!(
-            "{}{}{:<wa$}  {}  {}",
-            indent,
-            INDENT_L1,
-            col_account,
-            format!("{:<width$}", col_delta, width = w_delta).custom_color(*color),
-            format!("{:<wb$} → {}", col_before, col_after, wb = w_before)
-                .custom_color((171, 178, 191)),
-            wa = w_account,
+    for (idx, inst_logs) in instruction_logs.iter().enumerate() {
+        if idx > 0 {
+            let _ = writeln!(w);
+        }
+        let program_name = get_program_display_name(&inst_logs.program);
+        let _ = writeln!(
+            w,
+            "{} {} instruction",
+            format!("#{}", inst_logs.instruction_index + 1).bold(),
+            program_name.bold()
         );
+
+        for entry_with_depth in &inst_logs.entries {
+            render_log_entry(entry_with_depth, w);
+        }
+    }
+}
+
+fn get_program_display_name(pubkey: &str) -> &str {
+    pubkey
+}
+
+fn render_log_entry(entry_with_depth: &LogEntryWithDepth, w: &mut impl Write) {
+    let depth = entry_with_depth.depth as usize;
+    let indent = INDENT.repeat(depth);
+
+    match &entry_with_depth.entry {
+        LogEntry::Invoke { program, depth: invoke_depth } => {
+            if *invoke_depth > 1 {
+                let program_name = get_program_display_name(program);
+                let _ = writeln!(w, "{}{} {}", indent, "> Invoking".cyan(), program_name.cyan());
+            }
+        }
+        LogEntry::Log { message } => {
+            let _ = writeln!(
+                w,
+                "{}{} {}",
+                indent,
+                ">".custom_color(DIM_GRAY),
+                format!("Program log: {}", message).custom_color(DIM_GRAY)
+            );
+        }
+        LogEntry::Data { data } => {
+            let _ = writeln!(
+                w,
+                "{}{} {}",
+                indent,
+                ">".custom_color(DIM_GRAY),
+                format!("Program data: {}", truncate_display(data, 60)).custom_color(DIM_GRAY)
+            );
+        }
+        LogEntry::Consumed { _program: _, used, total } => {
+            let _ = writeln!(
+                w,
+                "{}{} {}",
+                indent,
+                ">".custom_color(DIM_GRAY),
+                format!("Program consumed: {} of {} compute units", used, total)
+                    .custom_color(DIM_GRAY)
+            );
+        }
+        LogEntry::Success { _program: _ } => {
+            let _ = writeln!(w, "{}{} {}", indent, ">".green(), "Program returned success".green());
+        }
+        LogEntry::Failed { _program: _, error } => {
+            let _ = writeln!(
+                w,
+                "{}{} {}",
+                indent,
+                ">".red(),
+                format!("Program failed: {}", error).red()
+            );
+        }
+        LogEntry::Return { _program: _, data } => {
+            let _ = writeln!(
+                w,
+                "{}{} {}",
+                indent,
+                ">".custom_color(DIM_GRAY),
+                format!("Program return: {}", truncate_display(data, 60)).custom_color(DIM_GRAY)
+            );
+        }
+        LogEntry::Other(msg) => {
+            if !msg.is_empty() {
+                let _ =
+                    writeln!(w, "{}{} {}", indent, ">".custom_color(DIM_GRAY), msg.custom_color(DIM_GRAY));
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Balance change tables
+// ---------------------------------------------------------------------------
+
+fn render_sol_balance_changes(
+    sol_changes: &[SolBalanceChangeSection],
+    indent: &str,
+    w: &mut impl Write,
+) {
+    use super::table::{Align, Cell, TableWriter};
+
+    let prefix = format!("{}{}", indent, INDENT_L1);
+    let mut table =
+        TableWriter::new(&prefix).column(Align::Left).column(Align::Left).column(Align::Left);
+    if let Some(w) = terminal_width() {
+        table = table.max_width(w);
     }
 
-    println!(
+    for c in sol_changes {
+        let sol_before = c.before as f64 / 1_000_000_000.0;
+        let sol_after = c.after as f64 / 1_000_000_000.0;
+        let sign = if c.change >= 0 { "+" } else { "" };
+        let color = if c.change >= 0 { COLOR_GREEN } else { COLOR_RED };
+
+        table.row(vec![
+            Cell::plain(&c.account),
+            Cell::colored(&format!("{}{:.9}", sign, c.change_sol), color),
+            Cell::colored(&format!("{:.9} → {:.9}", sol_before, sol_after), COLOR_BLUE),
+        ]);
+    }
+
+    table.print(w);
+    let _ = writeln!(
+        w,
         "\n{}",
         "  account  ±Δ(SOL)  before → after | (+) increase  (-) decrease".custom_color(DIM_GRAY)
     );
 }
 
-fn render_token_balance_changes(token_changes: &[TokenBalanceChangeSection], indent: &str) {
-    let rows: Vec<_> = token_changes
-        .iter()
-        .map(|c| {
-            let divisor = 10f64.powi(c.decimals as i32);
-            let ui_before = c.before as f64 / divisor;
-            let ui_after = c.after as f64 / divisor;
-            let prec = c.decimals as usize;
-            let sign = if c.change >= 0 { "+" } else { "" };
-            let col_before = format!("{:.prec$}", ui_before, prec = prec);
-            let col_after = format!("{:.prec$}", ui_after, prec = prec);
-            let col_delta = format!("{}{:.prec$}", sign, c.ui_change, prec = prec);
-            let color = if c.change >= 0 { (152, 195, 121) } else { (224, 108, 117) };
-            (
-                c.token_account.as_str(),
-                c.owner.as_str(),
-                col_before,
-                col_after,
-                col_delta,
-                c.mint.as_str(),
-                color,
-            )
-        })
-        .collect();
+fn render_token_balance_changes(
+    token_changes: &[TokenBalanceChangeSection],
+    indent: &str,
+    w: &mut impl Write,
+) {
+    use super::table::{Align, Cell, TableWriter};
 
-    let w_ta = rows.iter().map(|r| r.0.len()).max().unwrap_or(0);
-    let w_owner = rows.iter().map(|r| r.1.len()).max().unwrap_or(0);
-    let w_before = rows.iter().map(|r| r.2.len()).max().unwrap_or(0);
-    let w_after = rows.iter().map(|r| r.3.len()).max().unwrap_or(0);
-    let w_delta = rows.iter().map(|r| r.4.len()).max().unwrap_or(0);
-
-    for (col_ta, col_owner, col_before, col_after, col_delta, col_mint, color) in &rows {
-        println!(
-            "{}{}{:<wt$}  {:<wo$}  {}  {}  {}",
-            indent,
-            INDENT_L1,
-            col_ta,
-            col_owner,
-            format!("{:<wd$}", col_delta, wd = w_delta).custom_color(*color),
-            format!("{:<wb$} → {:<wa$}", col_before, col_after, wb = w_before, wa = w_after)
-                .custom_color((171, 178, 191)),
-            col_mint,
-            wt = w_ta,
-            wo = w_owner,
-        );
+    let prefix = format!("{}{}", indent, INDENT_L1);
+    let mut table = TableWriter::new(&prefix)
+        .column(Align::Left)
+        .column(Align::Left)
+        .column(Align::Left)
+        .column(Align::Left)
+        .column(Align::Left);
+    if let Some(w) = terminal_width() {
+        table = table.max_width(w);
     }
 
-    println!(
+    for c in token_changes {
+        let divisor = 10f64.powi(c.decimals as i32);
+        let ui_before = c.before as f64 / divisor;
+        let ui_after = c.after as f64 / divisor;
+        let prec = c.decimals as usize;
+        let sign = if c.change >= 0 { "+" } else { "" };
+        let color = if c.change >= 0 { COLOR_GREEN } else { COLOR_RED };
+
+        table.row(vec![
+            Cell::plain(&c.token_account),
+            Cell::plain(&c.owner),
+            Cell::colored(&format!("{}{:.prec$}", sign, c.ui_change, prec = prec), color),
+            Cell::colored(
+                &format!("{:.prec$} → {:.prec$}", ui_before, ui_after, prec = prec),
+                COLOR_BLUE,
+            ),
+            Cell::plain(&c.mint),
+        ]);
+    }
+
+    table.print(w);
+    let _ = writeln!(
+        w,
         "\n{}",
         "  token-account  owner  ±Δ(amount)  before → after  mint | (+) increase  (-) decrease"
             .custom_color(DIM_GRAY)
     );
 }
 
-fn render_lookup_tables_text(transaction: &TransactionSection) {
-    if transaction.lookups.is_empty() {
-        return;
-    }
-    let index_width = index_label_width(transaction.lookups.len().saturating_sub(1));
+// ---------------------------------------------------------------------------
+// Instruction details
+// ---------------------------------------------------------------------------
 
-    for (idx, lookup) in transaction.lookups.iter().enumerate() {
-        println!(
-            "{}{} {}",
-            INDENT_L1,
-            render_account_index_label(idx, index_width),
-            lookup.account_key
-        );
-    }
-}
-
-fn render_account_list_text(transaction: &TransactionSection, resolved: &ResolvedAccounts) {
-    let mut account_index = 0;
-    let layout = account_list_layout(transaction);
-
-    for account in &transaction.static_accounts {
-        account_index = render_account_entry_text(
-            account_index,
-            &account.pubkey,
-            account.signer,
-            account.writable,
-            &layout,
-            resolved,
-            None,
-        );
-    }
-
-    for (table_idx, lookup) in transaction.lookups.iter().enumerate() {
-        for entry in &lookup.writable {
-            account_index = render_account_entry_text(
-                account_index,
-                &entry.pubkey,
-                false,
-                true,
-                &layout,
-                resolved,
-                Some((table_idx, entry.index)),
-            );
-        }
-    }
-
-    for (table_idx, lookup) in transaction.lookups.iter().enumerate() {
-        for entry in &lookup.readonly {
-            account_index = render_account_entry_text(
-                account_index,
-                &entry.pubkey,
-                false,
-                false,
-                &layout,
-                resolved,
-                Some((table_idx, entry.index)),
-            );
-        }
-    }
-}
-
-fn render_account_entry_text(
-    index: usize,
-    pubkey_str: &str,
-    signer: bool,
-    writable: bool,
-    layout: &ColumnLayout,
-    resolved: &ResolvedAccounts,
-    lookup_info: Option<(usize, u8)>,
-) -> usize {
-    let pubkey = Pubkey::from_str(pubkey_str).unwrap();
-    let executable = resolved.accounts.get(&pubkey).map(|acc| acc.executable()).unwrap_or(false);
-    let index_label = render_account_index_label(index, layout.index_width);
-    let marker = render_account_marker(signer, writable, executable);
-    let pubkey_display = format!("{:<width$}", pubkey_str, width = layout.pubkey_width);
-    let lookup_suffix = match lookup_info {
-        Some((table_idx, table_inner_idx)) => {
-            format!("  ALT[{}] #{}", table_idx, table_inner_idx).custom_color(DIM_GRAY).to_string()
-        }
-        None => String::new(),
-    };
-    println!("{}{} {} {}{}", INDENT_L1, index_label, pubkey_display, marker, lookup_suffix);
-    index + 1
-}
-
-/// Render instruction details section with centered header.
 fn render_instruction_details_text(
     transaction: &TransactionSection,
     resolved: &ResolvedAccounts,
     show_ix_data: bool,
+    w: &mut impl Write,
 ) {
     let layout = instruction_account_layout(transaction);
 
-    let data_indent = " ".repeat(INDENT_L1.len() + layout.index_width + 3);
-    let inner_data_indent = " ".repeat(INDENT_L2.len() + layout.index_width + 3);
+    let data_indent = layout.data_indent(INDENT_L1);
+    let inner_data_indent = layout.data_indent(INDENT_L2);
 
     for (ix_pos, ix) in transaction.instructions.iter().enumerate() {
         if ix_pos > 0 {
-            println!();
+            let _ = writeln!(w);
         }
         let program_pubkey = ix.program.pubkey.as_str();
-        // Display outer instruction with 1-based indexing (#1, #2, #3, etc.)
         let outer_number = ix.index + 1;
 
+        // When an instruction has no accounts, indent data relative to "#N "
+        // instead of the account column to keep hex flush under the program name.
         let current_data_indent = if ix.accounts.is_empty() {
             " ".repeat(1 + outer_number.to_string().len() + 1)
         } else {
             data_indent.clone()
         };
 
-        // Try to parse the instruction
         if let Some(parsed) = &ix.parsed {
-            println!(
+            let _ = writeln!(
+                w,
                 "#{} {} {}",
-                outer_number.to_string().custom_color((229, 192, 123)),
+                outer_number.to_string().custom_color(COLOR_GOLD),
                 program_pubkey.cyan(),
-                format!("[{}]", parsed.name).custom_color((152, 195, 121))
+                format!("[{}]", parsed.name).custom_color(COLOR_GREEN)
             );
 
-            // Render accounts with parsed names
             for (i, account) in ix.accounts.iter().enumerate() {
                 let account_name = if i < parsed.account_names.len() {
                     parsed.account_names[i].clone()
@@ -569,6 +548,7 @@ fn render_instruction_details_text(
                     Some(&account_name),
                     INDENT_L1,
                     &layout,
+                    w,
                 );
             }
 
@@ -577,18 +557,20 @@ fn render_instruction_details_text(
                 &current_data_indent,
                 &ix.data,
                 show_ix_data,
+                w,
             );
         } else {
-            println!(
+            let _ = writeln!(
+                w,
                 "#{} {}",
-                outer_number.to_string().custom_color((229, 192, 123)),
+                outer_number.to_string().custom_color(COLOR_GOLD),
                 program_pubkey.cyan()
             );
 
             for account in &ix.accounts {
-                render_instruction_account_text(account, resolved, None, INDENT_L1, &layout);
+                render_instruction_account_text(account, resolved, None, INDENT_L1, &layout, w);
             }
-            render_instruction_data_text(&current_data_indent, &ix.data);
+            render_instruction_data_text(&current_data_indent, &ix.data, w);
         }
 
         if !ix.inner_instructions.is_empty() {
@@ -600,12 +582,13 @@ fn render_instruction_details_text(
                 };
 
                 if let Some(parsed_inner) = &inner_ix.parsed {
-                    println!(
+                    let _ = writeln!(
+                        w,
                         "{}{} {} {}",
                         INDENT_L1,
-                        format!("#{}", inner_ix.label).custom_color((229, 192, 123)),
+                        format!("#{}", inner_ix.label).custom_color(COLOR_GOLD),
                         inner_ix.program.pubkey.as_str().cyan(),
-                        format!("[{}]", parsed_inner.name).custom_color((152, 195, 121))
+                        format!("[{}]", parsed_inner.name).custom_color(COLOR_GREEN)
                     );
 
                     for (i, account) in inner_ix.accounts.iter().enumerate() {
@@ -620,6 +603,7 @@ fn render_instruction_details_text(
                             Some(&account_name),
                             INDENT_L2,
                             &layout,
+                            w,
                         );
                     }
 
@@ -628,28 +612,30 @@ fn render_instruction_details_text(
                         &current_inner_data_indent,
                         &inner_ix.data,
                         show_ix_data,
+                        w,
                     );
                 } else {
-                    println!(
+                    let _ = writeln!(
+                        w,
                         "{}{} {}",
                         INDENT_L1,
-                        format!("#{}", inner_ix.label).custom_color((229, 192, 123)),
+                        format!("#{}", inner_ix.label).custom_color(COLOR_GOLD),
                         inner_ix.program.pubkey.as_str().cyan()
                     );
 
                     for account in &inner_ix.accounts {
                         render_instruction_account_text(
-                            account, resolved, None, INDENT_L2, &layout,
+                            account, resolved, None, INDENT_L2, &layout, w,
                         );
                     }
-                    render_instruction_data_text(&current_inner_data_indent, &inner_ix.data);
+                    render_instruction_data_text(&current_inner_data_indent, &inner_ix.data, w);
                 }
             }
         }
     }
 
     let legend = render_account_legend(transaction);
-    println!("\n{}", legend.custom_color(DIM_GRAY));
+    let _ = writeln!(w, "\n{}", legend.custom_color(DIM_GRAY));
 }
 
 fn render_account_legend(transaction: &TransactionSection) -> String {
@@ -668,12 +654,112 @@ fn render_account_legend(transaction: &TransactionSection) -> String {
     legend
 }
 
+// ---------------------------------------------------------------------------
+// Account rendering helpers
+// ---------------------------------------------------------------------------
+
+fn render_lookup_tables_text(transaction: &TransactionSection, w: &mut impl Write) {
+    if transaction.lookups.is_empty() {
+        return;
+    }
+    let index_width = index_label_width(transaction.lookups.len().saturating_sub(1));
+
+    for (idx, lookup) in transaction.lookups.iter().enumerate() {
+        let _ = writeln!(
+            w,
+            "{}{} {}",
+            INDENT_L1,
+            render_account_index_label(idx, index_width),
+            lookup.account_key
+        );
+    }
+}
+
+fn render_account_list_text(
+    transaction: &TransactionSection,
+    resolved: &ResolvedAccounts,
+    w: &mut impl Write,
+) {
+    let mut account_index = 0;
+    let layout = account_list_layout(transaction);
+
+    for account in &transaction.static_accounts {
+        account_index = render_account_entry_text(
+            account_index,
+            &account.pubkey,
+            account.signer,
+            account.writable,
+            &layout,
+            resolved,
+            None,
+            w,
+        );
+    }
+
+    for (table_idx, lookup) in transaction.lookups.iter().enumerate() {
+        for entry in &lookup.writable {
+            account_index = render_account_entry_text(
+                account_index,
+                &entry.pubkey,
+                false,
+                true,
+                &layout,
+                resolved,
+                Some((table_idx, entry.index)),
+                w,
+            );
+        }
+    }
+
+    for (table_idx, lookup) in transaction.lookups.iter().enumerate() {
+        for entry in &lookup.readonly {
+            account_index = render_account_entry_text(
+                account_index,
+                &entry.pubkey,
+                false,
+                false,
+                &layout,
+                resolved,
+                Some((table_idx, entry.index)),
+                w,
+            );
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_account_entry_text(
+    index: usize,
+    pubkey_str: &str,
+    signer: bool,
+    writable: bool,
+    layout: &ColumnLayout,
+    resolved: &ResolvedAccounts,
+    lookup_info: Option<(usize, u8)>,
+    w: &mut impl Write,
+) -> usize {
+    let pubkey = Pubkey::from_str(pubkey_str).unwrap();
+    let executable = resolved.accounts.get(&pubkey).map(|acc| acc.executable()).unwrap_or(false);
+    let index_label = render_account_index_label(index, layout.index_width);
+    let marker = render_account_marker(signer, writable, executable);
+    let pubkey_display = format!("{:<width$}", pubkey_str, width = layout.pubkey_width);
+    let lookup_suffix = match lookup_info {
+        Some((table_idx, table_inner_idx)) => {
+            format!("  ALT[{}] #{}", table_idx, table_inner_idx).custom_color(DIM_GRAY).to_string()
+        }
+        None => String::new(),
+    };
+    let _ = writeln!(w, "{}{} {} {}{}", INDENT_L1, index_label, pubkey_display, marker, lookup_suffix);
+    index + 1
+}
+
 fn render_instruction_account_text(
     account: &InstructionAccountEntry,
     resolved: &ResolvedAccounts,
     name: Option<&str>,
     indent: &str,
     layout: &ColumnLayout,
+    w: &mut impl Write,
 ) {
     let executable = if let Ok(pubkey) = Pubkey::from_str(&account.pubkey) {
         resolved.accounts.get(&pubkey).map(|acc| acc.executable()).unwrap_or(false)
@@ -687,7 +773,7 @@ fn render_instruction_account_text(
     let source_marker = render_account_marker(account.signer, account.writable, executable);
     let index_label = render_account_index_label(account.index, layout.index_width);
     let pubkey_display = format!("{:<width$}", account.pubkey, width = layout.pubkey_width);
-    println!("{}{} {} {}{}", indent, index_label, pubkey_display, source_marker, name_suffix);
+    let _ = writeln!(w, "{}{} {} {}{}", indent, index_label, pubkey_display, source_marker, name_suffix);
 }
 
 fn render_account_marker(signer: bool, writable: bool, executable: bool) -> String {
@@ -702,10 +788,22 @@ fn account_mode_bits(signer: bool, writable: bool, executable: bool) -> String {
     format!("{signer_bit}{access_bit}{exec_bit}")
 }
 
+// ---------------------------------------------------------------------------
+// Column layout
+// ---------------------------------------------------------------------------
+
 /// Pre-computed column widths for aligned account display.
 struct ColumnLayout {
     index_width: usize,
     pubkey_width: usize,
+}
+
+impl ColumnLayout {
+    /// Indent that aligns with the first character after `[idx] pubkey `.
+    /// The index label occupies `index_width + 2` chars (brackets) plus a trailing space.
+    fn data_indent(&self, base_indent: &str) -> String {
+        format!("{}{}", base_indent, " ".repeat(self.index_width + 3))
+    }
 }
 
 fn instruction_account_layout(transaction: &TransactionSection) -> ColumnLayout {
@@ -755,107 +853,9 @@ fn render_account_index_label(index: usize, width: usize) -> String {
     format!("[{:>width$}]", index, width = width).custom_color(DIM_GRAY).to_string()
 }
 
-/// Render logs in a structured format, grouped by instruction with proper indentation.
-fn render_logs_structured(logs: &[String]) {
-    let instruction_logs = parse_logs_by_instruction(logs);
-
-    for (idx, inst_logs) in instruction_logs.iter().enumerate() {
-        if idx > 0 {
-            println!();
-        }
-        // Print instruction header
-        let program_name = get_program_display_name(&inst_logs.program);
-        println!(
-            "{} {} instruction",
-            format!("#{}", inst_logs.instruction_index + 1).bold(),
-            program_name.bold()
-        );
-
-        // Print log entries with proper indentation
-        for entry_with_depth in &inst_logs.entries {
-            render_log_entry(entry_with_depth);
-        }
-    }
-}
-
-/// Get a display name for a program (friendly name or address).
-fn get_program_display_name(pubkey: &str) -> &str {
-    // Return the address as-is (known_programs feature not implemented)
-    pubkey
-}
-
-/// Render a single log entry with appropriate formatting and color.
-fn render_log_entry(entry_with_depth: &LogEntryWithDepth) {
-    let depth = entry_with_depth.depth as usize;
-    // Base indent for logs under instruction header, plus additional for CPI depth
-    let indent = INDENT.repeat(depth);
-
-    match &entry_with_depth.entry {
-        LogEntry::Invoke { program, depth: invoke_depth } => {
-            // Only show "Invoking" for CPI calls (depth > 1)
-            if *invoke_depth > 1 {
-                let program_name = get_program_display_name(program);
-                println!("{}{} {}", indent, "> Invoking".cyan(), program_name.cyan());
-            }
-        }
-        LogEntry::Log { message } => {
-            println!(
-                "{}{} {}",
-                indent,
-                ">".custom_color(DIM_GRAY),
-                format!("Program log: {}", message).custom_color(DIM_GRAY)
-            );
-        }
-        LogEntry::Data { data } => {
-            println!(
-                "{}{} {}",
-                indent,
-                ">".custom_color(DIM_GRAY),
-                format!("Program data: {}", truncate_display(data, 60)).custom_color(DIM_GRAY)
-            );
-        }
-        LogEntry::Consumed { _program: _, used, total } => {
-            println!(
-                "{}{} {}",
-                indent,
-                ">".custom_color(DIM_GRAY),
-                format!("Program consumed: {} of {} compute units", used, total)
-                    .custom_color(DIM_GRAY)
-            );
-        }
-        LogEntry::Success { _program: _ } => {
-            println!("{}{} {}", indent, ">".green(), "Program returned success".green());
-        }
-        LogEntry::Failed { _program: _, error } => {
-            println!("{}{} {}", indent, ">".red(), format!("Program failed: {}", error).red());
-        }
-        LogEntry::Return { _program: _, data } => {
-            println!(
-                "{}{} {}",
-                indent,
-                ">".custom_color(DIM_GRAY),
-                format!("Program return: {}", truncate_display(data, 60)).custom_color(DIM_GRAY)
-            );
-        }
-        LogEntry::Other(msg) => {
-            if !msg.is_empty() {
-                println!("{}{} {}", indent, ">".custom_color(DIM_GRAY), msg.custom_color(DIM_GRAY));
-            }
-        }
-    }
-}
-
-fn truncate_sig(sig: &str, prefix_len: usize) -> String {
-    if sig.len() <= prefix_len * 2 + 3 {
-        sig.to_string()
-    } else {
-        format!("{}...{}", &sig[..prefix_len], &sig[sig.len() - prefix_len..])
-    }
-}
-
-fn truncate_display(value: &str, limit: usize) -> String {
-    if value.len() <= limit { value.to_string() } else { format!("{}…", &value[..limit]) }
-}
+// ---------------------------------------------------------------------------
+// Instruction data / parsed fields
+// ---------------------------------------------------------------------------
 
 struct OrderedFields<'a>(&'a [ParsedField]);
 
@@ -872,7 +872,7 @@ impl Serialize for OrderedFields<'_> {
     }
 }
 
-fn render_parsed_fields(fields: &ParsedInstructionFields, indent: &str) {
+fn render_parsed_fields(fields: &ParsedInstructionFields, indent: &str, w: &mut impl Write) {
     let ParsedInstructionFields::Parsed(fields) = fields else {
         return;
     };
@@ -881,36 +881,38 @@ fn render_parsed_fields(fields: &ParsedInstructionFields, indent: &str) {
     let pretty = serde_json::to_string_pretty(&ordered).unwrap_or_else(|_| "{}".to_string());
 
     for line in pretty.lines() {
-        println!("{}", format!("{}{}", indent, line).custom_color((171, 178, 191)));
+        let _ = writeln!(w, "{}", format!("{}{}", indent, line).custom_color(COLOR_BLUE));
     }
 }
 
-/// Render instruction data hex and/or parsed fields, choosing the raw-hex-amber
-/// fallback when structured decoding failed.
 fn render_instruction_data_and_fields(
     fields: &ParsedInstructionFields,
     indent: &str,
     data: &[u8],
     show_ix_data: bool,
+    w: &mut impl Write,
 ) {
-    // Non-empty RawHex means IDL matched but arg decoding failed — show amber hex.
     if let ParsedInstructionFields::RawHex(raw_hex) = fields {
         if !raw_hex.is_empty() {
             let line = format!("{}0x{} {} bytes", indent, hex::encode(data), data.len());
-            println!("{}", line.custom_color(RAW_HEX_AMBER));
+            let _ = writeln!(w, "{}", line.custom_color(RAW_HEX_AMBER));
             return;
         }
     }
 
     if show_ix_data {
-        render_instruction_data_text(indent, data);
+        render_instruction_data_text(indent, data, w);
     }
-    render_parsed_fields(fields, indent);
+    render_parsed_fields(fields, indent, w);
 }
 
-fn render_instruction_data_text(indent: &str, data: &[u8]) {
-    println!("{}0x{} {} bytes", indent, hex::encode(data), data.len());
+fn render_instruction_data_text(indent: &str, data: &[u8], w: &mut impl Write) {
+    let _ = writeln!(w, "{}0x{} {} bytes", indent, hex::encode(data), data.len());
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -918,9 +920,10 @@ mod tests {
 
     #[test]
     fn render_instruction_data_and_fields_uses_raw_hex_for_unparsed() {
-        // Verify the function returns early (no panic) for the RawHex variant.
-        // Stdout output is not captured here, but this exercises the code path.
         let fields = ParsedInstructionFields::RawHex("0025a16608ca3c00".to_string());
-        render_instruction_data_and_fields(&fields, "  ", &[0, 37, 161, 102], false);
+        let mut buf = Vec::new();
+        render_instruction_data_and_fields(&fields, "  ", &[0, 37, 161, 102], false, &mut buf);
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("0x"));
     }
 }

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -10,7 +10,7 @@ use solana_pubkey::Pubkey;
 use unicode_width::UnicodeWidthStr;
 
 use crate::parsers::{
-    instruction::{ParsedField, ParsedFieldValue, ParserRegistry},
+    instruction::{ParsedField, ParsedFieldValue, ParsedInstructionFields, ParserRegistry},
     log_parser::{LogEntry, LogEntryWithDepth, parse_logs_by_instruction},
 };
 use sonar_sim::internals::ResolvedAccounts;
@@ -889,10 +889,10 @@ impl Serialize for OrderedFields<'_> {
     }
 }
 
-fn render_parsed_fields(fields: &[ParsedField], indent: &str) {
-    if fields.is_empty() {
+fn render_parsed_fields(fields: &ParsedInstructionFields, indent: &str) {
+    let ParsedInstructionFields::Parsed(fields) = fields else {
         return;
-    }
+    };
 
     let ordered = OrderedFields(fields);
     let pretty = serde_json::to_string_pretty(&ordered).unwrap_or_else(|_| "{}".to_string());
@@ -918,12 +918,8 @@ fn render_instruction_data_text_with_color(
     }
 }
 
-fn should_render_raw_instruction_hex(fields: &[ParsedField]) -> bool {
-    matches!(
-        fields,
-        [ParsedField { name, value: ParsedFieldValue::Text(raw_hex) }]
-            if name == "__raw_hex__" && !raw_hex.is_empty()
-    )
+fn should_render_raw_instruction_hex(fields: &ParsedInstructionFields) -> bool {
+    matches!(fields, ParsedInstructionFields::RawHex(raw_hex) if !raw_hex.is_empty())
 }
 
 #[cfg(test)]
@@ -932,7 +928,7 @@ mod tests {
 
     #[test]
     fn should_render_raw_instruction_hex_for_unparsed_idl_fields() {
-        let fields = vec![ParsedField::text("__raw_hex__", "0025a16608ca3c00")];
+        let fields = ParsedInstructionFields::RawHex("0025a16608ca3c00".to_string());
 
         assert!(should_render_raw_instruction_hex(&fields));
     }

--- a/src/output/theme.rs
+++ b/src/output/theme.rs
@@ -1,0 +1,24 @@
+//! Centralized color palette for terminal output.
+//!
+//! Every color used in text rendering is defined here so the palette
+//! can be changed in one place.
+
+use colored::CustomColor;
+
+/// Subdued gray for metadata: index labels, permission flags, account names, log prefixes.
+pub(crate) const DIM_GRAY: CustomColor = CustomColor { r: 128, g: 128, b: 128 };
+
+/// Warm amber for fallback raw hex when structured instruction decoding fails.
+pub(crate) const RAW_HEX_AMBER: CustomColor = CustomColor { r: 214, g: 154, b: 74 };
+
+/// Green for positive balance changes and instruction names.
+pub(crate) const COLOR_GREEN: (u8, u8, u8) = (152, 195, 121);
+
+/// Red for negative balance changes and program failures.
+pub(crate) const COLOR_RED: (u8, u8, u8) = (224, 108, 117);
+
+/// Gold for instruction numbers (#1, #2, …).
+pub(crate) const COLOR_GOLD: (u8, u8, u8) = (229, 192, 123);
+
+/// Muted blue for before→after values and parsed instruction fields.
+pub(crate) const COLOR_BLUE: (u8, u8, u8) = (171, 178, 191);

--- a/src/parsers/binary_reader.rs
+++ b/src/parsers/binary_reader.rs
@@ -270,7 +270,11 @@ mod tests {
         let data = [0u8; 4];
         let result = try_parse(&data, |reader| {
             let _ = reader.read_u32()?;
-            Ok(ParsedInstruction { name: "Test".into(), fields: vec![], account_names: vec![] })
+            Ok(ParsedInstruction {
+                name: "Test".into(),
+                fields: vec![].into(),
+                account_names: vec![],
+            })
         })
         .unwrap();
         assert!(result.is_some());
@@ -282,7 +286,11 @@ mod tests {
         let data = [0u8; 1]; // too short for u32
         let result = try_parse(&data, |reader| {
             let _ = reader.read_u32()?;
-            Ok(ParsedInstruction { name: "Test".into(), fields: vec![], account_names: vec![] })
+            Ok(ParsedInstruction {
+                name: "Test".into(),
+                fields: vec![].into(),
+                account_names: vec![],
+            })
         })
         .unwrap();
         assert!(result.is_none());

--- a/src/parsers/instruction/anchor_idl.rs
+++ b/src/parsers/instruction/anchor_idl.rs
@@ -10,7 +10,9 @@ use solana_pubkey::Pubkey;
 use sonar_idl::{IdlInstructionFields, IdlParsedInstruction};
 
 use crate::core::transaction::InstructionSummary;
-use crate::parsers::instruction::{InstructionParser, ParsedField, ParsedInstruction};
+use crate::parsers::instruction::{
+    InstructionParser, ParsedField, ParsedInstruction, ParsedInstructionFields,
+};
 
 // ── Re-exports from sonar-idl ──
 
@@ -20,11 +22,13 @@ pub use sonar_idl::IndexedIdl;
 
 fn to_parsed_instruction(idl_parsed: IdlParsedInstruction) -> ParsedInstruction {
     let fields = match idl_parsed.fields {
-        IdlInstructionFields::Parsed(fields) => {
-            fields.into_iter().map(|field| ParsedField::json(field.name, field.value)).collect()
-        }
+        IdlInstructionFields::Parsed(fields) => fields
+            .into_iter()
+            .map(|field| ParsedField::json(field.name, field.value))
+            .collect::<Vec<_>>()
+            .into(),
         IdlInstructionFields::Unparsed(raw_args_hex) => {
-            vec![ParsedField::text("__raw_hex__", raw_args_hex)]
+            ParsedInstructionFields::RawHex(raw_args_hex)
         }
     };
 

--- a/src/parsers/instruction/anchor_idl.rs
+++ b/src/parsers/instruction/anchor_idl.rs
@@ -26,7 +26,6 @@ fn to_parsed_instruction(idl_parsed: IdlParsedInstruction) -> ParsedInstruction 
         IdlInstructionFields::Unparsed(raw_args_hex) => {
             vec![ParsedField::text("__raw_hex__", raw_args_hex)]
         }
-        IdlInstructionFields::Empty => Vec::new(),
     };
 
     ParsedInstruction { name: idl_parsed.name, fields, account_names: idl_parsed.account_names }

--- a/src/parsers/instruction/anchor_idl.rs
+++ b/src/parsers/instruction/anchor_idl.rs
@@ -7,7 +7,7 @@
 
 use anyhow::Result;
 use solana_pubkey::Pubkey;
-use sonar_idl::IdlParsedInstruction;
+use sonar_idl::{IdlInstructionFields, IdlParsedInstruction};
 
 use crate::core::transaction::InstructionSummary;
 use crate::parsers::instruction::{InstructionParser, ParsedField, ParsedInstruction};
@@ -19,11 +19,15 @@ pub use sonar_idl::IndexedIdl;
 // ── Adapter: IDL model → CLI model ──
 
 fn to_parsed_instruction(idl_parsed: IdlParsedInstruction) -> ParsedInstruction {
-    let fields = idl_parsed
-        .fields
-        .into_iter()
-        .map(|field| ParsedField::json(field.name, field.value))
-        .collect();
+    let fields = match idl_parsed.fields {
+        IdlInstructionFields::Parsed(fields) => {
+            fields.into_iter().map(|field| ParsedField::json(field.name, field.value)).collect()
+        }
+        IdlInstructionFields::Unparsed(raw_args_hex) => {
+            vec![ParsedField::text("__raw_hex__", raw_args_hex)]
+        }
+        IdlInstructionFields::Empty => Vec::new(),
+    };
 
     ParsedInstruction { name: idl_parsed.name, fields, account_names: idl_parsed.account_names }
 }

--- a/src/parsers/instruction/associated_token_program.rs
+++ b/src/parsers/instruction/associated_token_program.rs
@@ -61,7 +61,7 @@ fn parse_create_instruction(
 
     Ok(Some(ParsedInstruction {
         name: instruction_name.to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names,
     }))
 }
@@ -84,7 +84,11 @@ fn parse_recover_nested_instruction(
     ];
     append_extra_account_names(&mut account_names, instruction.accounts.len(), 7);
 
-    Ok(Some(ParsedInstruction { name: "RecoverNested".to_string(), fields: vec![], account_names }))
+    Ok(Some(ParsedInstruction {
+        name: "RecoverNested".to_string(),
+        fields: vec![].into(),
+        account_names,
+    }))
 }
 
 fn append_extra_account_names(

--- a/src/parsers/instruction/compute_budget_program.rs
+++ b/src/parsers/instruction/compute_budget_program.rs
@@ -56,7 +56,7 @@ fn parse_unused_instruction(data: &[u8]) -> Result<Option<ParsedInstruction>> {
 
     Ok(Some(ParsedInstruction {
         name: "Unused".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names: vec![],
     }))
 }
@@ -74,7 +74,7 @@ fn parse_u32_instruction(
         let value = reader.read_u32()?;
         Ok(ParsedInstruction {
             name: name.to_string(),
-            fields: vec![ParsedField::text(field_name, value.to_string())],
+            fields: vec![ParsedField::text(field_name, value.to_string())].into(),
             account_names: vec![],
         })
     })
@@ -93,7 +93,7 @@ fn parse_u64_instruction(
         let value = reader.read_u64()?;
         Ok(ParsedInstruction {
             name: name.to_string(),
-            fields: vec![ParsedField::text(field_name, value.to_string())],
+            fields: vec![ParsedField::text(field_name, value.to_string())].into(),
             account_names: vec![],
         })
     })

--- a/src/parsers/instruction/memo_program.rs
+++ b/src/parsers/instruction/memo_program.rs
@@ -22,7 +22,11 @@ impl InstructionParser for MemoProgramParser {
         let account_names =
             (0..instruction.accounts.len()).map(|index| format!("signer_{}", index)).collect();
 
-        Ok(Some(ParsedInstruction { name: "Memo".to_string(), fields: memo_fields, account_names }))
+        Ok(Some(ParsedInstruction {
+            name: "Memo".to_string(),
+            fields: memo_fields.into(),
+            account_names,
+        }))
     }
 }
 

--- a/src/parsers/instruction/mod.rs
+++ b/src/parsers/instruction/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ops::Deref;
 
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -15,10 +16,54 @@ use sonar_sim::internals::ResolvedAccounts;
 pub struct ParsedInstruction {
     /// The instruction name (e.g., "Transfer", "CreateAccount")
     pub name: String,
-    /// Vector of parsed fields preserving order
-    pub fields: Vec<ParsedField>,
+    /// Parsed field state preserving either structured fields or raw hex fallback
+    pub fields: ParsedInstructionFields,
     /// Human-readable names for each account in the instruction
     pub account_names: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ParsedInstructionFields {
+    Parsed(Vec<ParsedField>),
+    RawHex(String),
+}
+
+impl From<Vec<ParsedField>> for ParsedInstructionFields {
+    fn from(fields: Vec<ParsedField>) -> Self {
+        Self::Parsed(fields)
+    }
+}
+
+impl Deref for ParsedInstructionFields {
+    type Target = [ParsedField];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Parsed(fields) => fields.as_slice(),
+            Self::RawHex(_) => &[],
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a ParsedInstructionFields {
+    type Item = &'a ParsedField;
+    type IntoIter = std::slice::Iter<'a, ParsedField>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.deref().iter()
+    }
+}
+
+impl Serialize for ParsedInstructionFields {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Parsed(fields) => fields.serialize(serializer),
+            Self::RawHex(raw_hex) => serializer.serialize_str(raw_hex),
+        }
+    }
 }
 
 /// Ordered parsed field entry
@@ -545,9 +590,10 @@ mod tests {
 
         assert_eq!(parsed.name, "swap_toc");
         assert_eq!(parsed.account_names, vec!["payer"]);
-        assert_eq!(parsed.fields.len(), 1);
-        assert_eq!(parsed.fields[0].name, "__raw_hex__");
-        assert_eq!(parsed.fields[0].value, "0025a16608ca3c00".to_string());
+        assert!(matches!(
+            parsed.fields,
+            ParsedInstructionFields::RawHex(raw_hex) if raw_hex == "0025a16608ca3c00"
+        ));
 
         std::fs::remove_file(idl_path).ok();
         std::fs::remove_dir_all(test_dir).ok();

--- a/src/parsers/instruction/mod.rs
+++ b/src/parsers/instruction/mod.rs
@@ -28,12 +28,27 @@ pub enum ParsedInstructionFields {
     RawHex(String),
 }
 
+impl ParsedInstructionFields {
+    /// Returns the parsed fields if decoding succeeded, or `None` for the raw hex variant.
+    ///
+    /// Prefer this over `Deref` when you need to distinguish "no fields" from "failed to decode".
+    pub fn parsed_fields(&self) -> Option<&[ParsedField]> {
+        match self {
+            Self::Parsed(fields) => Some(fields),
+            Self::RawHex(_) => None,
+        }
+    }
+}
+
 impl From<Vec<ParsedField>> for ParsedInstructionFields {
     fn from(fields: Vec<ParsedField>) -> Self {
         Self::Parsed(fields)
     }
 }
 
+/// **Caution:** Returns an empty slice for `RawHex`, which is indistinguishable from a
+/// zero-field instruction. Use [`ParsedInstructionFields::parsed_fields`] when you need to
+/// differentiate between "no fields" and "failed to decode".
 impl Deref for ParsedInstructionFields {
     type Target = [ParsedField];
 

--- a/src/parsers/instruction/mod.rs
+++ b/src/parsers/instruction/mod.rs
@@ -482,6 +482,76 @@ mod tests {
         std::fs::remove_file(existing_path).ok();
         std::fs::remove_dir_all(test_dir).ok();
     }
+
+    #[test]
+    fn parser_registry_marks_truncated_idl_args_as_raw_hex() {
+        let test_dir = std::env::temp_dir().join(format!(
+            "sonar-idl-unparsed-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock should be valid")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&test_dir).expect("create temp idl dir");
+
+        let program_id = Pubkey::new_unique();
+        let idl_path = test_dir.join(format!("{program_id}.json"));
+        std::fs::write(
+            &idl_path,
+            format!(
+                r#"{{
+                    "address": "{program_id}",
+                    "metadata": {{ "name": "demo", "version": "0.1.0", "spec": "0.1.0" }},
+                    "instructions": [{{
+                        "name": "swap_toc",
+                        "discriminator": [187, 201, 212, 51, 16, 155, 236, 60],
+                        "accounts": [{{ "name": "payer", "writable": true, "signer": true }}],
+                        "args": [
+                            {{ "name": "amount_in", "type": "u64" }},
+                            {{ "name": "slippage_bps", "type": "u16" }}
+                        ]
+                    }}],
+                    "types": []
+                }}"#
+            ),
+        )
+        .expect("write temp idl");
+
+        let instruction = crate::core::transaction::InstructionSummary {
+            index: 7,
+            program: crate::core::transaction::AccountReferenceSummary {
+                index: 0,
+                pubkey: Some(program_id.to_string()),
+                signer: false,
+                writable: false,
+                source: crate::core::transaction::AccountSourceSummary::Static,
+            },
+            accounts: vec![crate::core::transaction::AccountReferenceSummary {
+                index: 1,
+                pubkey: Some(Pubkey::new_unique().to_string()),
+                signer: true,
+                writable: true,
+                source: crate::core::transaction::AccountSourceSummary::Static,
+            }],
+            data: vec![187, 201, 212, 51, 16, 155, 236, 60, 0, 37, 161, 102, 8, 202, 60, 0]
+                .into_boxed_slice(),
+        };
+
+        let mut registry = ParserRegistry::new(Some(test_dir.clone()));
+        let parsed = registry
+            .parse_instruction(&instruction, &program_id)
+            .expect("expected parser registry to preserve instruction metadata");
+
+        assert_eq!(parsed.name, "swap_toc");
+        assert_eq!(parsed.account_names, vec!["payer"]);
+        assert_eq!(parsed.fields.len(), 1);
+        assert_eq!(parsed.fields[0].name, "__raw_hex__");
+        assert_eq!(parsed.fields[0].value, "0025a16608ca3c00".to_string());
+
+        std::fs::remove_file(idl_path).ok();
+        std::fs::remove_dir_all(test_dir).ok();
+    }
 }
 
 mod system_program;

--- a/src/parsers/instruction/system_program.rs
+++ b/src/parsers/instruction/system_program.rs
@@ -84,7 +84,7 @@ fn parse_transfer_instruction(
         let lamports = reader.read_u64()?;
         Ok(ParsedInstruction {
             name: "Transfer".to_string(),
-            fields: vec![ParsedField::text("lamports", lamports.to_string())],
+            fields: vec![ParsedField::text("lamports", lamports.to_string())].into(),
             account_names: vec!["funding_account".to_string(), "recipient_account".to_string()],
         })
     })
@@ -109,7 +109,8 @@ fn parse_create_account_instruction(
                 ParsedField::text("lamports", lamports.to_string()),
                 ParsedField::text("space", space.to_string()),
                 ParsedField::text("owner", owner.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec!["funding_account".to_string(), "new_account".to_string()],
         })
     })
@@ -128,7 +129,7 @@ fn parse_assign_instruction(
         let owner = reader.read_pubkey()?;
         Ok(ParsedInstruction {
             name: "Assign".to_string(),
-            fields: vec![ParsedField::text("owner", owner.to_string())],
+            fields: vec![ParsedField::text("owner", owner.to_string())].into(),
             account_names: vec!["assigned_account".to_string()],
         })
     })
@@ -157,7 +158,8 @@ fn parse_create_account_with_seed_instruction(
                 ParsedField::text("lamports", lamports.to_string()),
                 ParsedField::text("space", space.to_string()),
                 ParsedField::text("owner", owner.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec![
                 "funding_account".to_string(),
                 "created_account".to_string(),
@@ -174,7 +176,7 @@ fn parse_advance_nonce_account_instruction(
     // AdvanceNonceAccount has no instruction data
     Ok(Some(ParsedInstruction {
         name: "AdvanceNonceAccount".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names: vec![
             "nonce_account".to_string(),
             "recent_blockhashes_sysvar".to_string(),
@@ -196,7 +198,7 @@ fn parse_withdraw_nonce_account_instruction(
         let lamports = reader.read_u64()?;
         Ok(ParsedInstruction {
             name: "WithdrawNonceAccount".to_string(),
-            fields: vec![ParsedField::text("lamports", lamports.to_string())],
+            fields: vec![ParsedField::text("lamports", lamports.to_string())].into(),
             account_names: vec![
                 "nonce_account".to_string(),
                 "recipient_account".to_string(),
@@ -221,7 +223,7 @@ fn parse_initialize_nonce_account_instruction(
         let authorized = reader.read_pubkey()?;
         Ok(ParsedInstruction {
             name: "InitializeNonceAccount".to_string(),
-            fields: vec![ParsedField::text("authorized", authorized.to_string())],
+            fields: vec![ParsedField::text("authorized", authorized.to_string())].into(),
             account_names: vec![
                 "nonce_account".to_string(),
                 "recent_blockhashes_sysvar".to_string(),
@@ -244,7 +246,7 @@ fn parse_authorize_nonce_account_instruction(
         let authorized = reader.read_pubkey()?;
         Ok(ParsedInstruction {
             name: "AuthorizeNonceAccount".to_string(),
-            fields: vec![ParsedField::text("new_authorized", authorized.to_string())],
+            fields: vec![ParsedField::text("new_authorized", authorized.to_string())].into(),
             account_names: vec!["nonce_account".to_string(), "nonce_authority".to_string()],
         })
     })
@@ -263,7 +265,7 @@ fn parse_allocate_instruction(
         let space = reader.read_u64()?;
         Ok(ParsedInstruction {
             name: "Allocate".to_string(),
-            fields: vec![ParsedField::text("space", space.to_string())],
+            fields: vec![ParsedField::text("space", space.to_string())].into(),
             account_names: vec!["allocated_account".to_string()],
         })
     })
@@ -290,7 +292,8 @@ fn parse_allocate_with_seed_instruction(
                 ParsedField::text("seed", seed),
                 ParsedField::text("space", space.to_string()),
                 ParsedField::text("owner", owner.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec!["allocated_account".to_string(), "base_account".to_string()],
         })
     })
@@ -315,7 +318,8 @@ fn parse_assign_with_seed_instruction(
                 ParsedField::text("base", base.to_string()),
                 ParsedField::text("seed", seed),
                 ParsedField::text("owner", owner.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec!["assigned_account".to_string(), "base_account".to_string()],
         })
     })
@@ -341,7 +345,8 @@ fn parse_transfer_with_seed_instruction(
                 ParsedField::text("lamports", lamports.to_string()),
                 ParsedField::text("from_seed", from_seed),
                 ParsedField::text("from_owner", from_owner.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec![
                 "funding_account".to_string(),
                 "base_account".to_string(),
@@ -358,7 +363,7 @@ fn parse_upgrade_nonce_account_instruction(
     // UpgradeNonceAccount has no instruction data
     Ok(Some(ParsedInstruction {
         name: "UpgradeNonceAccount".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names: vec!["nonce_account".to_string()],
     }))
 }
@@ -382,7 +387,8 @@ fn parse_create_account_allow_prefund_instruction(
                 ParsedField::text("lamports", lamports.to_string()),
                 ParsedField::text("space", space.to_string()),
                 ParsedField::text("owner", owner.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec![
                 "new_account".to_string(),
                 "(optional) funding_account".to_string(),

--- a/src/parsers/instruction/token2022_program.rs
+++ b/src/parsers/instruction/token2022_program.rs
@@ -358,7 +358,7 @@ fn dispatch_table_instruction(
                 );
                 Ok(ParsedInstruction {
                     name: def.name.to_string(),
-                    fields: vec![ParsedField::text("amount", amount.to_string())],
+                    fields: vec![ParsedField::text("amount", amount.to_string())].into(),
                     account_names,
                 })
             })
@@ -382,7 +382,8 @@ fn dispatch_table_instruction(
                     fields: vec![
                         ParsedField::text("amount", amount.to_string()),
                         ParsedField::text("decimals", decimals.to_string()),
-                    ],
+                    ]
+                    .into(),
                     account_names,
                 })
             })
@@ -400,7 +401,7 @@ fn dispatch_table_instruction(
             );
             Ok(Some(ParsedInstruction {
                 name: def.name.to_string(),
-                fields: vec![],
+                fields: vec![].into(),
                 account_names,
             }))
         }
@@ -410,7 +411,7 @@ fn dispatch_table_instruction(
             }
             Ok(Some(ParsedInstruction {
                 name: def.name.to_string(),
-                fields: vec![],
+                fields: vec![].into(),
                 account_names: def.account_names.iter().map(|s| s.to_string()).collect(),
             }))
         }
@@ -453,7 +454,8 @@ fn parse_initialize_mint_instruction(
             fields: vec![
                 ParsedField::text("decimals", decimals.to_string()),
                 ParsedField::text("has_freeze_authority", has_freeze_authority.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec!["mint".to_string(), "rent_sysvar".to_string()],
         })
     })
@@ -470,7 +472,7 @@ fn parse_initialize_account_instruction(
 
     Ok(Some(ParsedInstruction {
         name: "InitializeAccount".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names: vec![
             "account".to_string(),
             "mint".to_string(),
@@ -497,7 +499,7 @@ fn parse_initialize_multisig_instruction(
         }
         Ok(ParsedInstruction {
             name: "InitializeMultisig".to_string(),
-            fields: vec![ParsedField::text("m", m.to_string())],
+            fields: vec![ParsedField::text("m", m.to_string())].into(),
             account_names,
         })
     })
@@ -535,7 +537,8 @@ fn parse_set_authority_instruction(
             fields: vec![
                 ParsedField::text("authority_type", authority_type.to_string()),
                 ParsedField::text("cleared", cleared.to_string()),
-            ],
+            ]
+            .into(),
             account_names,
         })
     })
@@ -553,7 +556,7 @@ fn parse_initialize_account2_instruction(
         let owner_pubkey = reader.read_pubkey_as_string()?;
         Ok(ParsedInstruction {
             name: "InitializeAccount2".to_string(),
-            fields: vec![ParsedField::text("owner", owner_pubkey)],
+            fields: vec![ParsedField::text("owner", owner_pubkey)].into(),
             account_names: vec![
                 "account".to_string(),
                 "mint".to_string(),
@@ -579,7 +582,7 @@ fn parse_initialize_account3_instruction(
         }
         Ok(ParsedInstruction {
             name: "InitializeAccount3".to_string(),
-            fields: vec![ParsedField::text("owner", owner_pubkey)],
+            fields: vec![ParsedField::text("owner", owner_pubkey)].into(),
             account_names,
         })
     })
@@ -602,7 +605,7 @@ fn parse_initialize_multisig2_instruction(
         }
         Ok(ParsedInstruction {
             name: "InitializeMultisig2".to_string(),
-            fields: vec![ParsedField::text("m", m.to_string())],
+            fields: vec![ParsedField::text("m", m.to_string())].into(),
             account_names,
         })
     })
@@ -628,7 +631,8 @@ fn parse_initialize_mint2_instruction(
             fields: vec![
                 ParsedField::text("decimals", decimals.to_string()),
                 ParsedField::text("has_freeze_authority", has_freeze_authority.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec!["mint".to_string()],
         })
     })
@@ -646,7 +650,7 @@ fn parse_amount_to_ui_amount_instruction(
         let amount = reader.read_u64()?;
         Ok(ParsedInstruction {
             name: "AmountToUiAmount".to_string(),
-            fields: vec![ParsedField::text("amount", amount.to_string())],
+            fields: vec![ParsedField::text("amount", amount.to_string())].into(),
             account_names: vec!["mint".to_string()],
         })
     })
@@ -669,7 +673,7 @@ fn parse_ui_amount_to_amount_instruction(
 
     Ok(Some(ParsedInstruction {
         name: "UiAmountToAmount".to_string(),
-        fields: vec![ParsedField::text("ui_amount", ui_amount)],
+        fields: vec![ParsedField::text("ui_amount", ui_amount)].into(),
         account_names: vec!["mint".to_string()],
     }))
 }
@@ -687,7 +691,7 @@ fn parse_initialize_mint_close_authority_instruction(
             close_authority.map_or_else(|| "none".to_string(), |pk| pk.to_string());
         Ok(ParsedInstruction {
             name: "InitializeMintCloseAuthority".to_string(),
-            fields: vec![ParsedField::text("close_authority", close_authority_value)],
+            fields: vec![ParsedField::text("close_authority", close_authority_value)].into(),
             account_names: vec!["mint".to_string()],
         })
     })
@@ -711,7 +715,7 @@ fn parse_transfer_fee_extension_instruction(
         5 => parse_transfer_fee_set_fee_instruction(payload, instruction),
         unknown => Ok(Some(ParsedInstruction {
             name: format!("TransferFeeExtension({unknown})"),
-            fields: vec![ParsedField::text("raw_extension_data", hex::encode(payload))],
+            fields: vec![ParsedField::text("raw_extension_data", hex::encode(payload))].into(),
             account_names: generate_generic_account_names(instruction.accounts.len()),
         })),
     }
@@ -742,7 +746,8 @@ fn parse_transfer_fee_initialize_instruction(
                 ),
                 ParsedField::text("transfer_fee_basis_points", bps.to_string()),
                 ParsedField::text("maximum_fee", maximum_fee.to_string()),
-            ],
+            ]
+            .into(),
             account_names: vec!["mint".to_string()],
         })
     })
@@ -783,7 +788,8 @@ fn parse_transfer_checked_with_fee_instruction(
                 ParsedField::text("amount", amount.to_string()),
                 ParsedField::text("decimals", decimals.to_string()),
                 ParsedField::text("fee", fee.to_string()),
-            ],
+            ]
+            .into(),
             account_names,
         })
     })
@@ -812,7 +818,7 @@ fn parse_transfer_fee_withdraw_from_mint_instruction(
 
     Ok(Some(ParsedInstruction {
         name: "WithdrawWithheldTokensFromMint".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names,
     }))
 }
@@ -842,7 +848,8 @@ fn parse_transfer_fee_withdraw_from_accounts_instruction(
 
     Ok(Some(ParsedInstruction {
         name: "WithdrawWithheldTokensFromAccounts".to_string(),
-        fields: vec![ParsedField::text("num_token_accounts", num_token_accounts.to_string())],
+        fields: vec![ParsedField::text("num_token_accounts", num_token_accounts.to_string())]
+            .into(),
         account_names,
     }))
 }
@@ -861,7 +868,7 @@ fn parse_transfer_fee_harvest_to_mint_instruction(
 
     Ok(Some(ParsedInstruction {
         name: "HarvestWithheldTokensToMint".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names,
     }))
 }
@@ -896,7 +903,8 @@ fn parse_transfer_fee_set_fee_instruction(
                     transfer_fee_basis_points.to_string(),
                 ),
                 ParsedField::text("maximum_fee", maximum_fee.to_string()),
-            ],
+            ]
+            .into(),
             account_names,
         })
     })
@@ -940,7 +948,8 @@ fn parse_reallocate_instruction(
         fields: vec![ParsedField::text(
             "extension_types",
             if extension_types.is_empty() { "none".to_string() } else { extension_types.join(",") },
-        )],
+        )]
+        .into(),
         account_names,
     }))
 }
@@ -954,7 +963,7 @@ fn parse_create_native_mint_instruction(
 
     Ok(Some(ParsedInstruction {
         name: "CreateNativeMint".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names: vec![
             "funding_account".to_string(),
             "native_mint".to_string(),
@@ -974,7 +983,7 @@ fn parse_initialize_permanent_delegate_instruction(
         let delegate = reader.read_pubkey_as_string()?;
         Ok(ParsedInstruction {
             name: "InitializePermanentDelegate".to_string(),
-            fields: vec![ParsedField::text("delegate", delegate)],
+            fields: vec![ParsedField::text("delegate", delegate)].into(),
             account_names: vec!["mint".to_string()],
         })
     })
@@ -995,7 +1004,7 @@ fn parse_withdraw_excess_lamports_instruction(
 
     Ok(Some(ParsedInstruction {
         name: "WithdrawExcessLamports".to_string(),
-        fields: vec![],
+        fields: vec![].into(),
         account_names,
     }))
 }
@@ -1012,7 +1021,7 @@ fn parse_extension_prefix_instruction(
 
     Ok(Some(ParsedInstruction {
         name: name.to_string(),
-        fields,
+        fields: fields.into(),
         account_names: generate_generic_account_names(instruction.accounts.len()),
     }))
 }


### PR DESCRIPTION
## Summary

- **Extract shared utilities**: `format_with_commas`, `truncate_display` (fixed byte-slicing bug), `truncate_sig` into `output/fmt.rs`
- **Centralize color palette**: Named constants (`COLOR_GREEN`, `COLOR_RED`, `COLOR_GOLD`, `COLOR_BLUE`, `DIM_GRAY`, `RAW_HEX_AMBER`) in `output/theme.rs`, replacing ~11 inline magic tuples
- **Introduce `TableWriter`**: Auto-sizing column alignment with per-cell coloring in `output/table.rs`, replacing ~60 lines of manual width-scan + format-string code in balance change tables
- **Thread `&mut impl Write`**: All render functions accept a writer instead of printing to stdout directly — enables unit testing output content and surfaces IO errors via `flush()` at render boundaries
- **Consolidate constructor args**: New `SimulationContext` struct replaces 4 loose params (`account_closures`, `overrides`, `fundings`, `token_fundings`), eliminating `#[allow(clippy::too_many_arguments)]` on public API
- **Terminal-width-aware tables**: Balance tables respect real TTY width via `TableWriter::max_width`; piped/redirected output renders full-width (no synthetic truncation)
- **Clean up indent arithmetic**: `ColumnLayout::data_indent()` method replaces ad-hoc `" ".repeat(len + 3)` patterns

### Bug fixes included
- `truncate_display` now slices on char boundaries (was byte-slicing, would panic on multi-byte UTF-8)
- Uses `is_char_boundary` loop instead of `floor_char_boundary` (MSRV 1.86 compat)

## Test plan
- [x] `cargo check` — zero warnings
- [x] `cargo test` — all 552 unit tests + 26 integration tests pass
- [ ] Manual smoke test: `sonar sim` single TX and bundle, verify output looks correct
- [ ] Manual smoke test: `sonar sim ... | cat` (piped) — verify no pubkey truncation
- [ ] Manual smoke test: `sonar account` — verify account info rendering