### PR TITLE
refactor(test): remove 5 duplicate tests

### DIFF
--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -1,9 +1,6 @@
 pub(crate) use sonar_sim::internals::build_lookup_locations;
 pub use sonar_sim::internals::{LookupLocation, MessageAccountPlan, RawTransactionEncoding};
 
-#[cfg(test)]
-use sonar_sim::internals::AddressLookupPlan;
-
 use crate::core::rpc_client::{GetTransactionConfig, RpcClient};
 use anyhow::{Context, Result, anyhow};
 use base64::Engine;
@@ -547,85 +544,5 @@ mod tests {
         assert_eq!(resolved.len(), 1);
         assert_eq!(resolved[0].source, TxResolveSource::RawInput);
         assert_eq!(resolved[0].raw_tx_base64, raw_base64);
-    }
-
-    #[test]
-    fn test_build_lookup_locations_ordering() {
-        let table1 = Pubkey::new_unique();
-        let table2 = Pubkey::new_unique();
-
-        let plan = vec![
-            AddressLookupPlan {
-                account_key: table1,
-                writable_indexes: vec![0, 1],
-                readonly_indexes: vec![2, 3],
-            },
-            AddressLookupPlan {
-                account_key: table2,
-                writable_indexes: vec![5, 6],
-                readonly_indexes: vec![7],
-            },
-        ];
-
-        let locations = build_lookup_locations(&plan);
-
-        assert_eq!(locations.len(), 7, "Should have 7 lookup accounts");
-
-        assert_eq!(locations[0].table_account, table1);
-        assert_eq!(locations[0].table_index, 0);
-        assert!(locations[0].writable);
-
-        assert_eq!(locations[1].table_account, table1);
-        assert_eq!(locations[1].table_index, 1);
-        assert!(locations[1].writable);
-
-        assert_eq!(locations[2].table_account, table2);
-        assert_eq!(locations[2].table_index, 5);
-        assert!(locations[2].writable);
-
-        assert_eq!(locations[3].table_account, table2);
-        assert_eq!(locations[3].table_index, 6);
-        assert!(locations[3].writable);
-
-        assert_eq!(locations[4].table_account, table1);
-        assert_eq!(locations[4].table_index, 2);
-        assert!(!locations[4].writable);
-
-        assert_eq!(locations[5].table_account, table1);
-        assert_eq!(locations[5].table_index, 3);
-        assert!(!locations[5].writable);
-
-        assert_eq!(locations[6].table_account, table2);
-        assert_eq!(locations[6].table_index, 7);
-        assert!(!locations[6].writable);
-    }
-
-    #[test]
-    fn test_build_lookup_locations_empty() {
-        let locations = build_lookup_locations(&[]);
-        assert_eq!(locations.len(), 0, "Empty lookup plan should return empty locations");
-    }
-
-    #[test]
-    fn test_build_lookup_locations_single_table() {
-        let table = Pubkey::new_unique();
-        let plan = vec![AddressLookupPlan {
-            account_key: table,
-            writable_indexes: vec![10],
-            readonly_indexes: vec![20, 21],
-        }];
-
-        let locations = build_lookup_locations(&plan);
-
-        assert_eq!(locations.len(), 3);
-
-        assert_eq!(locations[0].table_index, 10);
-        assert!(locations[0].writable);
-
-        assert_eq!(locations[1].table_index, 20);
-        assert!(!locations[1].writable);
-
-        assert_eq!(locations[2].table_index, 21);
-        assert!(!locations[2].writable);
     }
 }

--- a/src/output/snapshot_tests.rs
+++ b/src/output/snapshot_tests.rs
@@ -165,19 +165,4 @@ mod tests {
         });
         insta::assert_snapshot!("execution_trace_failure", output);
     }
-
-    // -------------------------------------------------------------------
-    // Section title
-    // -------------------------------------------------------------------
-
-    #[test]
-    fn section_title_rendering() {
-        let output = capture(|w| {
-            crate::output::terminal::write_section_title(w, "SOL Balance Changes");
-        });
-        // Section titles depend on terminal width which varies; just check structure.
-        assert!(output.starts_with('\n'));
-        assert!(output.contains("SOL Balance Changes"));
-        assert!(output.ends_with("\n\n"));
-    }
 }

--- a/tests/e2e_cli_output_streams.rs
+++ b/tests/e2e_cli_output_streams.rs
@@ -580,27 +580,6 @@ fn config_without_subcommand_prints_config_help() {
     assert!(stdout.contains("set"), "expected set subcommand help, got: {stdout}");
 }
 
-#[test]
-fn cnofig_alias_is_rejected() {
-    let mut cmd = cargo_bin_cmd!("sonar");
-    cmd.arg("cnofig").arg("list");
-
-    let assert = cmd.assert().failure();
-    let output = assert.get_output();
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(stdout.trim().is_empty(), "expected no stdout when alias is rejected, got: {stdout}");
-    assert!(
-        stderr.contains("cnofig"),
-        "expected error mentioning removed alias cnofig, got: {stderr}"
-    );
-    assert!(
-        stderr.contains("unrecognized subcommand"),
-        "expected clap unknown subcommand error, got: {stderr}"
-    );
-}
-
 // ─── Global --json flag e2e tests ───────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Remove 3 `build_lookup_locations` tests from `src/core/transaction.rs` — exact copies of tests already in `crates/sonar-sim/src/transaction.rs`
- Remove `section_title_rendering` from `snapshot_tests.rs` — not a snapshot test, already covered by `terminal.rs::section_title_block_has_blank_line_after_header`
- Remove `cnofig_alias_is_rejected` e2e test — duplicates unit test `cli/config.rs::rejects_removed_cnofig_alias`

Test count: 586 → 581. All remaining tests pass, clippy clean.

## Test plan

- [x] `cargo test` — 581 tests pass, 0 failures
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` on changed files — clean
- [x] Verified canonical tests still exist in their respective modules