### PR TITLE
fix(parsers): emit numeric fields as proper JSON types instead of strings

### DIFF
--- a/crates/sonar-idl/src/decode.rs
+++ b/crates/sonar-idl/src/decode.rs
@@ -198,7 +198,12 @@ pub(crate) fn parse_simple_type(data: &[u8], offset: &mut usize, type_name: &str
                 data[start + 14],
                 data[start + 15],
             ]);
-            (Value::String(value.to_string()), 16)
+            // Emit as number when the value fits in u64; fall back to string
+            // only for values that exceed JSON's safe integer range.
+            (match u64::try_from(value) {
+                Ok(n) => Value::Number(JsonNumber::from(n)),
+                Err(_) => Value::String(value.to_string()),
+            }, 16)
         }
         "i128" => {
             check_data_len(data, start, 16)?;
@@ -220,7 +225,10 @@ pub(crate) fn parse_simple_type(data: &[u8], offset: &mut usize, type_name: &str
                 data[start + 14],
                 data[start + 15],
             ]);
-            (Value::String(value.to_string()), 16)
+            (match i64::try_from(value) {
+                Ok(n) => Value::Number(JsonNumber::from(n)),
+                Err(_) => Value::String(value.to_string()),
+            }, 16)
         }
         "pubkey" | "publicKey" => {
             check_data_len(data, start, 32)?;

--- a/src/parsers/instruction/compute_budget_program.rs
+++ b/src/parsers/instruction/compute_budget_program.rs
@@ -74,7 +74,7 @@ fn parse_u32_instruction(
         let value = reader.read_u32()?;
         Ok(ParsedInstruction {
             name: name.to_string(),
-            fields: vec![ParsedField::text(field_name, value.to_string())].into(),
+            fields: vec![ParsedField::number(field_name, value as u64)].into(),
             account_names: vec![],
         })
     })
@@ -93,7 +93,7 @@ fn parse_u64_instruction(
         let value = reader.read_u64()?;
         Ok(ParsedInstruction {
             name: name.to_string(),
-            fields: vec![ParsedField::text(field_name, value.to_string())].into(),
+            fields: vec![ParsedField::number(field_name, value)].into(),
             account_names: vec![],
         })
     })

--- a/src/parsers/instruction/system_program.rs
+++ b/src/parsers/instruction/system_program.rs
@@ -84,7 +84,7 @@ fn parse_transfer_instruction(
         let lamports = reader.read_u64()?;
         Ok(ParsedInstruction {
             name: "Transfer".to_string(),
-            fields: vec![ParsedField::text("lamports", lamports.to_string())].into(),
+            fields: vec![ParsedField::number("lamports", lamports)].into(),
             account_names: vec!["funding_account".to_string(), "recipient_account".to_string()],
         })
     })
