### PR TITLE
refactor: collapse duplicated mutation accessors into single mutations() method

### DIFF
--- a/crates/sonar-sim/src/executor.rs
+++ b/crates/sonar-sim/src/executor.rs
@@ -372,24 +372,9 @@ impl<B: SvmBackend> PreparedSimulation<B> {
         &self.resolved
     }
 
-    pub fn account_closures(&self) -> &[Pubkey] {
-        &self.record.account_closures
-    }
-
-    pub fn account_overrides(&self) -> &[AccountOverride] {
-        &self.record.account_overrides
-    }
-
-    pub fn sol_fundings(&self) -> &[SolFunding] {
-        &self.record.sol_fundings
-    }
-
-    pub fn token_fundings(&self) -> &[PreparedTokenFunding] {
-        &self.record.token_fundings
-    }
-
-    pub fn account_data_patches(&self) -> &[AccountDataPatch] {
-        &self.record.account_data_patches
+    /// Access the pre-simulation mutation record.
+    pub fn mutations(&self) -> &StateMutationOptions {
+        &self.record
     }
 }
 
@@ -532,24 +517,9 @@ impl<B: SvmBackend> SimulationRunner<B> {
         &self.resolved
     }
 
-    pub fn account_closures(&self) -> &[Pubkey] {
-        &self.record.account_closures
-    }
-
-    pub fn account_overrides(&self) -> &[AccountOverride] {
-        &self.record.account_overrides
-    }
-
-    pub fn sol_fundings(&self) -> &[SolFunding] {
-        &self.record.sol_fundings
-    }
-
-    pub fn token_fundings(&self) -> &[PreparedTokenFunding] {
-        &self.record.token_fundings
-    }
-
-    pub fn account_data_patches(&self) -> &[AccountDataPatch] {
-        &self.record.account_data_patches
+    /// Access the pre-simulation mutation record.
+    pub fn mutations(&self) -> &StateMutationOptions {
+        &self.record
     }
 }
 

--- a/src/handlers/simulate.rs
+++ b/src/handlers/simulate.rs
@@ -256,11 +256,12 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
     );
 
     progress.finish();
+    let mutations = runner.mutations();
     let ctx = output::SimulationContext {
-        account_closures: runner.account_closures(),
-        account_overrides: runner.account_overrides(),
-        fundings: runner.sol_fundings(),
-        token_fundings: runner.token_fundings(),
+        account_closures: &mutations.account_closures,
+        account_overrides: &mutations.account_overrides,
+        fundings: &mutations.sol_fundings,
+        token_fundings: &mutations.token_fundings,
     };
     output::render(
         &parsed_tx,
@@ -425,11 +426,12 @@ fn handle_bundle(
         .collect();
 
     progress.finish();
+    let mutations = runner.mutations();
     let ctx = output::SimulationContext {
-        account_closures: runner.account_closures(),
-        account_overrides: runner.account_overrides(),
-        fundings: runner.sol_fundings(),
-        token_fundings: runner.token_fundings(),
+        account_closures: &mutations.account_closures,
+        account_overrides: &mutations.account_overrides,
+        fundings: &mutations.sol_fundings,
+        token_fundings: &mutations.token_fundings,
     };
     output::render_bundle(
         &updated_txs,


### PR DESCRIPTION
## Summary

- Replaces 5 identical accessor methods (`account_closures()`, `account_overrides()`, `sol_fundings()`, `token_fundings()`, `account_data_patches()`) duplicated across both `PreparedSimulation` and `SimulationRunner` with a single `mutations()` method returning `&StateMutationOptions`
- Callers now access fields directly via `runner.mutations().account_closures` instead of `runner.account_closures()`
- Net removal of 28 lines — adding a new mutation field no longer requires touching 4 accessor methods across 2 types

Follow-up to #50 (naming alignment). Third item from the Ousterhout design-complexity review of sonar-sim.

## Test plan

- [x] `cargo test` — all 580 tests pass
- [x] `cargo check` — full workspace compiles clean