### PR TITLE
fix(rpc): increase ureq response body limit from 10MB to 128MB

### DIFF
--- a/crates/sonar-sim/src/rpc_transport.rs
+++ b/crates/sonar-sim/src/rpc_transport.rs
@@ -11,6 +11,7 @@ use crate::error::SonarSimError;
 use crate::rpc_json::JsonRpcResponse;
 
 const RPC_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_RESPONSE_SIZE: u64 = 128 * 1024 * 1024; // 128MB
 const MAX_RETRIES: u32 = 5;
 const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(2);
 
@@ -47,9 +48,14 @@ impl RpcTransport {
         for attempt in 0..=MAX_RETRIES {
             match self.agent.post(&self.rpc_url).send_json(&body) {
                 Ok(mut response) => {
-                    let rpc: JsonRpcResponse<T> = response.body_mut().read_json().map_err(
-                        |e| SonarSimError::Rpc { reason: format!("parse response: {e}") },
-                    )?;
+                    let rpc: JsonRpcResponse<T> = response
+                        .body_mut()
+                        .with_config()
+                        .limit(MAX_RESPONSE_SIZE)
+                        .read_json()
+                        .map_err(|e| SonarSimError::Rpc {
+                            reason: format!("parse response: {e}"),
+                        })?;
 
                     if let Some(err) = rpc.error {
                         return Err(SonarSimError::Rpc { reason: err.to_string() });


### PR DESCRIPTION
## Summary
- ureq 3.x defaults to a 10MB response body limit, causing `getMultipleAccounts` calls to fail with large account data
- Set an explicit 128MB limit via `.with_config().limit()` to handle large RPC responses

## Test plan
- [x] Verified the original failing command now succeeds:
  `sonar sim Q8F6sUE4zoPb34EgS9jML5TeZf4tTdWyXrnur5JYLrC9zo6wxuuUaqNv8G769Ycu9byoBHmGrTvyiro6Z8ktJTx -u <rpc-url>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)