### PR TITLE
feat(idl): add EnumUnit variant to suppress null display for fieldless enums

### DIFF
--- a/crates/sonar-idl/src/decode.rs
+++ b/crates/sonar-idl/src/decode.rs
@@ -390,12 +390,14 @@ pub(crate) fn parse_type_definition(
 
                 if variant_index < variants.len() {
                     let variant = &variants[variant_index];
-                    let payload = match variant.fields.as_ref() {
-                        Some(fields) => parse_idl_fields_value(data, offset, fields, indexed)?,
-                        None => IdlValue::Null,
-                    };
-
-                    return Ok(IdlValue::Struct(vec![(variant.name.clone(), payload)]));
+                    return Ok(match variant.fields.as_ref() {
+                        Some(fields) => {
+                            let payload =
+                                parse_idl_fields_value(data, offset, fields, indexed)?;
+                            IdlValue::Struct(vec![(variant.name.clone(), payload)])
+                        }
+                        None => IdlValue::EnumUnit(variant.name.clone()),
+                    });
                 }
             }
         }

--- a/crates/sonar-idl/src/tests/instruction.rs
+++ b/crates/sonar-idl/src/tests/instruction.rs
@@ -387,11 +387,11 @@ fn indexed_idl_parse_instruction_with_enum_arg() {
 
     let mut data = vec![1, 1, 1, 1, 1, 1, 1, 1, 0];
     let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
-    assert_eq!(parsed.fields[0].value, IdlValue::Struct(vec![("Start".into(), IdlValue::Null)]));
+    assert_eq!(parsed.fields[0].value, IdlValue::EnumUnit("Start".into()));
 
     data[8] = 1;
     let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
-    assert_eq!(parsed.fields[0].value, IdlValue::Struct(vec![("Stop".into(), IdlValue::Null)]));
+    assert_eq!(parsed.fields[0].value, IdlValue::EnumUnit("Stop".into()));
 }
 
 #[test]

--- a/crates/sonar-idl/src/value.rs
+++ b/crates/sonar-idl/src/value.rs
@@ -28,6 +28,8 @@ pub enum IdlValue {
     Struct(Vec<(String, IdlValue)>),
     /// Ordered values (vec, fixed-size array, tuple).
     Array(Vec<IdlValue>),
+    /// Fieldless (unit) enum variant — carries only a name, no payload.
+    EnumUnit(String),
     /// None / null (Option::None).
     Null,
 }
@@ -62,7 +64,33 @@ impl IdlValue {
                 Value::Object(map)
             }
             Self::Array(values) => Value::Array(values.iter().map(|v| v.to_json_value()).collect()),
+            Self::EnumUnit(name) => {
+                let mut map = serde_json::Map::with_capacity(1);
+                map.insert(name.clone(), Value::Null);
+                Value::Object(map)
+            }
             Self::Null => Value::Null,
+        }
+    }
+
+    /// Convert to `serde_json::Value` optimised for human-readable display.
+    ///
+    /// [`EnumUnit`] variants are flattened to a plain string so they render
+    /// as `name` instead of `name: null`.  All other values are identical
+    /// to [`to_json_value`].
+    pub fn to_display_json_value(&self) -> serde_json::Value {
+        use serde_json::Value;
+        match self {
+            Self::EnumUnit(name) => Value::String(name.clone()),
+            Self::Struct(fields) => {
+                let map: serde_json::Map<std::string::String, Value> =
+                    fields.iter().map(|(k, v)| (k.clone(), v.to_display_json_value())).collect();
+                Value::Object(map)
+            }
+            Self::Array(values) => {
+                Value::Array(values.iter().map(|v| v.to_display_json_value()).collect())
+            }
+            _ => self.to_json_value(),
         }
     }
 }

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -867,7 +867,7 @@ fn render_parsed_fields(fields: &ParsedInstructionFields, indent: &str, w: &mut 
     }
 
     let map: serde_json::Map<String, Value> =
-        fields.iter().map(|f| (f.name.clone(), f.value.to_json_value())).collect();
+        fields.iter().map(|f| (f.name.clone(), f.value.to_display_json_value())).collect();
     let pretty = pretty_print_unquoted(&Value::Object(map), indent);
 
     for line in pretty.lines() {


### PR DESCRIPTION
## Summary

- Adds `IdlValue::EnumUnit(String)` to distinguish fieldless enum variants from single-field structs with `Option::None`
- JSON output preserved (`{"FusionAmm": null}`); text output now renders cleanly as `FusionAmm` instead of `FusionAmm: null`
- Text renderer uses `to_display_json_value()` which flattens only `EnumUnit` variants

## Test plan

- [x] All 584 existing tests pass
- [x] Enum variant tests updated to assert `EnumUnit` representation
- [x] Snapshot for nested pretty-print unchanged (tests JSON path)