### PR TITLE
feat(rpc): parallel batch fetching and configurable --rpc-batch-size

### DIFF
--- a/crates/sonar-sim/src/account_fetcher.rs
+++ b/crates/sonar-sim/src/account_fetcher.rs
@@ -11,7 +11,9 @@ use crate::error::{Result, SonarSimError};
 use crate::rpc_provider::{RpcAccountProvider, SolanaRpcProvider};
 use crate::types::{AccountSource, FetchEvent, FetchObserver, FetchPolicy, RpcDecision};
 
-const MAX_ACCOUNTS_PER_REQUEST: usize = 100;
+/// Default maximum number of accounts per `getMultipleAccounts` RPC call.
+/// Matches the Solana validator's built-in limit.
+pub const DEFAULT_RPC_BATCH_SIZE: usize = 100;
 
 /// Low-level account fetcher that handles dedup, caching, source resolution,
 /// policy gating, observer events, and batched RPC calls.
@@ -26,6 +28,7 @@ pub struct AccountFetcher {
     sources: Vec<Arc<dyn AccountSource>>,
     policy: Option<Arc<dyn FetchPolicy>>,
     observers: Vec<Arc<dyn FetchObserver>>,
+    rpc_batch_size: usize,
 }
 
 impl AccountFetcher {
@@ -44,7 +47,14 @@ impl AccountFetcher {
             sources: Vec::new(),
             policy: None,
             observers: Vec::new(),
+            rpc_batch_size: DEFAULT_RPC_BATCH_SIZE,
         }
+    }
+
+    /// Set the maximum number of accounts per `getMultipleAccounts` RPC call.
+    pub fn with_rpc_batch_size(mut self, size: usize) -> Self {
+        self.rpc_batch_size = size.max(1);
+        self
     }
 
     pub fn with_source(mut self, source: Arc<dyn AccountSource>) -> Self {
@@ -66,6 +76,10 @@ impl AccountFetcher {
         Arc::clone(&self.provider)
     }
 
+    pub fn rpc_batch_size(&self) -> usize {
+        self.rpc_batch_size
+    }
+
     /// Fetch accounts by pubkey into `destination`.
     ///
     /// Handles the full pipeline:
@@ -79,8 +93,8 @@ impl AccountFetcher {
         pubkeys: &[Pubkey],
         destination: &mut HashMap<Pubkey, AccountSharedData>,
     ) -> Result<()> {
-        let mut unique = Vec::new();
-        let mut seen = HashSet::new();
+        let mut unique = Vec::with_capacity(pubkeys.len());
+        let mut seen = HashSet::with_capacity(pubkeys.len());
         for key in pubkeys {
             if crate::known_programs::is_litesvm_builtin_program(key) {
                 continue;
@@ -152,21 +166,50 @@ impl AccountFetcher {
         }
 
         let total_count = to_fetch.len();
-        let mut requested_count = 0usize;
-        let mut fetched_count = 0usize;
-        for (batch_index, chunk) in to_fetch.chunks(MAX_ACCOUNTS_PER_REQUEST).enumerate() {
+        let chunks: Vec<&[Pubkey]> = to_fetch.chunks(self.rpc_batch_size).collect();
+
+        for (batch_index, chunk) in chunks.iter().enumerate() {
             self.notify(FetchEvent::RpcBatchStarted {
                 batch_index,
                 batch_size: chunk.len(),
                 total_requested: total_count,
             });
-            let response =
-                self.provider.get_multiple_accounts(chunk).map_err(|e| SonarSimError::Rpc {
-                    reason: format!(
-                        "getMultipleAccounts call failed, account list: [{}]: {e}",
-                        format_pubkeys(chunk)
-                    ),
-                })?;
+        }
+
+        // Fetch all batches in parallel when multiple chunks are needed.
+        // Single-batch case avoids thread overhead.
+        let batch_results: Vec<Result<Vec<Option<AccountSharedData>>>> = if chunks.len() <= 1 {
+            chunks
+                .iter()
+                .map(|&chunk| self.provider.get_multiple_accounts(chunk))
+                .collect()
+        } else {
+            let provider = &self.provider;
+            std::thread::scope(|s| {
+                let handles: Vec<_> = chunks
+                    .iter()
+                    .map(|&chunk| {
+                        let provider = Arc::clone(provider);
+                        s.spawn(move || provider.get_multiple_accounts(chunk))
+                    })
+                    .collect();
+                handles
+                    .into_iter()
+                    .map(|h| h.join().expect("RPC batch thread panicked"))
+                    .collect()
+            })
+        };
+
+        // Process results and update caches
+        let mut requested_count = 0usize;
+        let mut fetched_count = 0usize;
+        for (&chunk, result) in chunks.iter().zip(batch_results) {
+            let response = result.map_err(|e| SonarSimError::Rpc {
+                reason: format!(
+                    "getMultipleAccounts call failed, account list: [{}]: {e}",
+                    format_pubkeys(chunk)
+                ),
+            })?;
 
             if response.len() != chunk.len() {
                 return Err(SonarSimError::Rpc {

--- a/crates/sonar-sim/src/account_loader.rs
+++ b/crates/sonar-sim/src/account_loader.rs
@@ -61,9 +61,19 @@ impl AccountLoader {
         self
     }
 
+    /// Set the maximum number of accounts per `getMultipleAccounts` RPC call.
+    pub fn with_rpc_batch_size(mut self, size: usize) -> Self {
+        self.fetcher = self.fetcher.with_rpc_batch_size(size);
+        self
+    }
+
     /// Expose the underlying provider so callers can reuse the RPC connection.
     pub fn provider(&self) -> Arc<dyn RpcAccountProvider> {
         self.fetcher.provider()
+    }
+
+    pub fn rpc_batch_size(&self) -> usize {
+        self.fetcher.rpc_batch_size()
     }
 
     /// Expose the inner fetcher for direct low-level account access.
@@ -90,7 +100,7 @@ impl AccountLoader {
 
     fn load_from_plans(&mut self, plans: &[MessageAccountPlan]) -> Result<ResolvedAccounts> {
         let initial = collect_initial_accounts(plans);
-        let mut accounts = HashMap::new();
+        let mut accounts = HashMap::with_capacity(initial.len());
 
         self.fetcher.fetch_accounts(&initial, &mut accounts).map_err(|e| {
             SonarSimError::AccountData {
@@ -260,8 +270,10 @@ impl AccountAppender for AccountLoader {
 }
 
 fn collect_initial_accounts(plans: &[MessageAccountPlan]) -> Vec<Pubkey> {
-    let mut keys = Vec::new();
-    let mut seen = HashSet::new();
+    let cap =
+        plans.iter().map(|p| p.static_accounts.len() + p.address_lookups.len()).sum::<usize>() + 2;
+    let mut keys = Vec::with_capacity(cap);
+    let mut seen = HashSet::with_capacity(cap);
 
     for plan in plans {
         for key in &plan.static_accounts {

--- a/crates/sonar-sim/src/internals.rs
+++ b/crates/sonar-sim/src/internals.rs
@@ -13,7 +13,7 @@ pub use crate::transaction::{
 
 // ── Account loading ──
 
-pub use crate::account_fetcher::AccountFetcher;
+pub use crate::account_fetcher::{AccountFetcher, DEFAULT_RPC_BATCH_SIZE};
 pub use crate::account_loader::AccountLoader;
 
 // ── Account types ──

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -40,6 +40,12 @@ pub struct RpcArgs {
         default_value = "https://api.mainnet-beta.solana.com"
     )]
     pub rpc_url: String,
+
+    /// Maximum accounts per getMultipleAccounts RPC call.
+    /// The default (100) matches the Solana validator limit.
+    /// Commercial RPC providers often support higher values.
+    #[arg(long = "rpc-batch-size", env = "SONAR_RPC_BATCH_SIZE", default_value = "100")]
+    pub rpc_batch_size: usize,
 }
 
 #[derive(Parser, Debug)]

--- a/src/core/account_loader.rs
+++ b/src/core/account_loader.rs
@@ -107,6 +107,7 @@ pub fn create_loader(
     local_dir: Option<PathBuf>,
     offline: bool,
     progress: Option<Progress>,
+    rpc_batch_size: usize,
 ) -> Result<AccountLoader> {
     let url = if rpc_url.is_empty() && offline {
         "http://localhost:8899".to_string()
@@ -118,7 +119,7 @@ pub fn create_loader(
         rpc_url
     };
 
-    let mut loader = AccountLoader::new(url)?;
+    let mut loader = AccountLoader::new(url)?.with_rpc_batch_size(rpc_batch_size);
 
     if let Some(dir) = local_dir {
         loader = loader.with_source(Arc::new(LocalDirSource::new(dir)));
@@ -137,9 +138,10 @@ pub fn create_loader(
     Ok(loader)
 }
 
-/// Create an `IdlFetcher` that shares the loader's RPC provider.
+/// Create an `IdlFetcher` that shares the loader's RPC provider and batch size.
 pub fn create_idl_fetcher(loader: &AccountLoader, progress: Option<Progress>) -> IdlFetcher {
     IdlFetcher::with_provider(loader.provider(), progress)
+        .with_rpc_batch_size(loader.rpc_batch_size())
 }
 
 #[cfg(test)]

--- a/src/core/idl_fetcher.rs
+++ b/src/core/idl_fetcher.rs
@@ -7,13 +7,12 @@ use solana_account::{AccountSharedData, ReadableAccount};
 use solana_pubkey::Pubkey;
 
 use crate::utils::progress::Progress;
-use sonar_sim::internals::{RpcAccountProvider, SolanaRpcProvider};
-
-const MAX_ACCOUNTS_PER_REQUEST: usize = 100;
+use sonar_sim::internals::{DEFAULT_RPC_BATCH_SIZE, RpcAccountProvider, SolanaRpcProvider};
 
 pub struct IdlFetcher {
     provider: Arc<dyn RpcAccountProvider>,
     progress: Option<Progress>,
+    rpc_batch_size: usize,
 }
 
 impl IdlFetcher {
@@ -21,14 +20,23 @@ impl IdlFetcher {
         if rpc_url.is_empty() {
             return Err(anyhow!("RPC URL cannot be empty"));
         }
-        Ok(Self { provider: Arc::new(SolanaRpcProvider::new(rpc_url)), progress })
+        Ok(Self {
+            provider: Arc::new(SolanaRpcProvider::new(rpc_url)),
+            progress,
+            rpc_batch_size: DEFAULT_RPC_BATCH_SIZE,
+        })
     }
 
     pub fn with_provider(
         provider: Arc<dyn RpcAccountProvider>,
         progress: Option<Progress>,
     ) -> Self {
-        Self { provider, progress }
+        Self { provider, progress, rpc_batch_size: DEFAULT_RPC_BATCH_SIZE }
+    }
+
+    pub fn with_rpc_batch_size(mut self, size: usize) -> Self {
+        self.rpc_batch_size = size.max(1);
+        self
     }
 
     /// Fetches and parses the Anchor IDL for a given program ID.
@@ -49,10 +57,64 @@ impl IdlFetcher {
 
     /// Fetches and parses Anchor IDLs for multiple program IDs in batch.
     ///
-    /// Uses `get_multiple_accounts` to minimize RPC round-trips.
-    /// Returns one `(program_id, result)` entry per input, preserving order.
+    /// Parallelizes RPC calls when many programs are requested (> batch_size)
+    /// to reduce total wall-clock time. Order is preserved to match input.
     pub fn fetch_idls(&self, program_ids: &[Pubkey]) -> Vec<(Pubkey, Result<Option<String>>)> {
-        self.fetch_idls_with(program_ids, |chunk| Ok(self.provider.get_multiple_accounts(chunk)?))
+        if program_ids.is_empty() {
+            return Vec::new();
+        }
+
+        let (pending, mut results) = prepare_idl_batch(program_ids);
+        let total = pending.len();
+        let chunks: Vec<&[(usize, Pubkey, Pubkey)]> =
+            pending.chunks(self.rpc_batch_size).collect();
+
+        // Fetch all chunks in parallel when multiple batches are needed
+        let batch_rpc_results: Vec<Result<Vec<Option<AccountSharedData>>>> =
+            if chunks.len() <= 1 {
+                chunks
+                    .iter()
+                    .map(|chunk| {
+                        let addrs: Vec<Pubkey> = chunk.iter().map(|(_, _, idl)| *idl).collect();
+                        self.provider
+                            .get_multiple_accounts(&addrs)
+                            .map_err(|e| anyhow!("{e}"))
+                    })
+                    .collect()
+            } else {
+                std::thread::scope(|s| {
+                    let handles: Vec<_> = chunks
+                        .iter()
+                        .map(|chunk| {
+                            let provider = Arc::clone(&self.provider);
+                            let addrs: Vec<Pubkey> =
+                                chunk.iter().map(|(_, _, idl)| *idl).collect();
+                            s.spawn(move || {
+                                provider
+                                    .get_multiple_accounts(&addrs)
+                                    .map_err(|e| anyhow!("{e}"))
+                            })
+                        })
+                        .collect();
+                    handles
+                        .into_iter()
+                        .map(|h| h.join().expect("IDL batch thread panicked"))
+                        .collect()
+                })
+            };
+
+        let mut requested = 0usize;
+        for (chunk, batch_result) in chunks.iter().zip(batch_rpc_results) {
+            self.set_progress_message(format!(
+                "fetching IDL accounts ({}/{})",
+                requested + 1,
+                total
+            ));
+            process_idl_chunk(chunk, batch_result, &mut results);
+            requested += chunk.len();
+        }
+
+        collect_idl_results(program_ids, results)
     }
 
     fn fetch_idl_with<F>(&self, program_id: &Pubkey, fetch_account: F) -> Result<Option<String>>
@@ -75,6 +137,7 @@ impl IdlFetcher {
         Ok(Some(parse_idl_account_data(account.data(), program_id)?))
     }
 
+    #[cfg(test)]
     fn fetch_idls_with<F>(
         &self,
         program_ids: &[Pubkey],
@@ -87,74 +150,22 @@ impl IdlFetcher {
             return Vec::new();
         }
 
-        let mut pending = Vec::with_capacity(program_ids.len());
-        let mut results: Vec<Option<Result<Option<String>>>> =
-            (0..program_ids.len()).map(|_| None).collect();
-
-        for (idx, program_id) in program_ids.iter().enumerate() {
-            match get_idl_address(program_id) {
-                Ok(idl_address) => pending.push((idx, *program_id, idl_address)),
-                Err(e) => results[idx] = Some(Err(e)),
-            }
-        }
-
+        let (pending, mut results) = prepare_idl_batch(program_ids);
         let total = pending.len();
         let mut requested = 0usize;
 
-        for chunk in pending.chunks(MAX_ACCOUNTS_PER_REQUEST) {
+        for chunk in pending.chunks(self.rpc_batch_size) {
             self.set_progress_message(format!(
                 "fetching IDL accounts ({}/{})",
                 requested + 1,
                 total
             ));
-
             let idl_addresses: Vec<Pubkey> = chunk.iter().map(|(_, _, idl)| *idl).collect();
-            match fetch_chunk(&idl_addresses) {
-                Ok(response) => {
-                    if response.len() != chunk.len() {
-                        for (idx, _, idl_addr) in chunk {
-                            results[*idx] = Some(Err(anyhow!(
-                                "Failed to fetch IDL account {}: RPC returned count mismatch ({} != {})",
-                                idl_addr,
-                                response.len(),
-                                chunk.len()
-                            )));
-                        }
-                    } else {
-                        for ((idx, program_id, _), maybe_account) in
-                            chunk.iter().zip(response.into_iter())
-                        {
-                            let parsed = match maybe_account {
-                                Some(account) => {
-                                    parse_idl_account_data(account.data(), program_id).map(Some)
-                                }
-                                None => Ok(None),
-                            };
-                            results[*idx] = Some(parsed);
-                        }
-                    }
-                }
-                Err(e) => {
-                    for (idx, _, idl_addr) in chunk {
-                        results[*idx] =
-                            Some(Err(anyhow!("Failed to fetch IDL account {}: {}", idl_addr, e)));
-                    }
-                }
-            }
+            process_idl_chunk(chunk, fetch_chunk(&idl_addresses), &mut results);
             requested += chunk.len();
         }
 
-        let mut ordered_results = Vec::with_capacity(program_ids.len());
-        for (idx, program_id) in program_ids.iter().enumerate() {
-            let result = results[idx].take().unwrap_or_else(|| {
-                Err(anyhow!(
-                    "Missing IDL fetch result for program {} (internal state mismatch)",
-                    program_id
-                ))
-            });
-            ordered_results.push((*program_id, result));
-        }
-        ordered_results
+        collect_idl_results(program_ids, results)
     }
 
     fn set_progress_message(&self, message: impl Into<std::borrow::Cow<'static, str>>) {
@@ -162,6 +173,84 @@ impl IdlFetcher {
             progress.set_message(message);
         }
     }
+}
+
+/// Derive IDL addresses for a batch of program IDs.
+/// Returns (pending_entries, results_slots) where each pending entry is
+/// `(original_index, program_id, idl_address)` and failed derivations are
+/// pre-filled in the results vec.
+fn prepare_idl_batch(
+    program_ids: &[Pubkey],
+) -> (Vec<(usize, Pubkey, Pubkey)>, Vec<Option<Result<Option<String>>>>) {
+    let mut pending = Vec::with_capacity(program_ids.len());
+    let mut results: Vec<Option<Result<Option<String>>>> =
+        (0..program_ids.len()).map(|_| None).collect();
+    for (idx, program_id) in program_ids.iter().enumerate() {
+        match get_idl_address(program_id) {
+            Ok(idl_address) => pending.push((idx, *program_id, idl_address)),
+            Err(e) => results[idx] = Some(Err(e)),
+        }
+    }
+    (pending, results)
+}
+
+/// Process a single batch RPC response, parsing IDL data into the results vec.
+fn process_idl_chunk(
+    chunk: &[(usize, Pubkey, Pubkey)],
+    batch_result: Result<Vec<Option<AccountSharedData>>>,
+    results: &mut [Option<Result<Option<String>>>],
+) {
+    match batch_result {
+        Ok(response) => {
+            if response.len() != chunk.len() {
+                for &(idx, _, idl_addr) in chunk {
+                    results[idx] = Some(Err(anyhow!(
+                        "Failed to fetch IDL account {}: RPC returned count mismatch ({} != {})",
+                        idl_addr,
+                        response.len(),
+                        chunk.len()
+                    )));
+                }
+            } else {
+                for (&(idx, program_id, _), maybe_account) in
+                    chunk.iter().zip(response.into_iter())
+                {
+                    results[idx] = Some(match maybe_account {
+                        Some(account) => {
+                            parse_idl_account_data(account.data(), &program_id).map(Some)
+                        }
+                        None => Ok(None),
+                    });
+                }
+            }
+        }
+        Err(e) => {
+            for &(idx, _, idl_addr) in chunk {
+                results[idx] =
+                    Some(Err(anyhow!("Failed to fetch IDL account {}: {}", idl_addr, e)));
+            }
+        }
+    }
+}
+
+/// Collect ordered results, matching original program_ids input order.
+fn collect_idl_results(
+    program_ids: &[Pubkey],
+    mut results: Vec<Option<Result<Option<String>>>>,
+) -> Vec<(Pubkey, Result<Option<String>>)> {
+    program_ids
+        .iter()
+        .enumerate()
+        .map(|(idx, program_id)| {
+            let result = results[idx].take().unwrap_or_else(|| {
+                Err(anyhow!(
+                    "Missing IDL fetch result for program {} (internal state mismatch)",
+                    program_id
+                ))
+            });
+            (*program_id, result)
+        })
+        .collect()
 }
 
 fn is_account_not_found_error(error: &str) -> bool {
@@ -227,7 +316,8 @@ mod tests {
     use solana_account::{Account, AccountSharedData, ReadableAccount};
     use solana_pubkey::Pubkey;
 
-    use super::{IdlFetcher, MAX_ACCOUNTS_PER_REQUEST, get_idl_address, parse_idl_account_data};
+    use super::{IdlFetcher, get_idl_address, parse_idl_account_data};
+    use sonar_sim::internals::DEFAULT_RPC_BATCH_SIZE;
     use sonar_sim::internals::FakeAccountProvider;
 
     fn dummy_fetcher() -> IdlFetcher {
@@ -315,7 +405,7 @@ mod tests {
     fn fetch_idls_chunk_error_only_affects_failed_chunk() {
         let fetcher = dummy_fetcher();
         let program_ids: Vec<Pubkey> =
-            (0..(MAX_ACCOUNTS_PER_REQUEST + 1)).map(|_| Pubkey::new_unique()).collect();
+            (0..(DEFAULT_RPC_BATCH_SIZE + 1)).map(|_| Pubkey::new_unique()).collect();
 
         let mut call_count = 0usize;
         let results = fetcher.fetch_idls_with(&program_ids, |chunk| {
@@ -330,7 +420,7 @@ mod tests {
         assert_eq!(results.len(), program_ids.len());
         for (idx, (program_id, result)) in results.iter().enumerate() {
             assert_eq!(*program_id, program_ids[idx]);
-            if idx < MAX_ACCOUNTS_PER_REQUEST {
+            if idx < DEFAULT_RPC_BATCH_SIZE {
                 assert!(result.as_ref().unwrap().is_none());
             } else {
                 assert!(result.is_err());

--- a/src/handlers/common.rs
+++ b/src/handlers/common.rs
@@ -44,6 +44,7 @@ pub(crate) struct CachePrepareArgs<'a> {
     pub cache_dir: &'a Option<PathBuf>,
     pub refresh_cache: bool,
     pub no_idl_fetch: bool,
+    pub rpc_batch_size: usize,
 }
 
 /// Result of resolving cache state and preparing accounts/IDLs.
@@ -159,6 +160,7 @@ pub(crate) fn resolve_cache_and_prepare(
         parser_registry,
         args.no_idl_fetch,
         progress,
+        args.rpc_batch_size,
     )?;
 
     Ok(CachePreparedContext { cache_dir: resolved_cache_dir, offline, prepared })
@@ -285,12 +287,14 @@ pub(crate) fn prepare_accounts_and_idls(
     parser_registry: &mut ParserRegistry,
     no_idl_fetch: bool,
     progress: &Progress,
+    rpc_batch_size: usize,
 ) -> Result<PreparedPipelineContext> {
     let mut account_loader = account_loader::create_loader(
         rpc_url.to_string(),
         cache_dir,
         offline,
         Some(progress.clone()),
+        rpc_batch_size,
     )?;
     let resolved_accounts = if parsed_txs.len() == 1 {
         account_loader.load_for_transaction(&parsed_txs[0].transaction)?

--- a/src/handlers/decode.rs
+++ b/src/handlers/decode.rs
@@ -22,6 +22,7 @@ pub(crate) fn handle(args: DecodeArgs, json: bool) -> Result<()> {
         cache_dir,
         refresh_cache,
     } = args;
+    let rpc_batch_size = rpc.rpc_batch_size;
     let rpc_url = rpc.rpc_url;
     let resolver_cache_location =
         if refresh_cache { None } else { Some(super::common::build_cache_location(&cache_dir)) };
@@ -38,6 +39,7 @@ pub(crate) fn handle(args: DecodeArgs, json: bool) -> Result<()> {
         cache_dir: &cache_dir,
         refresh_cache,
         no_idl_fetch,
+        rpc_batch_size,
     };
     let cached = resolve_cache_and_prepare(
         &cache_args,

--- a/src/handlers/idl.rs
+++ b/src/handlers/idl.rs
@@ -42,13 +42,13 @@ pub(crate) fn handle(args: IdlArgs, json: bool) -> Result<()> {
 fn handle_fetch(args: IdlFetchArgs, json: bool) -> Result<()> {
     let program_ids = parse_program_ids(&args.programs)?;
     let output_dir = resolve_output_dir(args.output_dir, None);
-    fetch_and_write_idls(program_ids, args.rpc.rpc_url, output_dir, json)
+    fetch_and_write_idls(program_ids, args.rpc.rpc_url, args.rpc.rpc_batch_size, output_dir, json)
 }
 
 fn handle_sync(args: IdlSyncArgs, json: bool) -> Result<()> {
     let (program_ids, default_output_dir) = collect_program_ids_from_sync_path(&args.path)?;
     let output_dir = resolve_output_dir(args.output_dir, default_output_dir.as_deref());
-    fetch_and_write_idls(program_ids, args.rpc.rpc_url, output_dir, json)
+    fetch_and_write_idls(program_ids, args.rpc.rpc_url, args.rpc.rpc_batch_size, output_dir, json)
 }
 
 fn handle_address(args: IdlAddressArgs, json: bool) -> Result<()> {
@@ -85,6 +85,7 @@ fn parse_program_ids(raw_programs: &[String]) -> Result<Vec<Pubkey>> {
 fn fetch_and_write_idls(
     program_ids: Vec<Pubkey>,
     rpc_url: String,
+    rpc_batch_size: usize,
     output_dir: PathBuf,
     json: bool,
 ) -> Result<()> {
@@ -92,7 +93,8 @@ fn fetch_and_write_idls(
         .with_context(|| format!("Failed to create output directory: {}", output_dir.display()))?;
 
     let progress = Progress::new();
-    let fetcher = idl_fetcher::IdlFetcher::new(rpc_url, Some(progress.clone()))?;
+    let fetcher = idl_fetcher::IdlFetcher::new(rpc_url, Some(progress.clone()))?
+        .with_rpc_batch_size(rpc_batch_size);
     let results = fetcher.fetch_idls(&program_ids);
     progress.finish();
 

--- a/src/handlers/simulate.rs
+++ b/src/handlers/simulate.rs
@@ -90,6 +90,7 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
     } = args;
     // --cache-dir or --refresh-cache imply --cache
     let cache = cache || cache_dir.is_some() || refresh_cache;
+    let rpc_batch_size = rpc.rpc_batch_size;
     let rpc_url = rpc.rpc_url;
     let resolver_cache_location = Some(build_cache_location(&cache_dir));
 
@@ -145,6 +146,7 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
             cache_dir,
             refresh_cache,
             no_idl_fetch,
+            rpc_batch_size,
             &progress,
         );
     }
@@ -168,6 +170,7 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
         cache_dir: &cache_dir,
         refresh_cache,
         no_idl_fetch,
+        rpc_batch_size,
     };
     let cached = resolve_cache_and_prepare(
         &cache_args,
@@ -288,6 +291,7 @@ fn handle_bundle(
     cache_dir: Option<PathBuf>,
     refresh_cache: bool,
     no_idl_fetch: bool,
+    rpc_batch_size: usize,
     progress: &Progress,
 ) -> Result<()> {
     log::info!("Bundle simulation mode: {} transactions", tx_inputs.len());
@@ -308,6 +312,7 @@ fn handle_bundle(
         cache_dir: &cache_dir,
         refresh_cache,
         no_idl_fetch,
+        rpc_batch_size,
     };
     let cached = resolve_cache_and_prepare(
         &cache_args,

--- a/src/handlers/trace.rs
+++ b/src/handlers/trace.rs
@@ -32,6 +32,7 @@ use crate::utils::progress::Progress;
 pub(crate) fn handle(args: TraceArgs, json: bool) -> Result<()> {
     let progress = Progress::new();
     let rpc_url = args.rpc.rpc_url;
+    let rpc_batch_size = args.rpc.rpc_batch_size;
     let idl_dir = args.idl_dir.clone();
     let mut parser_registry = ParserRegistry::new(idl_dir);
 
@@ -84,6 +85,7 @@ pub(crate) fn handle(args: TraceArgs, json: bool) -> Result<()> {
         args.no_idl_fetch,
         meta_lookups,
         &progress,
+        rpc_batch_size,
     );
 
     progress.finish();
@@ -134,6 +136,7 @@ fn load_accounts_and_idls(
     no_idl_fetch: bool,
     meta_lookups: Vec<ResolvedLookup>,
     progress: &Progress,
+    rpc_batch_size: usize,
 ) -> ResolvedAccounts {
     let mut program_ids: Vec<Pubkey> = parsed_tx
         .summary
@@ -147,16 +150,18 @@ fn load_accounts_and_idls(
 
     progress.set_message("Fetching program accounts...");
     let mut accounts: HashMap<Pubkey, AccountSharedData> = HashMap::new();
-    match client.get_multiple_accounts(&program_ids) {
-        Ok(results) => {
-            for (pubkey, account) in program_ids.iter().zip(results) {
-                if let Some(account) = account {
-                    accounts.insert(*pubkey, AccountSharedData::from(account));
+    for chunk in program_ids.chunks(rpc_batch_size) {
+        match client.get_multiple_accounts(chunk) {
+            Ok(results) => {
+                for (pubkey, account) in chunk.iter().zip(results) {
+                    if let Some(account) = account {
+                        accounts.insert(*pubkey, AccountSharedData::from(account));
+                    }
                 }
             }
-        }
-        Err(e) => {
-            log::warn!("Failed to fetch program accounts: {:#}", e);
+            Err(e) => {
+                log::warn!("Failed to fetch program accounts: {:#}", e);
+            }
         }
     }
 
@@ -179,7 +184,7 @@ fn load_accounts_and_idls(
     let resolved = ResolvedAccounts { accounts, lookups: meta_lookups };
 
     // Delegate to the shared IDL pipeline (auto-fetch + load from disk)
-    match account_loader::create_loader(rpc_url.to_string(), None, false, Some(progress.clone())) {
+    match account_loader::create_loader(rpc_url.to_string(), None, false, Some(progress.clone()), rpc_batch_size) {
         Ok(loader) => {
             super::common::run_idl_pipeline(
                 &loader,


### PR DESCRIPTION
## Summary

- Parallelize `getMultipleAccounts` RPC calls via `std::thread::scope` when >1 batch is needed, with single-batch path avoiding thread overhead
- Add `--rpc-batch-size` CLI option (default 100, env `SONAR_RPC_BATCH_SIZE`) for users on commercial RPC providers (Helius, Triton, etc.) that support higher per-request limits
- Pre-size `Vec`/`HashSet`/`HashMap` in account loading hot paths
- Extract shared IDL batch helpers (`prepare_idl_batch`, `process_idl_chunk`, `collect_idl_results`) to eliminate duplication

## Test plan

- [ ] `cargo test` — all 581 tests pass
- [ ] `sonar simulate --help` shows `--rpc-batch-size` option
- [ ] `sonar simulate <tx> --rpc-batch-size 200` works with a provider that supports it
- [ ] `sonar trace <sig> --rpc-batch-size 50` correctly chunks the initial program fetch
- [ ] `sonar idl fetch <program> --rpc-batch-size 200` honors the batch size
- [ ] `SONAR_RPC_BATCH_SIZE=200 sonar simulate <tx>` picks up env var