### PR TITLE
feat(trace): add trace subcommand for historical execution traces

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,6 +11,7 @@ mod pda;
 mod program_elf;
 mod send;
 mod simulate;
+mod trace;
 
 // Re-export all public types from submodules
 pub use account::*;
@@ -24,6 +25,7 @@ pub use pda::*;
 pub use program_elf::*;
 pub use send::*;
 pub use simulate::*;
+pub use trace::*;
 
 use clap::{Args, Parser, Subcommand};
 
@@ -64,6 +66,9 @@ pub enum Commands {
     /// Decode and display a raw transaction without simulation
     #[command(alias = "dec", next_line_help = true)]
     Decode(DecodeArgs),
+    /// Display the historical execution trace of a confirmed transaction
+    #[command(next_line_help = true)]
+    Trace(TraceArgs),
     /// Manage Anchor IDLs (fetch, sync, address)
     #[command(next_line_help = true)]
     Idl(IdlArgs),

--- a/src/cli/trace.rs
+++ b/src/cli/trace.rs
@@ -1,0 +1,34 @@
+//! Trace command arguments.
+
+use std::path::PathBuf;
+
+use clap::Args;
+
+use super::RpcArgs;
+
+/// Display the historical execution trace of a confirmed transaction.
+#[derive(Args, Debug)]
+pub struct TraceArgs {
+    /// Transaction signature to look up
+    pub signature: String,
+    #[command(flatten)]
+    pub rpc: RpcArgs,
+    /// Directory containing Anchor IDL JSON files
+    #[arg(long = "idl-dir", value_name = "DIR", env = "SONAR_IDL_DIR")]
+    pub idl_dir: Option<PathBuf>,
+    /// Skip auto-fetching missing IDLs from chain
+    #[arg(long = "no-idl-fetch", env = "SONAR_NO_IDL_FETCH")]
+    pub no_idl_fetch: bool,
+    /// Always print raw instruction data, even when parser succeeds
+    #[arg(long = "raw-ix-data", env = "SONAR_RAW_IX_DATA")]
+    pub ix_data: bool,
+    /// Print raw program logs instead of structured execution trace
+    #[arg(short = 'l', long = "raw-log", env = "SONAR_RAW_LOG")]
+    pub raw_log: bool,
+    /// Show detailed instruction information (accounts, parsed fields, inner instructions)
+    #[arg(short = 'd', long = "show-ix-detail", env = "SONAR_SHOW_IX_DETAIL")]
+    pub show_ix_detail: bool,
+    /// Show SOL and token balance changes
+    #[arg(short = 'b', long = "show-balance-change", env = "SONAR_SHOW_BALANCE_CHANGE")]
+    pub show_balance_change: bool,
+}

--- a/src/core/rpc_client.rs
+++ b/src/core/rpc_client.rs
@@ -12,7 +12,7 @@ use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_transaction::versioned::VersionedTransaction;
 use solana_transaction_status_client_types::{
-    EncodedConfirmedTransactionWithStatusMeta, TransactionStatus, UiTransactionEncoding,
+    EncodedTransaction, TransactionStatus, UiTransactionEncoding, UiTransactionStatusMeta,
 };
 
 use sonar_sim::internals::rpc_json::{JsonRpcResponse, RpcAccountInfo, RpcResultValue};
@@ -42,6 +42,25 @@ pub struct GetTransactionConfig {
     pub encoding: UiTransactionEncoding,
     pub commitment: CommitmentConfig,
     pub max_supported_transaction_version: Option<u8>,
+}
+
+// RPC `getTransaction` response, deserialized without `#[serde(flatten)]`.
+//
+// The upstream `EncodedConfirmedTransactionWithStatusMeta` uses
+// `#[serde(flatten)]` which breaks untagged enum deserialization of the
+// `version` field (serde bug <https://github.com/serde-rs/serde/issues/1183>).
+// V0 transactions return `"version": 0` (integer) which the flattened
+// deserializer misinterprets. This struct matches the flat JSON shape directly.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)] // slot, block_time, version are needed for deserialization only
+pub struct RpcTransactionResponse {
+    pub slot: u64,
+    pub block_time: Option<i64>,
+    pub transaction: EncodedTransaction,
+    pub meta: Option<UiTransactionStatusMeta>,
+    #[serde(default)]
+    version: Option<serde_json::Value>,
 }
 
 // ---------------------------------------------------------------------------
@@ -117,6 +136,17 @@ impl RpcClient {
             .map_err(|e| anyhow!("{e}"))
     }
 
+    pub fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> Result<Vec<Option<Account>>> {
+        let keys: Vec<String> = pubkeys.iter().map(|k| k.to_string()).collect();
+        let result: RpcResultValue<Vec<Option<RpcAccountInfo>>> =
+            self.call("getMultipleAccounts", serde_json::json!([keys, {"encoding": "base64"}]))?;
+        result
+            .value
+            .into_iter()
+            .map(|opt| opt.map(|info| info.into_account().map_err(|e| anyhow!("{e}"))).transpose())
+            .collect()
+    }
+
     pub fn get_account_with_commitment(
         &self,
         pubkey: &Pubkey,
@@ -168,7 +198,7 @@ impl RpcClient {
         &self,
         signature: &Signature,
         config: GetTransactionConfig,
-    ) -> Result<EncodedConfirmedTransactionWithStatusMeta> {
+    ) -> Result<RpcTransactionResponse> {
         self.call(
             "getTransaction",
             serde_json::json!([

--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -155,7 +155,6 @@ pub fn fetch_transaction_from_rpc(
 
     let tx = response
         .transaction
-        .transaction
         .decode()
         .ok_or_else(|| anyhow!("Failed to decode transaction from RPC response"))?;
     encode_transaction_to_base64(&tx)

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -11,3 +11,4 @@ pub(crate) mod pda;
 pub(crate) mod program_elf;
 pub(crate) mod send;
 pub(crate) mod simulate;
+pub(crate) mod trace;

--- a/src/handlers/trace.rs
+++ b/src/handlers/trace.rs
@@ -1,0 +1,462 @@
+use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
+
+use anyhow::{Result, anyhow};
+use solana_commitment_config::CommitmentConfig;
+use solana_message::compiled_instruction::CompiledInstruction;
+use solana_message::inner_instruction::{InnerInstruction, InnerInstructionsList};
+use solana_pubkey::Pubkey;
+use solana_transaction_status_client_types::option_serializer::OptionSerializer;
+use solana_transaction_status_client_types::{
+    UiCompiledInstruction, UiInnerInstructions, UiInstruction, UiTransactionEncoding,
+    UiTransactionStatusMeta, UiTransactionTokenBalance,
+};
+use sonar_sim::internals::{
+    ExecutionResult, ExecutionStatus, ResolvedAccounts, ResolvedLookup, ReturnData,
+    SimulationMetadata,
+};
+
+use solana_account::AccountSharedData;
+
+use crate::cli::TraceArgs;
+use crate::core::account_loader;
+use crate::core::rpc_client::{GetTransactionConfig, RpcClient};
+use crate::core::transaction::{
+    ParsedTransaction, encode_transaction_to_base64, parse_raw_transaction,
+};
+use crate::output::report::{SolBalanceChangeSection, TokenBalanceChangeSection};
+use crate::output::{self, BalanceChangeOptions, LogDisplayOptions, RenderOptions};
+use crate::parsers::instruction::ParserRegistry;
+use crate::utils::progress::Progress;
+
+pub(crate) fn handle(args: TraceArgs, json: bool) -> Result<()> {
+    let progress = Progress::new();
+    let rpc_url = args.rpc.rpc_url;
+    let idl_dir = args.idl_dir.clone();
+    let mut parser_registry = ParserRegistry::new(idl_dir);
+
+    let signature = args.signature.trim().to_string();
+    let parsed_sig =
+        signature.parse().map_err(|_| anyhow!("Invalid transaction signature: {}", signature))?;
+
+    progress.set_message("Fetching transaction from RPC...");
+    let client = RpcClient::new(&rpc_url);
+    let config = GetTransactionConfig {
+        encoding: UiTransactionEncoding::Base64,
+        commitment: CommitmentConfig::confirmed(),
+        max_supported_transaction_version: Some(0),
+    };
+    let response = client.get_transaction_with_config(&parsed_sig, config).map_err(|e| {
+        log::error!("RPC get_transaction error: {:?}", e);
+        anyhow!("Failed to fetch transaction for signature: {}. Error: {}", signature, e)
+    })?;
+
+    let tx = response
+        .transaction
+        .decode()
+        .ok_or_else(|| anyhow!("Failed to decode transaction from RPC response"))?;
+    let raw_base64 = encode_transaction_to_base64(&tx)?;
+
+    let meta = response.meta;
+    let inner_instructions = meta
+        .as_ref()
+        .and_then(|m| match &m.inner_instructions {
+            OptionSerializer::Some(ui_inner) => Some(convert_ui_inner_instructions(ui_inner)),
+            _ => None,
+        })
+        .unwrap_or_default();
+
+    let mut parsed_tx = parse_raw_transaction(&raw_base64)?;
+    parsed_tx.summary.inner_instructions = inner_instructions;
+
+    // Resolve lookups and ordered keys from historical meta.loaded_addresses,
+    // not live ALT state — ALTs may have been closed since the tx confirmed.
+    let (meta_lookups, ordered_keys) = resolve_from_meta(&parsed_tx, &meta);
+
+    // Fetch only program accounts for IDL parsing — trace doesn't need
+    // sysvars, token accounts, or ALTs like simulate/decode do.
+    let resolved_accounts = load_accounts_and_idls(
+        &client,
+        &rpc_url,
+        &parsed_tx,
+        &ordered_keys,
+        &mut parser_registry,
+        args.no_idl_fetch,
+        meta_lookups,
+        &progress,
+    );
+
+    progress.finish();
+
+    let execution_result = build_execution_result(&meta);
+
+    let (sol_changes, token_changes) = if args.show_balance_change {
+        compute_balance_changes(&meta, &ordered_keys)
+    } else {
+        (Vec::new(), Vec::new())
+    };
+
+    let render_opts = RenderOptions {
+        json,
+        show_ix_data: args.ix_data,
+        show_ix_detail: args.show_ix_detail,
+        verify_signatures: false,
+        balance_opts: BalanceChangeOptions { show_balance_change: args.show_balance_change },
+        log_opts: LogDisplayOptions { raw_log: args.raw_log },
+    };
+
+    output::render_trace(
+        &parsed_tx,
+        &resolved_accounts,
+        &execution_result,
+        &mut parser_registry,
+        &render_opts,
+        sol_changes,
+        token_changes,
+    )?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Program-only account loading for IDL parsing
+// ---------------------------------------------------------------------------
+
+/// Fetch outer instruction program accounts for IDL parsing, then mark
+/// CPI program accounts as executable using inner instruction data already
+/// in memory (zero extra RPC calls for the executable flag).
+fn load_accounts_and_idls(
+    client: &RpcClient,
+    rpc_url: &str,
+    parsed_tx: &ParsedTransaction,
+    ordered_keys: &[Pubkey],
+    parser_registry: &mut ParserRegistry,
+    no_idl_fetch: bool,
+    meta_lookups: Vec<ResolvedLookup>,
+    progress: &Progress,
+) -> ResolvedAccounts {
+    let mut program_ids: Vec<Pubkey> = parsed_tx
+        .summary
+        .instructions
+        .iter()
+        .filter_map(|ix| ix.program.pubkey.as_ref())
+        .filter_map(|s| Pubkey::from_str(s).ok())
+        .collect();
+    program_ids.sort();
+    program_ids.dedup();
+
+    progress.set_message("Fetching program accounts...");
+    let mut accounts: HashMap<Pubkey, AccountSharedData> = HashMap::new();
+    match client.get_multiple_accounts(&program_ids) {
+        Ok(results) => {
+            for (pubkey, account) in program_ids.iter().zip(results) {
+                if let Some(account) = account {
+                    accounts.insert(*pubkey, AccountSharedData::from(account));
+                }
+            }
+        }
+        Err(e) => {
+            log::warn!("Failed to fetch program accounts: {:#}", e);
+        }
+    }
+
+    // Mark CPI program accounts as executable using inner instruction data
+    // already in memory — no extra RPC calls needed.
+    for group in &parsed_tx.summary.inner_instructions {
+        for inner_ix in group {
+            let idx = inner_ix.instruction.program_id_index as usize;
+            if let Some(&pubkey) = ordered_keys.get(idx) {
+                accounts.entry(pubkey).or_insert_with(|| {
+                    AccountSharedData::from(solana_account::Account {
+                        executable: true,
+                        ..Default::default()
+                    })
+                });
+            }
+        }
+    }
+
+    let resolved = ResolvedAccounts { accounts, lookups: meta_lookups };
+
+    // Delegate to the shared IDL pipeline (auto-fetch + load from disk)
+    match account_loader::create_loader(rpc_url.to_string(), None, false, Some(progress.clone())) {
+        Ok(loader) => {
+            super::common::run_idl_pipeline(
+                &loader,
+                parser_registry,
+                &resolved,
+                no_idl_fetch,
+                false,
+                Some(progress),
+            );
+        }
+        Err(e) => {
+            log::warn!("Failed to create account loader for IDL fetching: {:#}", e);
+        }
+    }
+
+    resolved
+}
+
+// ---------------------------------------------------------------------------
+// RPC metadata → native type conversions
+// ---------------------------------------------------------------------------
+
+/// Convert RPC UiInnerInstructions to native InnerInstructionsList.
+///
+/// InnerInstructionsList is Vec<Vec<InnerInstruction>>, indexed by outer instruction index.
+/// UiInnerInstructions has an explicit `index` field for the outer instruction index.
+fn convert_ui_inner_instructions(ui_inner: &[UiInnerInstructions]) -> InnerInstructionsList {
+    let max_index = ui_inner.iter().map(|g| g.index as usize).max().unwrap_or(0);
+    let mut result: InnerInstructionsList = vec![Vec::new(); max_index + 1];
+
+    for group in ui_inner {
+        let idx = group.index as usize;
+        for ui_ix in &group.instructions {
+            if let UiInstruction::Compiled(compiled) = ui_ix {
+                result[idx].push(convert_ui_compiled_to_inner(compiled));
+            }
+            // UiInstruction::Parsed skipped: lacks raw account indices.
+            // With Base64 encoding request, inner instructions arrive as Compiled.
+        }
+    }
+    result
+}
+
+fn convert_ui_compiled_to_inner(ui: &UiCompiledInstruction) -> InnerInstruction {
+    let data = bs58::decode(&ui.data).into_vec().unwrap_or_else(|e| {
+        log::warn!("Failed to decode inner instruction data as base58: {}", e);
+        Vec::new()
+    });
+    InnerInstruction {
+        instruction: CompiledInstruction {
+            program_id_index: ui.program_id_index,
+            accounts: ui.accounts.clone(),
+            data,
+        },
+        stack_height: ui.stack_height.unwrap_or(0).try_into().unwrap_or(0),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Balance change computation (directly from RPC arrays)
+// ---------------------------------------------------------------------------
+
+/// Resolve lookup addresses and build the ordered account key list from
+/// `meta.loaded_addresses` (historical data) rather than live ALT state.
+///
+/// Returns (ResolvedLookup list, ordered account keys). The ordered keys
+/// match Solana's v0 account ordering: static keys, then all writable
+/// lookup addresses across all tables, then all readonly — matching the
+/// RPC balance array indices.
+fn resolve_from_meta(
+    parsed_tx: &ParsedTransaction,
+    meta: &Option<UiTransactionStatusMeta>,
+) -> (Vec<ResolvedLookup>, Vec<Pubkey>) {
+    let mut ordered_keys: Vec<Pubkey> = parsed_tx.account_plan.static_accounts.clone();
+
+    let Some(meta) = meta else {
+        return (Vec::new(), ordered_keys);
+    };
+    let OptionSerializer::Some(loaded) = &meta.loaded_addresses else {
+        return (Vec::new(), ordered_keys);
+    };
+
+    let writable_addrs: Vec<Pubkey> =
+        loaded.writable.iter().filter_map(|s| Pubkey::from_str(s).ok()).collect();
+    let readonly_addrs: Vec<Pubkey> =
+        loaded.readonly.iter().filter_map(|s| Pubkey::from_str(s).ok()).collect();
+
+    // Ordered keys: static ++ all writable lookups ++ all readonly lookups
+    ordered_keys.extend_from_slice(&writable_addrs);
+    ordered_keys.extend_from_slice(&readonly_addrs);
+
+    // Distribute flat address lists across per-table ResolvedLookup entries
+    let mut w_offset = 0;
+    let mut r_offset = 0;
+    let lookups = parsed_tx
+        .account_plan
+        .address_lookups
+        .iter()
+        .map(|lookup| {
+            let w_count = lookup.writable_indexes.len();
+            let r_count = lookup.readonly_indexes.len();
+            let w = writable_addrs.get(w_offset..w_offset + w_count).unwrap_or_default().to_vec();
+            let r = readonly_addrs.get(r_offset..r_offset + r_count).unwrap_or_default().to_vec();
+            w_offset += w_count;
+            r_offset += r_count;
+
+            ResolvedLookup {
+                account_key: lookup.account_key,
+                writable_indexes: lookup.writable_indexes.clone(),
+                writable_addresses: w,
+                readonly_indexes: lookup.readonly_indexes.clone(),
+                readonly_addresses: r,
+            }
+        })
+        .collect();
+
+    (lookups, ordered_keys)
+}
+
+/// Compute SOL and token balance changes directly from RPC balance arrays.
+fn compute_balance_changes(
+    meta: &Option<UiTransactionStatusMeta>,
+    ordered_keys: &[Pubkey],
+) -> (Vec<SolBalanceChangeSection>, Vec<TokenBalanceChangeSection>) {
+    let Some(meta) = meta else {
+        return (Vec::new(), Vec::new());
+    };
+
+    let sol_changes: Vec<SolBalanceChangeSection> = meta
+        .pre_balances
+        .iter()
+        .zip(&meta.post_balances)
+        .enumerate()
+        .filter(|(_, (pre, post))| pre != post)
+        .filter_map(|(i, (pre, post))| {
+            let pubkey = ordered_keys.get(i)?;
+            let change = *post as i128 - *pre as i128;
+            Some(SolBalanceChangeSection {
+                account: pubkey.to_string(),
+                before: *pre,
+                after: *post,
+                change,
+                change_sol: change as f64 / 1_000_000_000.0,
+            })
+        })
+        .collect();
+
+    let pre_tokens = match &meta.pre_token_balances {
+        OptionSerializer::Some(b) => b.as_slice(),
+        _ => &[],
+    };
+    let post_tokens = match &meta.post_token_balances {
+        OptionSerializer::Some(b) => b.as_slice(),
+        _ => &[],
+    };
+    let token_changes = compute_token_balance_changes(pre_tokens, post_tokens, ordered_keys);
+
+    (sol_changes, token_changes)
+}
+
+/// Match pre/post token balances by account_index and compute diffs.
+fn compute_token_balance_changes(
+    pre: &[UiTransactionTokenBalance],
+    post: &[UiTransactionTokenBalance],
+    ordered_keys: &[Pubkey],
+) -> Vec<TokenBalanceChangeSection> {
+    let mut changes = Vec::new();
+
+    let pre_map: HashMap<u8, &UiTransactionTokenBalance> =
+        pre.iter().map(|b| (b.account_index, b)).collect();
+
+    for post_tb in post {
+        let account_index = post_tb.account_index;
+        let Some(pubkey) = ordered_keys.get(account_index as usize) else { continue };
+
+        let pre_amount: u64 = pre_map
+            .get(&account_index)
+            .and_then(|tb| tb.ui_token_amount.amount.parse().ok())
+            .unwrap_or(0);
+        let post_amount: u64 = post_tb.ui_token_amount.amount.parse().unwrap_or(0);
+
+        if pre_amount != post_amount {
+            changes.push(make_token_change(post_tb, pubkey, pre_amount, post_amount));
+        }
+    }
+
+    // Closed token accounts: exist in pre but not in post
+    let post_indices: HashSet<u8> = post.iter().map(|b| b.account_index).collect();
+    for pre_tb in pre {
+        if post_indices.contains(&pre_tb.account_index) {
+            continue;
+        }
+        let Some(pubkey) = ordered_keys.get(pre_tb.account_index as usize) else { continue };
+        let pre_amount: u64 = pre_tb.ui_token_amount.amount.parse().unwrap_or(0);
+        if pre_amount != 0 {
+            changes.push(make_token_change(pre_tb, pubkey, pre_amount, 0));
+        }
+    }
+
+    changes
+}
+
+fn make_token_change(
+    tb: &UiTransactionTokenBalance,
+    pubkey: &Pubkey,
+    before: u64,
+    after: u64,
+) -> TokenBalanceChangeSection {
+    let change = after as i128 - before as i128;
+    let decimals = tb.ui_token_amount.decimals;
+    let divisor = 10f64.powi(decimals as i32);
+    TokenBalanceChangeSection {
+        owner: match &tb.owner {
+            OptionSerializer::Some(s) => s.clone(),
+            _ => String::new(),
+        },
+        token_account: pubkey.to_string(),
+        mint: tb.mint.clone(),
+        before,
+        after,
+        change,
+        decimals,
+        ui_change: change as f64 / divisor,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Execution result construction
+// ---------------------------------------------------------------------------
+
+/// Build ExecutionResult from RPC metadata for SimulationSection rendering.
+/// Inner instructions go through TransactionSection (via parsed_tx.summary), not here.
+fn build_execution_result(meta: &Option<UiTransactionStatusMeta>) -> ExecutionResult {
+    let Some(meta) = meta else {
+        return ExecutionResult {
+            status: ExecutionStatus::Failed("No execution metadata in RPC response".into()),
+            meta: SimulationMetadata::default(),
+            post_accounts: HashMap::new(),
+            pre_accounts: HashMap::new(),
+        };
+    };
+
+    let status = match &meta.err {
+        Some(err) => ExecutionStatus::Failed(format!("{:?}", err)),
+        None => ExecutionStatus::Succeeded,
+    };
+
+    let logs = match &meta.log_messages {
+        OptionSerializer::Some(logs) => logs.clone(),
+        _ => Vec::new(),
+    };
+
+    let compute_units_consumed = match &meta.compute_units_consumed {
+        OptionSerializer::Some(cu) => *cu,
+        _ => 0,
+    };
+
+    let return_data = match &meta.return_data {
+        OptionSerializer::Some(rd) => {
+            let program_id = rd.program_id.parse::<Pubkey>().unwrap_or_default();
+            let (data_str, _encoding) = &rd.data;
+            let data = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, data_str)
+                .unwrap_or_default();
+            ReturnData { program_id, data }
+        }
+        _ => ReturnData::default(),
+    };
+
+    ExecutionResult {
+        status,
+        meta: SimulationMetadata {
+            logs,
+            inner_instructions: Vec::new(),
+            compute_units_consumed,
+            return_data,
+        },
+        post_accounts: HashMap::new(),
+        pre_accounts: HashMap::new(),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,7 @@ fn run() -> Result<()> {
             handlers::completions::handle(args);
             return Ok(());
         }
+        Commands::Trace(args) => handlers::trace::handle(args, json)?,
     }
     Ok(())
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,7 +1,7 @@
 mod account_text;
 mod fmt;
 mod json;
-mod report;
+pub(crate) mod report;
 #[cfg(test)]
 mod snapshot_tests;
 mod table;
@@ -21,7 +21,10 @@ use sonar_sim::internals::{
     AccountOverride, ExecutionResult, PreparedTokenFunding, ResolvedAccounts, SolFunding,
 };
 
-use report::{BundleReport, LookupResolver, Report, TransactionSection};
+use report::{
+    BundleReport, LookupResolver, Report, SolBalanceChangeSection, TokenBalanceChangeSection,
+    TransactionSection,
+};
 
 /// Balance change display options.
 #[derive(Debug, Clone, Copy, Default)]
@@ -72,12 +75,42 @@ pub fn render(
         opts.verify_signatures,
         opts.balance_opts,
     );
+    render_report(&report, resolved, parser_registry, opts)
+}
+
+/// Render a trace report with pre-computed balance changes from RPC metadata.
+pub fn render_trace(
+    parsed: &ParsedTransaction,
+    resolved: &ResolvedAccounts,
+    simulation: &ExecutionResult,
+    parser_registry: &mut ParserRegistry,
+    opts: &RenderOptions,
+    sol_balance_changes: Vec<SolBalanceChangeSection>,
+    token_balance_changes: Vec<TokenBalanceChangeSection>,
+) -> Result<()> {
+    let report = Report::from_trace(
+        parsed,
+        resolved,
+        simulation,
+        parser_registry,
+        sol_balance_changes,
+        token_balance_changes,
+    );
+    render_report(&report, resolved, parser_registry, opts)
+}
+
+fn render_report(
+    report: &Report,
+    resolved: &ResolvedAccounts,
+    parser_registry: &mut ParserRegistry,
+    opts: &RenderOptions,
+) -> Result<()> {
     if opts.json {
-        json::render_json(&report)
+        json::render_json(report)
     } else {
         let mut stdout = std::io::stdout().lock();
         text::render_text(
-            &report,
+            report,
             resolved,
             parser_registry,
             opts.show_ix_data,

--- a/src/output/report.rs
+++ b/src/output/report.rs
@@ -35,24 +35,24 @@ pub(super) struct Report {
 }
 
 #[derive(Serialize)]
-pub(super) struct SolBalanceChangeSection {
-    pub(super) account: String,
-    pub(super) before: u64,
-    pub(super) after: u64,
-    pub(super) change: i128,
-    pub(super) change_sol: f64,
+pub(crate) struct SolBalanceChangeSection {
+    pub(crate) account: String,
+    pub(crate) before: u64,
+    pub(crate) after: u64,
+    pub(crate) change: i128,
+    pub(crate) change_sol: f64,
 }
 
 #[derive(Serialize)]
-pub(super) struct TokenBalanceChangeSection {
-    pub(super) owner: String,
-    pub(super) token_account: String,
-    pub(super) mint: String,
-    pub(super) before: u64,
-    pub(super) after: u64,
-    pub(super) change: i128,
-    pub(super) decimals: u8,
-    pub(super) ui_change: f64,
+pub(crate) struct TokenBalanceChangeSection {
+    pub(crate) owner: String,
+    pub(crate) token_account: String,
+    pub(crate) mint: String,
+    pub(crate) before: u64,
+    pub(crate) after: u64,
+    pub(crate) change: i128,
+    pub(crate) decimals: u8,
+    pub(crate) ui_change: f64,
 }
 
 /// Report structure for bundle simulation (multiple transactions).
@@ -209,6 +209,33 @@ impl Report {
             overrides,
             fundings,
             token_fundings,
+            sol_balance_changes,
+            token_balance_changes,
+        }
+    }
+
+    /// Construct a trace report with pre-computed balance changes.
+    /// No SimulationContext needed — trace is read-only historical data.
+    pub(super) fn from_trace(
+        parsed: &ParsedTransaction,
+        resolved: &ResolvedAccounts,
+        simulation: &ExecutionResult,
+        parser_registry: &mut ParserRegistry,
+        sol_balance_changes: Vec<SolBalanceChangeSection>,
+        token_balance_changes: Vec<TokenBalanceChangeSection>,
+    ) -> Self {
+        let resolver = LookupResolver::new(resolved.lookup_details());
+        let transaction =
+            TransactionSection::from_sources(parsed, resolved, &resolver, parser_registry, false);
+        let simulation_section = SimulationSection::from_result(simulation);
+
+        Self {
+            transaction,
+            simulation: simulation_section,
+            account_closures: Vec::new(),
+            overrides: Vec::new(),
+            fundings: Vec::new(),
+            token_fundings: Vec::new(),
             sol_balance_changes,
             token_balance_changes,
         }


### PR DESCRIPTION
## Summary

- Adds `sonar trace <signature>` that displays the full execution trace of a confirmed transaction by extracting metadata from the RPC `getTransaction` response
- Shows inner instructions (CPI calls), structured program logs, compute units, return data, and SOL/token balance changes
- Uses `meta.loaded_addresses` for lookup resolution instead of live ALT fetches, so old transactions with closed ALTs still work
- Fixes v0 transaction deserialization for both `decode` and `trace` by replacing the upstream `EncodedConfirmedTransactionWithStatusMeta` (broken serde `flatten`+`untagged` combo) with a custom struct

### CLI interface

```
sonar trace <SIGNATURE> [-d] [-b] [-l] [--raw-ix-data] [--idl-dir DIR]
```

Reuses the same render options as `simulate` (`-d`, `-b`, `-l`, `--json`).

### Design rationale

`decode` is static deserialization — it parses transaction bytes. `simulate` executes against current state. `trace` fills the gap: historical execution data for confirmed transactions where simulation fails due to stale state. See `ai-docs/superpowers/specs/2026-04-12-trace-subcommand-design.md`.

## Test plan

- [ ] `sonar trace <CPI_TX_SIG> -d` shows inner instructions with parsed names
- [ ] `sonar trace <SIG> -b` shows SOL and token balance changes
- [ ] `sonar trace <SIG> --json` produces valid JSON matching simulate schema
- [ ] `sonar trace invalid-sig` shows clear error
- [ ] `sonar decode <SIG>` unchanged (no inner instructions, no execution metadata)
- [ ] v0 transactions with lookup tables work (previously failed with serde error)