### PR TITLE
refactor: align StateMutationOptions field names with Mutations

### DIFF
--- a/crates/sonar-sim/src/executor.rs
+++ b/crates/sonar-sim/src/executor.rs
@@ -63,10 +63,10 @@ pub struct ExecutionOptions {
 #[derive(Debug, Clone, Default)]
 pub struct StateMutationOptions {
     pub account_closures: Vec<Pubkey>,
-    pub overrides: Vec<AccountOverride>,
+    pub account_overrides: Vec<AccountOverride>,
     pub sol_fundings: Vec<SolFunding>,
     pub token_fundings: Vec<PreparedTokenFunding>,
-    pub data_patches: Vec<AccountDataPatch>,
+    pub account_data_patches: Vec<AccountDataPatch>,
 }
 
 /// Simulation execution options passed to [`PreparedSimulation::prepare`].
@@ -116,8 +116,8 @@ impl SimulationOptionsBuilder {
         self
     }
 
-    pub fn overrides(mut self, overrides: Vec<AccountOverride>) -> Self {
-        self.opts.mutations.overrides = overrides;
+    pub fn account_overrides(mut self, account_overrides: Vec<AccountOverride>) -> Self {
+        self.opts.mutations.account_overrides = account_overrides;
         self
     }
 
@@ -131,8 +131,8 @@ impl SimulationOptionsBuilder {
         self
     }
 
-    pub fn data_patches(mut self, data_patches: Vec<AccountDataPatch>) -> Self {
-        self.opts.mutations.data_patches = data_patches;
+    pub fn account_data_patches(mut self, account_data_patches: Vec<AccountDataPatch>) -> Self {
+        self.opts.mutations.account_data_patches = account_data_patches;
         self
     }
 
@@ -149,9 +149,9 @@ impl StateMutationOptions {
         resolved: &ResolvedAccounts,
     ) -> Result<()> {
         apply_account_closures(svm, &self.account_closures)?;
-        apply_overrides(svm, &self.overrides, resolved)?;
+        apply_overrides(svm, &self.account_overrides, resolved)?;
         apply_sol_fundings(svm, &self.sol_fundings)?;
-        apply_data_patches(svm, &self.data_patches)?;
+        apply_data_patches(svm, &self.account_data_patches)?;
         apply_token_fundings(svm, &self.token_fundings, resolved)?;
         Ok(())
     }
@@ -376,8 +376,8 @@ impl<B: SvmBackend> PreparedSimulation<B> {
         &self.record.account_closures
     }
 
-    pub fn overrides(&self) -> &[AccountOverride] {
-        &self.record.overrides
+    pub fn account_overrides(&self) -> &[AccountOverride] {
+        &self.record.account_overrides
     }
 
     pub fn sol_fundings(&self) -> &[SolFunding] {
@@ -388,8 +388,8 @@ impl<B: SvmBackend> PreparedSimulation<B> {
         &self.record.token_fundings
     }
 
-    pub fn data_patches(&self) -> &[AccountDataPatch] {
-        &self.record.data_patches
+    pub fn account_data_patches(&self) -> &[AccountDataPatch] {
+        &self.record.account_data_patches
     }
 }
 
@@ -536,8 +536,8 @@ impl<B: SvmBackend> SimulationRunner<B> {
         &self.record.account_closures
     }
 
-    pub fn overrides(&self) -> &[AccountOverride] {
-        &self.record.overrides
+    pub fn account_overrides(&self) -> &[AccountOverride] {
+        &self.record.account_overrides
     }
 
     pub fn sol_fundings(&self) -> &[SolFunding] {
@@ -548,8 +548,8 @@ impl<B: SvmBackend> SimulationRunner<B> {
         &self.record.token_fundings
     }
 
-    pub fn data_patches(&self) -> &[AccountDataPatch] {
-        &self.record.data_patches
+    pub fn account_data_patches(&self) -> &[AccountDataPatch] {
+        &self.record.account_data_patches
     }
 }
 

--- a/crates/sonar-sim/src/pipeline.rs
+++ b/crates/sonar-sim/src/pipeline.rs
@@ -286,10 +286,10 @@ impl Pipeline {
             },
             mutations: StateMutationOptions {
                 account_closures: mutations.account_closures,
-                overrides: mutations.account_overrides,
+                account_overrides: mutations.account_overrides,
                 sol_fundings: mutations.sol_fundings,
                 token_fundings: prepared_fundings,
-                data_patches: mutations.account_data_patches,
+                account_data_patches: mutations.account_data_patches,
             },
         })
     }

--- a/src/handlers/simulate.rs
+++ b/src/handlers/simulate.rs
@@ -96,10 +96,10 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
 
     let TransactionInputArgs { tx } = transaction;
 
-    let overrides = parse_cli_args(override_args, cli::parse_override)?;
+    let account_overrides = parse_cli_args(override_args, cli::parse_override)?;
     let sol_fundings = parse_cli_args(funding_args, cli::parse_funding)?;
     let token_funding_requests = parse_cli_args(token_funding_args, cli::parse_token_funding)?;
-    let data_patches = parse_cli_args(data_patch_args, cli::parse_data_patch)?;
+    let account_data_patches = parse_cli_args(data_patch_args, cli::parse_data_patch)?;
     let account_closures = parse_cli_args(account_closure_args, cli::parse_close_account)?;
     let ix_account_patches = parse_cli_args(ix_account_patch_args, cli::parse_ix_account_patch)?;
     let ix_account_appends = parse_cli_args(ix_account_append_args, cli::parse_ix_account_append)?;
@@ -125,9 +125,9 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
             },
             mutations: StateMutationOptions {
                 account_closures,
-                overrides,
+                account_overrides,
                 sol_fundings,
-                data_patches,
+                account_data_patches,
                 ..Default::default()
             },
         };
@@ -184,7 +184,7 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
     let mut prepared = cached.prepared;
 
     warn_unmatched_addresses(
-        &overrides,
+        &account_overrides,
         &sol_fundings,
         &token_funding_requests,
         &account_closures,
@@ -237,10 +237,10 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
         },
         mutations: StateMutationOptions {
             account_closures,
-            overrides,
+            account_overrides,
             sol_fundings,
             token_fundings: prepared_token_fundings,
-            data_patches,
+            account_data_patches,
         },
     };
     let mut runner =
@@ -258,7 +258,7 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
     progress.finish();
     let ctx = output::SimulationContext {
         account_closures: runner.account_closures(),
-        overrides: runner.overrides(),
+        account_overrides: runner.account_overrides(),
         fundings: runner.sol_fundings(),
         token_fundings: runner.token_fundings(),
     };
@@ -327,7 +327,7 @@ fn handle_bundle(
 
     let parsed_tx_refs: Vec<_> = parsed_txs.iter().collect();
     warn_unmatched_addresses(
-        &sim_opts.mutations.overrides,
+        &sim_opts.mutations.account_overrides,
         &sim_opts.mutations.sol_fundings,
         &token_funding_requests,
         &sim_opts.mutations.account_closures,
@@ -427,7 +427,7 @@ fn handle_bundle(
     progress.finish();
     let ctx = output::SimulationContext {
         account_closures: runner.account_closures(),
-        overrides: runner.overrides(),
+        account_overrides: runner.account_overrides(),
         fundings: runner.sol_fundings(),
         token_fundings: runner.token_fundings(),
     };

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -53,7 +53,7 @@ pub struct RenderOptions {
 /// Grouped simulation context arguments that are always passed together.
 pub struct SimulationContext<'a> {
     pub account_closures: &'a [Pubkey],
-    pub overrides: &'a [AccountOverride],
+    pub account_overrides: &'a [AccountOverride],
     pub fundings: &'a [SolFunding],
     pub token_fundings: &'a [PreparedTokenFunding],
 }

--- a/src/output/report.rs
+++ b/src/output/report.rs
@@ -110,7 +110,7 @@ impl BundleReport {
             .collect();
 
         let account_closures = closures_to_sections(ctx.account_closures);
-        let overrides = ctx.overrides.iter().map(override_to_section).collect();
+        let overrides = ctx.account_overrides.iter().map(override_to_section).collect();
 
         let fundings = ctx
             .fundings
@@ -172,7 +172,7 @@ impl Report {
         );
         let simulation_section = SimulationSection::from_result(simulation);
         let account_closures = closures_to_sections(ctx.account_closures);
-        let overrides = ctx.overrides.iter().map(override_to_section).collect();
+        let overrides = ctx.account_overrides.iter().map(override_to_section).collect();
         let (sol_balance_changes, token_balance_changes) =
             if matches!(simulation.status, ExecutionStatus::Succeeded)
                 && balance_opts.show_balance_change


### PR DESCRIPTION
## Summary

- Renames `StateMutationOptions::overrides` → `account_overrides` and `data_patches` → `account_data_patches` to match the corresponding `Mutations` struct fields
- Updates builder methods, accessor methods on `PreparedSimulation`/`SimulationRunner`, and all call sites across the codebase
- Eliminates the cognitive mapping needed when reading the pipeline code that bridges `Mutations` → `StateMutationOptions`

Follow-up to #49 (execute/execute_bundle deduplication). Identified during an Ousterhout design-complexity review as a naming consistency violation.

## Test plan

- [x] `cargo test` — all 580 tests pass
- [x] `cargo check` — full workspace compiles clean
- [x] Codex review — no regressions found