### PR TITLE
feat(cli): improve help text discoverability for AI agents

### DIFF
--- a/src/cli/borsh.rs
+++ b/src/cli/borsh.rs
@@ -1,5 +1,10 @@
 use clap::{Args, Subcommand};
 
+/// Serialize or deserialize data using Borsh-compatible type descriptors.
+///
+/// Type descriptors are lowercase: u8/u16/u32/u64/u128, i8..i128, bool, string,
+/// pubkey, vec<T>, [T;N] (fixed array), (T1,T2,...) (tuple), option<T>.
+/// Nest freely, e.g. `vec<(u64,option<pubkey>)>`.
 #[derive(Args, Debug)]
 pub struct BorshArgs {
     #[command(subcommand)]

--- a/src/cli/cache.rs
+++ b/src/cli/cache.rs
@@ -12,7 +12,10 @@ pub struct CacheArgs {
 pub enum CacheCommands {
     /// List all cached transaction account snapshots
     List,
-    /// Remove cached account snapshots
+    /// Remove cached account snapshots (ALL entries by default — use --older-than to scope)
+    ///
+    /// Without --older-than this wipes every cache entry. Run `sonar cache list`
+    /// first to inspect what would be deleted.
     Clean(CacheCleanArgs),
     /// Show details of a specific cache entry
     Info(CacheInfoArgs),

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -4,6 +4,12 @@ use clap::{Args, Subcommand};
 
 /// View or modify `~/.config/sonar/config.toml`.
 #[derive(Args, Debug)]
+#[command(after_help = "\
+EXAMPLES:
+  sonar config list
+  sonar config get show_ix_detail
+  sonar config set show_ix_detail=true    KEY=VALUE form
+  sonar config set show_ix_detail true    KEY VALUE form")]
 pub struct ConfigArgs {
     #[command(subcommand)]
     pub command: ConfigSubcommands,

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -7,7 +7,10 @@ use clap::Args;
 use super::RpcArgs;
 use super::simulate::TransactionInputArgs;
 
-/// Decode and display a raw transaction without simulation.
+/// Parse a raw transaction without executing it.
+///
+/// Unlike simulate, decode does not run the transaction — it only parses
+/// instruction data and account metadata from the raw transaction bytes.
 #[derive(Args, Debug)]
 pub struct DecodeArgs {
     #[command(flatten)]

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -7,10 +7,6 @@ use clap::Args;
 use super::RpcArgs;
 use super::simulate::TransactionInputArgs;
 
-/// Parse a raw transaction without executing it.
-///
-/// Unlike simulate, decode does not run the transaction — it only parses
-/// instruction data and account metadata from the raw transaction bytes.
 #[derive(Args, Debug)]
 pub struct DecodeArgs {
     #[command(flatten)]

--- a/src/cli/idl.rs
+++ b/src/cli/idl.rs
@@ -8,6 +8,13 @@ use super::RpcArgs;
 
 /// Manage Anchor IDLs: fetch, sync, and derive IDL account address.
 #[derive(Args, Debug)]
+#[command(after_help = "\
+EXAMPLES:
+  sonar idl fetch <PROG>                       Fetch one IDL to cwd
+  sonar idl fetch <PROG1> <PROG2> -o ./idls    Fetch many into ./idls
+  sonar idl sync ./idls                        Upload all IDLs in dir
+  sonar idl sync ./idls/<PROG>.json            Upload a single IDL file
+  sonar idl address <PROG>                     Derive the IDL account PDA")]
 pub struct IdlArgs {
     #[command(subcommand)]
     pub command: IdlSubcommands,
@@ -16,10 +23,17 @@ pub struct IdlArgs {
 #[derive(Subcommand, Debug)]
 pub enum IdlSubcommands {
     /// Fetch Anchor IDLs from on-chain program accounts
+    ///
+    /// Use when you have the program ID and want the latest on-chain IDL.
+    /// Writes one `<PUBKEY>.json` per program to --output-dir (default: cwd).
     Fetch(IdlFetchArgs),
     /// Sync IDLs using a directory or one `<PUBKEY>.json` file as source
+    ///
+    /// Inverse of fetch: re-uploads local IDL files to the IDL account on chain.
     Sync(IdlSyncArgs),
     /// Calculate Anchor IDL account address for a program
+    ///
+    /// Pure derivation — no RPC call. Equivalent to the Anchor IDL seed convention.
     Address(IdlAddressArgs),
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -69,10 +69,10 @@ pub enum Commands {
     /// Simulate a Solana transaction locally using LiteSVM
     #[command(alias = "sim", next_line_help = true)]
     Simulate(Box<SimulateArgs>),
-    /// Decode and display a raw transaction without simulation
+    /// Parse a raw transaction without executing it
     #[command(alias = "dec", next_line_help = true)]
     Decode(DecodeArgs),
-    /// Replay the historical execution of a confirmed transaction
+    /// Fetch and display a confirmed transaction's on-chain execution
     #[command(next_line_help = true)]
     Replay(ReplayArgs),
     /// Manage Anchor IDLs (fetch, sync, address)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -98,9 +98,16 @@ pub enum Commands {
     #[command(next_line_help = true)]
     Pda(PdaArgs),
     /// Get raw program data (ELF bytecode) from an upgradeable Program/ProgramData/Buffer account
+    ///
+    /// Either --output <FILE> (use "-" for stdout) or --verify-sha256 <HASH> is
+    /// required. When both are given, the file is written only if the hash matches.
     #[command(name = "program-elf", next_line_help = true)]
     ProgramData(ProgramDataArgs),
     /// Send a signed transaction to the network
+    ///
+    /// Unlike simulate, send broadcasts to the RPC and mutates on-chain state.
+    /// The TX must already be signed — sonar does not sign. Use --wait to block
+    /// until the configured commitment level is reached.
     #[command(next_line_help = true)]
     Send(SendArgs),
     /// Generate shell completion scripts

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -70,9 +70,16 @@ pub enum Commands {
     #[command(alias = "sim", next_line_help = true)]
     Simulate(Box<SimulateArgs>),
     /// Parse a raw transaction without executing it
+    ///
+    /// Unlike simulate, decode does not run the transaction — it only parses
+    /// instruction data and account metadata from the raw transaction bytes.
     #[command(alias = "dec", next_line_help = true)]
     Decode(DecodeArgs),
     /// Fetch and display a confirmed transaction's on-chain execution
+    ///
+    /// Unlike simulate, replay retrieves the actual execution results (logs,
+    /// inner instructions, balance changes) from the RPC node — no local
+    /// execution.
     #[command(next_line_help = true)]
     Replay(ReplayArgs),
     /// Manage Anchor IDLs (fetch, sync, address)

--- a/src/cli/pda.rs
+++ b/src/cli/pda.rs
@@ -12,7 +12,10 @@ pub struct PdaArgs {
     pub program_id: String,
 
     /// Seeds in format: type:value (repeatable), e.g. string:hello pubkey:<PUBKEY>
-    /// Types: string (str), pubkey (pk), bool, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, bytes (hex)
+    ///
+    /// Seed types with aliases in parentheses:
+    ///   string (str) · pubkey (pk) · bool · u8 · u16 · u32 · u64 · u128
+    ///   i8 · i16 · i32 · i64 · i128 · bytes (hex)
     #[arg(value_name = "SEED", num_args = 1.., required = true)]
     pub seeds: Vec<String>,
 }
@@ -70,7 +73,7 @@ impl FromStr for SeedType {
             "i128" => Ok(SeedType::I128),
             "bytes" | "hex" => Ok(SeedType::Bytes),
             _ => Err(format!(
-                "Unknown seed type: '{}'. Supported: string, pubkey, bool, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, bytes",
+                "Unknown seed type: '{}'. Supported: string (str), pubkey (pk, publickey), bool, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, bytes (hex)",
                 s
             )),
         }

--- a/src/cli/pda.rs
+++ b/src/cli/pda.rs
@@ -6,6 +6,11 @@ use solana_pubkey::Pubkey;
 use std::str::FromStr;
 
 #[derive(Args, Debug)]
+#[command(after_help = "\
+EXAMPLES:
+  sonar pda 11111111111111111111111111111111 str:vault pk:So11111111111111111111111111111111111111112
+  sonar pda <PROG> str:position u64:42 bool:true
+  sonar pda <PROG> bytes:deadbeef          Raw hex seed")]
 pub struct PdaArgs {
     /// The program ID to derive the PDA from
     #[arg(value_name = "PROGRAM_ID")]
@@ -101,7 +106,12 @@ pub fn parse_seeds(inputs: &[String]) -> Result<Vec<ParsedSeed>, String> {
         let part = raw.trim();
         let (type_str, value) = part
             .split_once(':')
-            .ok_or_else(|| format!("Invalid seed format '{}': expected 'type:value'", part))?;
+            .ok_or_else(|| {
+                format!(
+                    "Invalid seed format '{}': expected 'type:value' (e.g. 'str:vault', 'pk:<PUBKEY>', 'u64:42')",
+                    part
+                )
+            })?;
         let type_str = type_str.trim();
         let value = value.trim();
 

--- a/src/cli/replay.rs
+++ b/src/cli/replay.rs
@@ -6,10 +6,6 @@ use clap::Args;
 
 use super::RpcArgs;
 
-/// Fetch and display a confirmed transaction's on-chain execution.
-///
-/// Unlike simulate, replay retrieves the actual execution results (logs, inner
-/// instructions, balance changes) from the RPC node — no local execution.
 #[derive(Args, Debug)]
 pub struct ReplayArgs {
     /// Transaction signature to look up

--- a/src/cli/replay.rs
+++ b/src/cli/replay.rs
@@ -6,7 +6,10 @@ use clap::Args;
 
 use super::RpcArgs;
 
-/// Replay the historical execution of a confirmed transaction.
+/// Fetch and display a confirmed transaction's on-chain execution.
+///
+/// Unlike simulate, replay retrieves the actual execution results (logs, inner
+/// instructions, balance changes) from the RPC node — no local execution.
 #[derive(Args, Debug)]
 pub struct ReplayArgs {
     /// Transaction signature to look up

--- a/src/cli/simulate.rs
+++ b/src/cli/simulate.rs
@@ -16,6 +16,12 @@ const HELP_HEADING_SIMULATION_CONTROLS: &str = "Simulation Controls";
 const HELP_HEADING_OUTPUT_DEBUG: &str = "Output & Debug";
 
 #[derive(Args, Debug)]
+#[command(after_help = "\
+EXAMPLES:
+  sonar simulate <TX>                           Single transaction
+  sonar simulate <TX1> <TX2>                    Bundle (atomic multi-tx)
+  sonar simulate <TX> --fund-sol ALICE=1sol     Fund account before sim
+  sonar simulate <TX> --override PROG=prog.so   Override on-chain program")]
 pub struct SimulateArgs {
     #[command(flatten, next_help_heading = HELP_HEADING_INPUT_RPC)]
     pub transaction: TransactionInputArgs,
@@ -181,7 +187,7 @@ pub struct SimulateArgs {
 pub struct TransactionInputArgs {
     /// Raw transaction (Base58/Base64) or transaction signature.
     /// Omit to read from stdin (when stdin is not a TTY).
-    /// Pass multiple values for bundle mode.
+    /// Pass multiple TX values to simulate a bundle (atomic multi-transaction).
     #[arg(value_name = "TX", required = false)]
     pub tx: Vec<String>,
 }

--- a/src/cli/simulate.rs
+++ b/src/cli/simulate.rs
@@ -67,6 +67,7 @@ pub struct SimulateArgs {
     /// Patch an account pubkey within a specific instruction.
     /// Format: <IX>.<ACCOUNT>=<NEW_PUBKEY>[:<w|r>] (1-based indices)
     /// Append :w (default) for writable, :r for read-only.
+    /// Example: --patch-ix-account 1.3=So11111111111111111111111111111111111111112:r
     #[arg(
         short = 'A',
         long = "patch-ix-account",
@@ -79,6 +80,7 @@ pub struct SimulateArgs {
     /// Append an account to the end of a specific instruction's account list.
     /// Format: <IX>=<PUBKEY>[:<w|r>] (1-based instruction index)
     /// Append :w (default) for writable, :r for read-only.
+    /// Example: --append-ix-account 2=So11111111111111111111111111111111111111112
     #[arg(
         long = "append-ix-account",
         help_heading = HELP_HEADING_STATE_PREPARATION,
@@ -90,6 +92,7 @@ pub struct SimulateArgs {
     /// Patch bytes in an instruction's data field before simulation.
     /// Format: <IX>=<OFFSET>:<HEX_DATA> (1-based instruction index)
     /// HEX_DATA may optionally start with 0x.
+    /// Example: --patch-ix-data 1=8:0xdeadbeef
     #[arg(
         short = 'P',
         long = "patch-ix-data",
@@ -102,6 +105,7 @@ pub struct SimulateArgs {
     /// Patch bytes in an account data field before simulation.
     /// Format: <PUBKEY>=<OFFSET>:<HEX_DATA>
     /// HEX_DATA may optionally start with 0x.
+    /// Example: --patch-account-data So11111111111111111111111111111111111111112=16:0xdeadbeef
     #[arg(
         short = 'p',
         long = "patch-account-data",


### PR DESCRIPTION
## Summary
- Clarify `decode` and `replay` about text to clearly distinguish from `simulate`
- Surface PDA seed type aliases (`str`, `pk`, `hex`, `publickey`) in help text and error messages
- Make bundle mode more prominent in `simulate` (TX arg help + `after_help` examples section)

## Test plan
- [ ] `cargo run -- simulate --help` — verify EXAMPLES section and bundle mention
- [ ] `cargo run -- decode --help` — verify updated about text
- [ ] `cargo run -- replay --help` — verify updated about text
- [ ] `cargo run -- pda --help` — verify seed types with aliases are visible
- [ ] `cargo test` — all passing