### PR TITLE
refactor: split Mutations into TransactionMutations and StateMutations

### DIFF
--- a/crates/sonar-sim/src/lib.rs
+++ b/crates/sonar-sim/src/lib.rs
@@ -32,7 +32,7 @@ pub(crate) mod types;
 
 pub use balance_changes::{SolBalanceChange, TokenBalanceChange};
 pub use error::{Result, SonarSimError};
-pub use mutations::{Mutations, MutationsBuilder};
+pub use mutations::{Mutations, MutationsBuilder, StateMutations, TransactionMutations};
 pub use pipeline::Pipeline;
 pub use result::SimulationResult;
 pub use types::{AccountSource, FetchEvent, FetchObserver};

--- a/crates/sonar-sim/src/mutations.rs
+++ b/crates/sonar-sim/src/mutations.rs
@@ -9,21 +9,35 @@ use crate::types::{
     InstructionDataPatch, SolFunding, TokenFunding,
 };
 
-/// All mutations to apply before simulation execution.
-///
-/// Combines both transaction-level mutations (instruction patches) and
-/// state-level mutations (account overrides, funding, closures).
-/// Construct via [`Mutations::builder()`] or [`Mutations::default()`].
+/// Instruction-level mutations applied to the raw transaction before simulation.
 #[derive(Debug, Clone, Default)]
