### PR TITLE
fix(output): decouple table max_width from ambient terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,7 +1604,7 @@ version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
- "console",
+ "console 0.15.11",
  "number_prefix",
  "portable-atomic",
  "unicode-width",
@@ -1607,6 +1618,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console 0.16.3",
+ "once_cell",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -2646,6 +2669,12 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "smallvec"
@@ -4060,6 +4089,7 @@ dependencies = [
  "flate2",
  "hex",
  "indicatif",
+ "insta",
  "log",
  "num-bigint 0.4.6",
  "serde",

--- a/src/output/snapshot_tests.rs
+++ b/src/output/snapshot_tests.rs
@@ -33,7 +33,7 @@ mod tests {
             change_sol: 1.5,
         }];
         let output = capture(|w| {
-            crate::output::text::render_sol_balance_changes(&changes, "", w);
+            crate::output::text::render_sol_balance_changes(&changes, "", None, w);
         });
         insta::assert_snapshot!("sol_balance_single_positive", output);
     }
@@ -57,7 +57,7 @@ mod tests {
             },
         ];
         let output = capture(|w| {
-            crate::output::text::render_sol_balance_changes(&changes, "", w);
+            crate::output::text::render_sol_balance_changes(&changes, "", None, w);
         });
         insta::assert_snapshot!("sol_balance_mixed", output);
     }
@@ -79,7 +79,7 @@ mod tests {
             ui_change: -0.5,
         }];
         let output = capture(|w| {
-            crate::output::text::render_token_balance_changes(&changes, "", w);
+            crate::output::text::render_token_balance_changes(&changes, "", None, w);
         });
         insta::assert_snapshot!("token_balance_single", output);
     }
@@ -109,7 +109,7 @@ mod tests {
             },
         ];
         let output = capture(|w| {
-            crate::output::text::render_token_balance_changes(&changes, "", w);
+            crate::output::text::render_token_balance_changes(&changes, "", None, w);
         });
         insta::assert_snapshot!("token_balance_multiple", output);
     }

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -55,14 +55,15 @@ pub(super) fn render_text(
         render_instruction_details_text(&report.transaction, resolved, show_ix_data, w);
     }
 
+    let tw = terminal_width();
     if !report.sol_balance_changes.is_empty() {
         write_section_title(w, "SOL Balance Changes");
-        render_sol_balance_changes(&report.sol_balance_changes, "", w);
+        render_sol_balance_changes(&report.sol_balance_changes, "", tw, w);
     }
 
     if !report.token_balance_changes.is_empty() {
         write_section_title(w, "Token Balance Changes");
-        render_token_balance_changes(&report.token_balance_changes, "", w);
+        render_token_balance_changes(&report.token_balance_changes, "", tw, w);
     }
 
     let _ = writeln!(w);
@@ -104,14 +105,15 @@ pub(super) fn render_bundle_text(
         }
     }
 
+    let tw = terminal_width();
     if !bundle.sol_balance_changes.is_empty() {
         write_section_title(w, "SOL Balance Changes");
-        render_sol_balance_changes(&bundle.sol_balance_changes, INDENT_L1, w);
+        render_sol_balance_changes(&bundle.sol_balance_changes, INDENT_L1, tw, w);
     }
 
     if !bundle.token_balance_changes.is_empty() {
         write_section_title(w, "Token Balance Changes");
-        render_token_balance_changes(&bundle.token_balance_changes, INDENT_L1, w);
+        render_token_balance_changes(&bundle.token_balance_changes, INDENT_L1, tw, w);
     }
 
     let _ = writeln!(w);
@@ -418,6 +420,7 @@ fn render_log_entry(entry_with_depth: &LogEntryWithDepth, w: &mut impl Write) {
 pub(super) fn render_sol_balance_changes(
     sol_changes: &[SolBalanceChangeSection],
     indent: &str,
+    max_width: Option<usize>,
     w: &mut impl Write,
 ) {
     use super::table::{Align, Cell, TableWriter};
@@ -425,8 +428,8 @@ pub(super) fn render_sol_balance_changes(
     let prefix = format!("{}{}", indent, INDENT_L1);
     let mut table =
         TableWriter::new(&prefix).column(Align::Left).column(Align::Left).column(Align::Left);
-    if let Some(w) = terminal_width() {
-        table = table.max_width(w);
+    if let Some(mw) = max_width {
+        table = table.max_width(mw);
     }
 
     for c in sol_changes {
@@ -453,6 +456,7 @@ pub(super) fn render_sol_balance_changes(
 pub(super) fn render_token_balance_changes(
     token_changes: &[TokenBalanceChangeSection],
     indent: &str,
+    max_width: Option<usize>,
     w: &mut impl Write,
 ) {
     use super::table::{Align, Cell, TableWriter};
@@ -464,8 +468,8 @@ pub(super) fn render_token_balance_changes(
         .column(Align::Left)
         .column(Align::Left)
         .column(Align::Left);
-    if let Some(w) = terminal_width() {
-        table = table.max_width(w);
+    if let Some(mw) = max_width {
+        table = table.max_width(mw);
     }
 
     for c in token_changes {


### PR DESCRIPTION
## Summary

- `terminal_width()` queries the real stdout, not the `&mut impl Write` buffer passed to render functions
- This caused snapshot tests to produce different output depending on the terminal size of whoever runs `cargo test`
- Pass `max_width` as an explicit `Option<usize>` parameter: top-level render functions pass `terminal_width()`, tests pass `None`

## Test plan
- [x] `cargo test` — all 560 tests pass regardless of terminal width