### PR TITLE
rename: trace subcommand → replay

### DIFF
--- a/crates/sonar-sim/src/account_fetcher.rs
+++ b/crates/sonar-sim/src/account_fetcher.rs
@@ -179,10 +179,7 @@ impl AccountFetcher {
         // Fetch all batches in parallel when multiple chunks are needed.
         // Single-batch case avoids thread overhead.
         let batch_results: Vec<Result<Vec<Option<AccountSharedData>>>> = if chunks.len() <= 1 {
-            chunks
-                .iter()
-                .map(|&chunk| self.provider.get_multiple_accounts(chunk))
-                .collect()
+            chunks.iter().map(|&chunk| self.provider.get_multiple_accounts(chunk)).collect()
         } else {
             let provider = &self.provider;
             std::thread::scope(|s| {
@@ -193,10 +190,7 @@ impl AccountFetcher {
                         s.spawn(move || provider.get_multiple_accounts(chunk))
                     })
                     .collect();
-                handles
-                    .into_iter()
-                    .map(|h| h.join().expect("RPC batch thread panicked"))
-                    .collect()
+                handles.into_iter().map(|h| h.join().expect("RPC batch thread panicked")).collect()
             })
         };
 

--- a/docs/simulate.md
+++ b/docs/simulate.md
@@ -1,4 +1,4 @@
-# Simulate & Decode
+# Simulate, Decode & Replay
 
 ## Simulate
 
@@ -187,6 +187,30 @@ sonar decode <TX_OR_SIGNATURE> --rpc-url <RPC_URL> --no-cache
 sonar decode <TX_OR_SIGNATURE> --rpc-url <RPC_URL> --refresh-cache
 
 sonar decode <TX_OR_SIGNATURE> --rpc-url <RPC_URL> --cache-dir /path/to/cache