-pub struct Mutations {
+pub struct TransactionMutations {
+    pub(crate) ix_account_patches: Vec<InstructionAccountPatch>,
+    pub(crate) ix_account_appends: Vec<InstructionAccountAppend>,
+    pub(crate) ix_data_patches: Vec<InstructionDataPatch>,
+}
+
+/// Account-state mutations applied to the SVM before execution.
+#[derive(Debug, Clone, Default)]
+pub struct StateMutations {
     pub(crate) account_overrides: Vec<AccountOverride>,
     pub(crate) account_closures: Vec<Pubkey>,
     pub(crate) sol_fundings: Vec<SolFunding>,
     pub(crate) token_fundings: Vec<TokenFunding>,
     pub(crate) account_data_patches: Vec<AccountDataPatch>,
-    pub(crate) ix_account_patches: Vec<InstructionAccountPatch>,
-    pub(crate) ix_account_appends: Vec<InstructionAccountAppend>,
-    pub(crate) ix_data_patches: Vec<InstructionDataPatch>,
+}
+
+/// All mutations to apply before simulation execution.
+///
+/// Groups transaction-level mutations (instruction patches) separately
+/// from state-level mutations (account overrides, funding, closures).
+/// Construct via [`Mutations::builder()`] or [`Mutations::default()`].
+#[derive(Debug, Clone, Default)]
+pub struct Mutations {
+    /// Instruction patches applied to the raw transaction.
+    pub(crate) transaction: TransactionMutations,
+    /// Account-state changes applied to the SVM before execution.
+    pub(crate) state: StateMutations,
 }
 
 impl Mutations {
@@ -32,14 +46,25 @@ impl Mutations {
     }
 
     pub fn is_empty(&self) -> bool {
+        self.transaction.is_empty() && self.state.is_empty()
+    }
+}
+
+impl TransactionMutations {
+    pub fn is_empty(&self) -> bool {
+        self.ix_account_patches.is_empty()
+            && self.ix_account_appends.is_empty()
+            && self.ix_data_patches.is_empty()
+    }
+}
+
+impl StateMutations {
+    pub fn is_empty(&self) -> bool {
         self.account_overrides.is_empty()
             && self.account_closures.is_empty()
             && self.sol_fundings.is_empty()
             && self.token_fundings.is_empty()
             && self.account_data_patches.is_empty()
-            && self.ix_account_patches.is_empty()
-            && self.ix_account_appends.is_empty()
-            && self.ix_data_patches.is_empty()
     }
 }
 
@@ -51,42 +76,42 @@ pub struct MutationsBuilder {
 
 impl MutationsBuilder {
     pub fn add_override(mut self, account_override: AccountOverride) -> Self {
-        self.inner.account_overrides.push(account_override);
+        self.inner.state.account_overrides.push(account_override);
         self
     }
 
     pub fn close_account(mut self, pubkey: Pubkey) -> Self {
-        self.inner.account_closures.push(pubkey);
+        self.inner.state.account_closures.push(pubkey);
         self
     }
 
     pub fn fund_sol(mut self, funding: SolFunding) -> Self {
-        self.inner.sol_fundings.push(funding);
+        self.inner.state.sol_fundings.push(funding);
         self
     }
 
     pub fn fund_token(mut self, funding: TokenFunding) -> Self {
-        self.inner.token_fundings.push(funding);
+        self.inner.state.token_fundings.push(funding);
         self
     }
 
     pub fn patch_account_data(mut self, patch: AccountDataPatch) -> Self {
-        self.inner.account_data_patches.push(patch);
+        self.inner.state.account_data_patches.push(patch);
         self
     }
 
     pub fn patch_ix_account(mut self, patch: InstructionAccountPatch) -> Self {
-        self.inner.ix_account_patches.push(patch);
+        self.inner.transaction.ix_account_patches.push(patch);
         self
     }
 
     pub fn append_ix_account(mut self, append: InstructionAccountAppend) -> Self {
-        self.inner.ix_account_appends.push(append);
+        self.inner.transaction.ix_account_appends.push(append);
         self
     }
 
     pub fn patch_ix_data(mut self, patch: InstructionDataPatch) -> Self {
-        self.inner.ix_data_patches.push(patch);
+        self.inner.transaction.ix_data_patches.push(patch);
         self
     }
 
@@ -103,21 +128,15 @@ mod tests {
     fn default_mutations_are_empty() {
         let m = Mutations::default();
         assert!(m.is_empty());
-        assert!(m.account_overrides.is_empty());
-        assert!(m.account_closures.is_empty());
-        assert!(m.sol_fundings.is_empty());
-        assert!(m.token_fundings.is_empty());
-        assert!(m.account_data_patches.is_empty());
-        assert!(m.ix_account_patches.is_empty());
-        assert!(m.ix_account_appends.is_empty());
-        assert!(m.ix_data_patches.is_empty());
+        assert!(m.state.is_empty());
+        assert!(m.transaction.is_empty());
     }
 
     #[test]
     fn builder_close_account() {
         let pk = Pubkey::new_unique();
         let m = Mutations::builder().close_account(pk).build();
-        assert_eq!(m.account_closures, vec![pk]);
+        assert_eq!(m.state.account_closures, vec![pk]);
     }
 
     #[test]
@@ -126,9 +145,9 @@ mod tests {
         let m = Mutations::builder()
             .fund_sol(SolFunding { pubkey: pk, amount_lamports: 1_000_000 })
             .build();
-        assert_eq!(m.sol_fundings.len(), 1);
-        assert_eq!(m.sol_fundings[0].pubkey, pk);
-        assert_eq!(m.sol_fundings[0].amount_lamports, 1_000_000);
+        assert_eq!(m.state.sol_fundings.len(), 1);
+        assert_eq!(m.state.sol_fundings[0].pubkey, pk);
+        assert_eq!(m.state.sol_fundings[0].amount_lamports, 1_000_000);
     }
 
     #[test]
@@ -140,8 +159,8 @@ mod tests {
             .fund_sol(SolFunding { pubkey: pk2, amount_lamports: 500 })
             .close_account(pk2)
             .build();
-        assert_eq!(m.account_closures.len(), 2);
-        assert_eq!(m.sol_fundings.len(), 1);
+        assert_eq!(m.state.account_closures.len(), 2);
+        assert_eq!(m.state.sol_fundings.len(), 1);
         assert!(!m.is_empty());
     }
 }

--- a/crates/sonar-sim/src/pipeline.rs
+++ b/crates/sonar-sim/src/pipeline.rs
@@ -236,14 +236,15 @@ impl Pipeline {
 
     /// Apply transaction-level mutations (instruction patches) to a single transaction.
     fn apply_tx_mutations(tx: &mut VersionedTransaction, mutations: &Mutations) -> Result<()> {
-        if !mutations.ix_account_patches.is_empty() {
-            apply_ix_account_patches(tx, &mutations.ix_account_patches)?;
+        let tx_m = &mutations.transaction;
+        if !tx_m.ix_account_patches.is_empty() {
+            apply_ix_account_patches(tx, &tx_m.ix_account_patches)?;
         }
-        if !mutations.ix_account_appends.is_empty() {
-            apply_ix_account_appends(tx, &mutations.ix_account_appends)?;
+        if !tx_m.ix_account_appends.is_empty() {
+            apply_ix_account_appends(tx, &tx_m.ix_account_appends)?;
         }
-        if !mutations.ix_data_patches.is_empty() {
-            apply_ix_data_patches(tx, &mutations.ix_data_patches)?;
+        if !tx_m.ix_data_patches.is_empty() {
+            apply_ix_data_patches(tx, &tx_m.ix_data_patches)?;
         }
         Ok(())
     }
@@ -272,8 +273,9 @@ impl Pipeline {
         loader: &mut AccountLoader,
         resolved: &ResolvedAccounts,
     ) -> Result<SimulationOptions> {
-        let prepared_fundings = if !mutations.token_fundings.is_empty() {
-            prepare_token_fundings(loader, resolved, &mutations.token_fundings)?
+        let state = mutations.state;
+        let prepared_fundings = if !state.token_fundings.is_empty() {
+            prepare_token_fundings(loader, resolved, &state.token_fundings)?
         } else {
             vec![]
         };
@@ -285,11 +287,11 @@ impl Pipeline {
                 timestamp: self.timestamp,
             },
             mutations: StateMutationOptions {
-                account_closures: mutations.account_closures,
-                account_overrides: mutations.account_overrides,
-                sol_fundings: mutations.sol_fundings,
+                account_closures: state.account_closures,
+                account_overrides: state.account_overrides,
+                sol_fundings: state.sol_fundings,
                 token_fundings: prepared_fundings,
-                account_data_patches: mutations.account_data_patches,
+                account_data_patches: state.account_data_patches,
             },
         })
     }


### PR DESCRIPTION
## Summary

- Splits the flat `Mutations` struct into two nested sub-structs that make the timing distinction explicit in the type system:
  - `TransactionMutations` — instruction patches applied to the raw transaction before simulation
  - `StateMutations` — account-state changes applied to the SVM before execution
- `Mutations` now has `transaction` and `state` fields instead of 8 flat fields
- Each sub-struct has its own `is_empty()` method
- `MutationsBuilder` API is unchanged — callers are unaffected

Fourth item from the Ousterhout design-complexity review of sonar-sim (temporal decomposition fix). Follow-up to #51.

## Test plan

- [x] `cargo test -p sonar-sim` — all 147 tests pass
- [x] `cargo check` — full workspace compiles clean