### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "sonar"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.86.0"
 
 [package]
 name = "sonar"
-version = "0.3.0"
+version = "0.5.0"
 edition = "2021"
 rust-version.workspace = true
 


### PR DESCRIPTION
## Summary
- Bump sonar version from 0.3.0 to 0.5.0 in Cargo.toml and Cargo.lock

## Test plan
- [ ] Verify `cargo build` succeeds
- [ ] Verify `sonar --version` reports 0.5.0