+```
+
+## Replay
+
+Replay the historical execution of a confirmed transaction. Fetches the transaction by signature from RPC and reconstructs the execution trace from on-chain metadata — no local simulation needed.
+
+```bash
+# Replay a confirmed transaction
+sonar replay <SIGNATURE> --rpc-url https://api.mainnet-beta.solana.com
+
+# Show balance changes and instruction details
+sonar replay <SIGNATURE> --rpc-url <RPC_URL> -b -d
+
+# JSON output
+sonar replay <SIGNATURE> --rpc-url <RPC_URL> --json
+
+# Print raw logs instead of structured output
+sonar replay <SIGNATURE> --rpc-url <RPC_URL> --raw-log
+
+# Always print raw instruction data, even when parser succeeds
+sonar replay <SIGNATURE> --rpc-url <RPC_URL> --raw-ix-data
+
+# Load Anchor IDL files from a custom directory
+sonar replay <SIGNATURE> --rpc-url <RPC_URL> --idl-dir /path/to/idls
 ```
 
 ## Cache Management

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,9 +9,9 @@ mod decode;
 mod idl;
 mod pda;
 mod program_elf;
+mod replay;
 mod send;
 mod simulate;
-mod trace;
 
 // Re-export all public types from submodules
 pub use account::*;
@@ -23,9 +23,9 @@ pub use decode::*;
 pub use idl::*;
 pub use pda::*;
 pub use program_elf::*;
+pub use replay::*;
 pub use send::*;
 pub use simulate::*;
-pub use trace::*;
 
 use clap::{Args, Parser, Subcommand};
 
@@ -72,9 +72,9 @@ pub enum Commands {
     /// Decode and display a raw transaction without simulation
     #[command(alias = "dec", next_line_help = true)]
     Decode(DecodeArgs),
-    /// Display the historical execution trace of a confirmed transaction
+    /// Replay the historical execution of a confirmed transaction
     #[command(next_line_help = true)]
-    Trace(TraceArgs),
+    Replay(ReplayArgs),
     /// Manage Anchor IDLs (fetch, sync, address)
     #[command(next_line_help = true)]
     Idl(IdlArgs),

--- a/src/cli/replay.rs
+++ b/src/cli/replay.rs
@@ -1,4 +1,4 @@
-//! Trace command arguments.
+//! Replay command arguments.
 
 use std::path::PathBuf;
 
@@ -6,9 +6,9 @@ use clap::Args;
 
 use super::RpcArgs;
 
-/// Display the historical execution trace of a confirmed transaction.
+/// Replay the historical execution of a confirmed transaction.
 #[derive(Args, Debug)]
-pub struct TraceArgs {
+pub struct ReplayArgs {
     /// Transaction signature to look up
     pub signature: String,
     #[command(flatten)]

--- a/src/core/idl_fetcher.rs
+++ b/src/core/idl_fetcher.rs
@@ -66,42 +66,32 @@ impl IdlFetcher {
 
         let (pending, mut results) = prepare_idl_batch(program_ids);
         let total = pending.len();
-        let chunks: Vec<&[(usize, Pubkey, Pubkey)]> =
-            pending.chunks(self.rpc_batch_size).collect();
+        let chunks: Vec<&[(usize, Pubkey, Pubkey)]> = pending.chunks(self.rpc_batch_size).collect();
 
         // Fetch all chunks in parallel when multiple batches are needed
-        let batch_rpc_results: Vec<Result<Vec<Option<AccountSharedData>>>> =
-            if chunks.len() <= 1 {
-                chunks
+        let batch_rpc_results: Vec<Result<Vec<Option<AccountSharedData>>>> = if chunks.len() <= 1 {
+            chunks
+                .iter()
+                .map(|chunk| {
+                    let addrs: Vec<Pubkey> = chunk.iter().map(|(_, _, idl)| *idl).collect();
+                    self.provider.get_multiple_accounts(&addrs).map_err(|e| anyhow!("{e}"))
+                })
+                .collect()
+        } else {
+            std::thread::scope(|s| {
+                let handles: Vec<_> = chunks
                     .iter()
                     .map(|chunk| {
+                        let provider = Arc::clone(&self.provider);
                         let addrs: Vec<Pubkey> = chunk.iter().map(|(_, _, idl)| *idl).collect();
-                        self.provider
-                            .get_multiple_accounts(&addrs)
-                            .map_err(|e| anyhow!("{e}"))
-                    })
-                    .collect()
-            } else {
-                std::thread::scope(|s| {
-                    let handles: Vec<_> = chunks
-                        .iter()
-                        .map(|chunk| {
-                            let provider = Arc::clone(&self.provider);
-                            let addrs: Vec<Pubkey> =
-                                chunk.iter().map(|(_, _, idl)| *idl).collect();
-                            s.spawn(move || {
-                                provider
-                                    .get_multiple_accounts(&addrs)
-                                    .map_err(|e| anyhow!("{e}"))
-                            })
+                        s.spawn(move || {
+                            provider.get_multiple_accounts(&addrs).map_err(|e| anyhow!("{e}"))
                         })
-                        .collect();
-                    handles
-                        .into_iter()
-                        .map(|h| h.join().expect("IDL batch thread panicked"))
-                        .collect()
-                })
-            };
+                    })
+                    .collect();
+                handles.into_iter().map(|h| h.join().expect("IDL batch thread panicked")).collect()
+            })
+        };
 
         let mut requested = 0usize;
         for (chunk, batch_result) in chunks.iter().zip(batch_rpc_results) {
@@ -212,8 +202,7 @@ fn process_idl_chunk(
                     )));
                 }
             } else {
-                for (&(idx, program_id, _), maybe_account) in
-                    chunk.iter().zip(response.into_iter())
+                for (&(idx, program_id, _), maybe_account) in chunk.iter().zip(response.into_iter())
                 {
                     results[idx] = Some(match maybe_account {
                         Some(account) => {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -9,6 +9,6 @@ pub(crate) mod decode;
 pub(crate) mod idl;
 pub(crate) mod pda;
 pub(crate) mod program_elf;
+pub(crate) mod replay;
 pub(crate) mod send;
 pub(crate) mod simulate;
-pub(crate) mod trace;

--- a/src/handlers/replay.rs
+++ b/src/handlers/replay.rs
@@ -18,7 +18,7 @@ use sonar_sim::internals::{
 
 use solana_account::AccountSharedData;
 
-use crate::cli::TraceArgs;
+use crate::cli::ReplayArgs;
 use crate::core::account_loader;
 use crate::core::rpc_client::{GetTransactionConfig, RpcClient};
 use crate::core::transaction::{
@@ -29,7 +29,7 @@ use crate::output::{self, BalanceChangeOptions, LogDisplayOptions, RenderOptions
 use crate::parsers::instruction::ParserRegistry;
 use crate::utils::progress::Progress;
 
-pub(crate) fn handle(args: TraceArgs, json: bool) -> Result<()> {
+pub(crate) fn handle(args: ReplayArgs, json: bool) -> Result<()> {
     let progress = Progress::new();
     let rpc_url = args.rpc.rpc_url;
     let rpc_batch_size = args.rpc.rpc_batch_size;
@@ -74,7 +74,7 @@ pub(crate) fn handle(args: TraceArgs, json: bool) -> Result<()> {
     // not live ALT state — ALTs may have been closed since the tx confirmed.
     let (meta_lookups, ordered_keys) = resolve_from_meta(&parsed_tx, &meta);
 
-    // Fetch only program accounts for IDL parsing — trace doesn't need
+    // Fetch only program accounts for IDL parsing — replay doesn't need
     // sysvars, token accounts, or ALTs like simulate/decode do.
     let resolved_accounts = load_accounts_and_idls(
         &client,
@@ -107,7 +107,7 @@ pub(crate) fn handle(args: TraceArgs, json: bool) -> Result<()> {
         log_opts: LogDisplayOptions { raw_log: args.raw_log },
     };
 
-    output::render_trace(
+    output::render_replay(
         &parsed_tx,
         &resolved_accounts,
         &execution_result,
@@ -184,7 +184,13 @@ fn load_accounts_and_idls(
     let resolved = ResolvedAccounts { accounts, lookups: meta_lookups };
 
     // Delegate to the shared IDL pipeline (auto-fetch + load from disk)
-    match account_loader::create_loader(rpc_url.to_string(), None, false, Some(progress.clone()), rpc_batch_size) {
+    match account_loader::create_loader(
+        rpc_url.to_string(),
+        None,
+        false,
+        Some(progress.clone()),
+        rpc_batch_size,
+    ) {
         Ok(loader) => {
             super::common::run_idl_pipeline(
                 &loader,

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,7 @@ fn run() -> Result<()> {
             handlers::completions::handle(args);
             return Ok(());
         }
-        Commands::Trace(args) => handlers::trace::handle(args, json)?,
+        Commands::Replay(args) => handlers::replay::handle(args, json)?,
     }
     Ok(())
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -78,8 +78,8 @@ pub fn render(
     render_report(&report, resolved, parser_registry, opts)
 }
 
-/// Render a trace report with pre-computed balance changes from RPC metadata.
-pub fn render_trace(
+/// Render a replay report with pre-computed balance changes from RPC metadata.
+pub fn render_replay(
     parsed: &ParsedTransaction,
     resolved: &ResolvedAccounts,
     simulation: &ExecutionResult,
@@ -88,7 +88,7 @@ pub fn render_trace(
     sol_balance_changes: Vec<SolBalanceChangeSection>,
     token_balance_changes: Vec<TokenBalanceChangeSection>,
 ) -> Result<()> {
-    let report = Report::from_trace(
+    let report = Report::from_replay(
         parsed,
         resolved,
         simulation,

--- a/src/output/report.rs
+++ b/src/output/report.rs
@@ -214,9 +214,9 @@ impl Report {
         }
     }
 
-    /// Construct a trace report with pre-computed balance changes.
-    /// No SimulationContext needed — trace is read-only historical data.
-    pub(super) fn from_trace(
+    /// Construct a replay report with pre-computed balance changes.
+    /// No SimulationContext needed — replay is read-only historical data.
+    pub(super) fn from_replay(
         parsed: &ParsedTransaction,
         resolved: &ResolvedAccounts,
         simulation: &ExecutionResult,


### PR DESCRIPTION
## Summary

- Rename `sonar trace` to `sonar replay` — better communicates reconstructing historical execution vs instrumenting live processes, aligns with Solana-native "replay stage" terminology, and contrasts cleanly with `simulate`
- Add `## Replay` section to `docs/simulate.md`
- Includes `cargo fmt` pass on two unrelated files

**Breaking change:** `sonar trace` is removed; use `sonar replay` instead.

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt` clean
- [x] `sonar replay --help` shows correct subcommand
- [x] `sonar --help` lists `replay` (not `trace`)