@@ -106,8 +106,8 @@ fn parse_create_account_instruction(
         Ok(ParsedInstruction {
             name: "CreateAccount".to_string(),
             fields: vec![
-                ParsedField::text("lamports", lamports.to_string()),
-                ParsedField::text("space", space.to_string()),
+                ParsedField::number("lamports", lamports),
+                ParsedField::number("space", space),
                 ParsedField::text("owner", owner.to_string()),
             ]
             .into(),
@@ -155,8 +155,8 @@ fn parse_create_account_with_seed_instruction(
             fields: vec![
                 ParsedField::text("base", base.to_string()),
                 ParsedField::text("seed", seed),
-                ParsedField::text("lamports", lamports.to_string()),
-                ParsedField::text("space", space.to_string()),
+                ParsedField::number("lamports", lamports),
+                ParsedField::number("space", space),
                 ParsedField::text("owner", owner.to_string()),
             ]
             .into(),
@@ -198,7 +198,7 @@ fn parse_withdraw_nonce_account_instruction(
         let lamports = reader.read_u64()?;
         Ok(ParsedInstruction {
             name: "WithdrawNonceAccount".to_string(),
-            fields: vec![ParsedField::text("lamports", lamports.to_string())].into(),
+            fields: vec![ParsedField::number("lamports", lamports)].into(),
             account_names: vec![
                 "nonce_account".to_string(),
                 "recipient_account".to_string(),
@@ -265,7 +265,7 @@ fn parse_allocate_instruction(
         let space = reader.read_u64()?;
         Ok(ParsedInstruction {
             name: "Allocate".to_string(),
-            fields: vec![ParsedField::text("space", space.to_string())].into(),
+            fields: vec![ParsedField::number("space", space)].into(),
             account_names: vec!["allocated_account".to_string()],
         })
     })
@@ -290,7 +290,7 @@ fn parse_allocate_with_seed_instruction(
             fields: vec![
                 ParsedField::text("base", base.to_string()),
                 ParsedField::text("seed", seed),
-                ParsedField::text("space", space.to_string()),
+                ParsedField::number("space", space),
                 ParsedField::text("owner", owner.to_string()),
             ]
             .into(),
@@ -342,7 +342,7 @@ fn parse_transfer_with_seed_instruction(
         Ok(ParsedInstruction {
             name: "TransferWithSeed".to_string(),
             fields: vec![
-                ParsedField::text("lamports", lamports.to_string()),
+                ParsedField::number("lamports", lamports),
                 ParsedField::text("from_seed", from_seed),
                 ParsedField::text("from_owner", from_owner.to_string()),
             ]
@@ -384,8 +384,8 @@ fn parse_create_account_allow_prefund_instruction(
         Ok(ParsedInstruction {
             name: "CreateAccountAllowPrefund".to_string(),
             fields: vec![
-                ParsedField::text("lamports", lamports.to_string()),
-                ParsedField::text("space", space.to_string()),
+                ParsedField::number("lamports", lamports),
+                ParsedField::number("space", space),
                 ParsedField::text("owner", owner.to_string()),
             ]
             .into(),

--- a/src/parsers/instruction/token2022_program.rs
+++ b/src/parsers/instruction/token2022_program.rs
@@ -358,7 +358,7 @@ fn dispatch_table_instruction(
                 );
                 Ok(ParsedInstruction {
                     name: def.name.to_string(),
-                    fields: vec![ParsedField::text("amount", amount.to_string())].into(),
+                    fields: vec![ParsedField::number("amount", amount)].into(),
                     account_names,
                 })
             })
@@ -380,8 +380,8 @@ fn dispatch_table_instruction(
                 Ok(ParsedInstruction {
                     name: def.name.to_string(),
                     fields: vec![
-                        ParsedField::text("amount", amount.to_string()),
-                        ParsedField::text("decimals", decimals.to_string()),
+                        ParsedField::number("amount", amount),
+                        ParsedField::number("decimals", decimals as u64),
                     ]
                     .into(),
                     account_names,
@@ -452,8 +452,8 @@ fn parse_initialize_mint_instruction(
         Ok(ParsedInstruction {
             name: "InitializeMint".to_string(),
             fields: vec![
-                ParsedField::text("decimals", decimals.to_string()),
-                ParsedField::text("has_freeze_authority", has_freeze_authority.to_string()),
+                ParsedField::number("decimals", decimals as u64),
+                ParsedField::boolean("has_freeze_authority", has_freeze_authority),
             ]
             .into(),
             account_names: vec!["mint".to_string(), "rent_sysvar".to_string()],
@@ -499,7 +499,7 @@ fn parse_initialize_multisig_instruction(
         }
         Ok(ParsedInstruction {
             name: "InitializeMultisig".to_string(),
-            fields: vec![ParsedField::text("m", m.to_string())].into(),
+            fields: vec![ParsedField::number("m", m as u64)].into(),
             account_names,
         })
     })
@@ -535,8 +535,8 @@ fn parse_set_authority_instruction(
         Ok(ParsedInstruction {
             name: "SetAuthority".to_string(),
             fields: vec![
-                ParsedField::text("authority_type", authority_type.to_string()),
-                ParsedField::text("cleared", cleared.to_string()),
+                ParsedField::text("authority_type", authority_type),
+                ParsedField::boolean("cleared", cleared),
             ]
             .into(),
             account_names,
@@ -605,7 +605,7 @@ fn parse_initialize_multisig2_instruction(
         }
         Ok(ParsedInstruction {
             name: "InitializeMultisig2".to_string(),
-            fields: vec![ParsedField::text("m", m.to_string())].into(),
+            fields: vec![ParsedField::number("m", m as u64)].into(),
             account_names,
         })
     })
@@ -629,8 +629,8 @@ fn parse_initialize_mint2_instruction(
         Ok(ParsedInstruction {
             name: "InitializeMint2".to_string(),
             fields: vec![
-                ParsedField::text("decimals", decimals.to_string()),
-                ParsedField::text("has_freeze_authority", has_freeze_authority.to_string()),
+                ParsedField::number("decimals", decimals as u64),
+                ParsedField::boolean("has_freeze_authority", has_freeze_authority),
             ]
             .into(),
             account_names: vec!["mint".to_string()],
@@ -650,7 +650,7 @@ fn parse_amount_to_ui_amount_instruction(
         let amount = reader.read_u64()?;
         Ok(ParsedInstruction {
             name: "AmountToUiAmount".to_string(),
-            fields: vec![ParsedField::text("amount", amount.to_string())].into(),
+            fields: vec![ParsedField::number("amount", amount)].into(),
             account_names: vec!["mint".to_string()],
         })
     })
@@ -744,8 +744,8 @@ fn parse_transfer_fee_initialize_instruction(
                     "withdraw_withheld_authority",
                     withdraw_authority.map_or_else(|| "none".to_string(), |pk| pk.to_string()),
                 ),
-                ParsedField::text("transfer_fee_basis_points", bps.to_string()),
-                ParsedField::text("maximum_fee", maximum_fee.to_string()),
+                ParsedField::number("transfer_fee_basis_points", bps as u64),
+                ParsedField::number("maximum_fee", maximum_fee),
             ]
             .into(),
             account_names: vec!["mint".to_string()],
@@ -775,9 +775,9 @@ fn parse_transfer_checked_with_fee_instruction(
         Ok(ParsedInstruction {
             name: "TransferCheckedWithFee".to_string(),
             fields: vec![
-                ParsedField::text("amount", amount.to_string()),
-                ParsedField::text("decimals", decimals.to_string()),
-                ParsedField::text("fee", fee.to_string()),
+                ParsedField::number("amount", amount),
+                ParsedField::number("decimals", decimals as u64),
+                ParsedField::number("fee", fee),
             ]
             .into(),
             account_names,
@@ -830,7 +830,7 @@ fn parse_transfer_fee_withdraw_from_accounts_instruction(
 
     Ok(Some(ParsedInstruction {
         name: "WithdrawWithheldTokensFromAccounts".to_string(),
-        fields: vec![ParsedField::text("num_token_accounts", num_token_accounts.to_string())]
+        fields: vec![ParsedField::number("num_token_accounts", num_token_accounts as u64)]
             .into(),
         account_names,
     }))
@@ -879,7 +879,7 @@ fn parse_transfer_fee_set_fee_instruction(
                     "transfer_fee_basis_points",
                     transfer_fee_basis_points.to_string(),
                 ),
-                ParsedField::text("maximum_fee", maximum_fee.to_string()),
+                ParsedField::number("maximum_fee", maximum_fee),
             ]
             .into(),
             account_names,

--- a/src/parsers/instruction/types.rs
+++ b/src/parsers/instruction/types.rs
@@ -88,6 +88,18 @@ impl ParsedField {
     pub fn json(name: impl Into<String>, value: Value) -> Self {
         Self { name: name.into(), value: ParsedFieldValue::Json(value) }
     }
+
+    pub fn number(name: impl Into<String>, value: u64) -> Self {
+        Self::json(name, Value::Number(serde_json::Number::from(value)))
+    }
+
+    pub fn signed_number(name: impl Into<String>, value: i64) -> Self {
+        Self::json(name, Value::Number(serde_json::Number::from(value)))
+    }
+
+    pub fn boolean(name: impl Into<String>, value: bool) -> Self {
+        Self::json(name, Value::Bool(value))
+    }
 }
 
 impl<N, V> From<(N, V)> for ParsedField
@@ -124,7 +136,10 @@ impl PartialEq<&str> for ParsedFieldValue {
     fn eq(&self, other: &&str) -> bool {
         match self {
             ParsedFieldValue::Text(text) => text == *other,
-            ParsedFieldValue::Json(_) => false,
+            ParsedFieldValue::Json(Value::String(s)) => s == *other,
+            ParsedFieldValue::Json(Value::Number(n)) => n.to_string() == *other,
+            ParsedFieldValue::Json(Value::Bool(b)) => b.to_string() == *other,
+            _ => false,
         }
     }
 }
@@ -133,7 +148,10 @@ impl PartialEq<String> for ParsedFieldValue {
     fn eq(&self, other: &String) -> bool {
         match self {
             ParsedFieldValue::Text(text) => text == other,
-            ParsedFieldValue::Json(_) => false,
+            ParsedFieldValue::Json(Value::String(s)) => s == other,
+            ParsedFieldValue::Json(Value::Number(n)) => n.to_string() == *other,
+            ParsedFieldValue::Json(Value::Bool(b)) => b.to_string() == *other,
+            _ => false,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `ParsedField::number()`, `signed_number()`, `boolean()` typed constructors so parsers declare field types explicitly at the source
- Update system_program, token2022_program, compute_budget_program parsers to use typed constructors for numeric/boolean fields (lamports, amount, decimals, units, etc.)
- IDL decoder: emit u128/i128 as `Value::Number` when value fits in u64/i64, fall back to string only for truly large values
- Extend `PartialEq<&str>` on `ParsedFieldValue` to support `Json(Number)` and `Json(Bool)` comparison so existing tests remain compatible

## Before
```
"amount": "390069087195",
"decimals": "6"
```

## After
```
"amount": 390069087195,
"decimals": 6
```

## Test plan
- [x] All 556 unit tests pass
- [x] Verified terminal output: numbers unquoted, pubkeys/seeds remain quoted strings
- [x] `seed` field correctly stays as string even when numeric (e.g. `"seed": "1775861105640"`)