### PR TITLE
refactor: simplify sonar sim internals

### DIFF
--- a/crates/sonar-sim/src/account_fetcher.rs
+++ b/crates/sonar-sim/src/account_fetcher.rs
@@ -93,6 +93,49 @@ impl AccountFetcher {
         pubkeys: &[Pubkey],
         destination: &mut HashMap<Pubkey, AccountSharedData>,
     ) -> Result<()> {
+        let unique = Self::dedupe_requested(pubkeys, destination);
+        if unique.is_empty() {
+            return Ok(());
+        }
+
+        trace!("Preparing to fetch {} accounts: [{}]", unique.len(), format_pubkeys(&unique));
+
+        let mut to_fetch = self.resolve_from_cache(unique, destination);
+        if to_fetch.is_empty() {
+            return Ok(());
+        }
+
+        to_fetch = self.resolve_from_sources(to_fetch, destination)?;
+        if to_fetch.is_empty() {
+            return Ok(());
+        }
+
+        let Some(to_fetch) = self.filter_rpc_candidates(to_fetch) else {
+            return Ok(());
+        };
+
+        let total_count = to_fetch.len();
+        let chunks: Vec<&[Pubkey]> = to_fetch.chunks(self.rpc_batch_size).collect();
+        self.notify_batches_started(&chunks, total_count);
+
+        let batch_results = self.fetch_rpc_batches(&chunks);
+        let fetched_count =
+            self.apply_rpc_results(&chunks, batch_results, total_count, destination)?;
+
+        self.notify(FetchEvent::RpcFinished {
+            requested: total_count,
+            fetched: fetched_count,
+            missing: total_count.saturating_sub(fetched_count),
+        });
+
+        debug!("Successfully fetched {} accounts from RPC", total_count);
+        Ok(())
+    }
+
+    fn dedupe_requested(
+        pubkeys: &[Pubkey],
+        destination: &HashMap<Pubkey, AccountSharedData>,
+    ) -> Vec<Pubkey> {
         let mut unique = Vec::with_capacity(pubkeys.len());
         let mut seen = HashSet::with_capacity(pubkeys.len());
         for key in pubkeys {
@@ -106,13 +149,14 @@ impl AccountFetcher {
                 unique.push(*key);
             }
         }
+        unique
+    }
 
-        if unique.is_empty() {
-            return Ok(());
-        }
-
-        trace!("Preparing to fetch {} accounts: [{}]", unique.len(), format_pubkeys(&unique));
-
+    fn resolve_from_cache(
+        &self,
+        unique: Vec<Pubkey>,
+        destination: &mut HashMap<Pubkey, AccountSharedData>,
+    ) -> Vec<Pubkey> {
         let mut to_fetch = Vec::new();
         for key in unique {
             if let Some(account) = self.cache.get(&key) {
@@ -121,11 +165,14 @@ impl AccountFetcher {
                 to_fetch.push(key);
             }
         }
+        to_fetch
+    }
 
-        if to_fetch.is_empty() {
-            return Ok(());
-        }
-
+    fn resolve_from_sources(
+        &mut self,
+        mut to_fetch: Vec<Pubkey>,
+        destination: &mut HashMap<Pubkey, AccountSharedData>,
+    ) -> Result<Vec<Pubkey>> {
         for source in &self.sources {
             if to_fetch.is_empty() {
                 break;
@@ -148,26 +195,22 @@ impl AccountFetcher {
             }
             to_fetch = still_missing;
         }
+        Ok(to_fetch)
+    }
 
-        if to_fetch.is_empty() {
-            return Ok(());
-        }
-
+    fn filter_rpc_candidates(&self, mut to_fetch: Vec<Pubkey>) -> Option<Vec<Pubkey>> {
         if let Some(policy) = &self.policy {
             if policy.decide_rpc(&to_fetch) == RpcDecision::Deny {
                 self.notify(FetchEvent::RpcSkippedByPolicy { missing: to_fetch });
-                return Ok(());
+                return None;
             }
         }
 
         to_fetch.retain(|key| !self.missing_cache.contains(key));
-        if to_fetch.is_empty() {
-            return Ok(());
-        }
+        if to_fetch.is_empty() { None } else { Some(to_fetch) }
+    }
 
-        let total_count = to_fetch.len();
-        let chunks: Vec<&[Pubkey]> = to_fetch.chunks(self.rpc_batch_size).collect();
-
+    fn notify_batches_started(&self, chunks: &[&[Pubkey]], total_count: usize) {
         for (batch_index, chunk) in chunks.iter().enumerate() {
             self.notify(FetchEvent::RpcBatchStarted {
                 batch_index,
@@ -175,26 +218,39 @@ impl AccountFetcher {
                 total_requested: total_count,
             });
         }
+    }
 
-        // Fetch all batches in parallel when multiple chunks are needed.
-        // Single-batch case avoids thread overhead.
-        let batch_results: Vec<Result<Vec<Option<AccountSharedData>>>> = if chunks.len() <= 1 {
-            chunks.iter().map(|&chunk| self.provider.get_multiple_accounts(chunk)).collect()
-        } else {
-            let provider = &self.provider;
-            std::thread::scope(|s| {
-                let handles: Vec<_> = chunks
-                    .iter()
-                    .map(|&chunk| {
-                        let provider = Arc::clone(provider);
-                        s.spawn(move || provider.get_multiple_accounts(chunk))
-                    })
-                    .collect();
-                handles.into_iter().map(|h| h.join().expect("RPC batch thread panicked")).collect()
-            })
-        };
+    fn fetch_rpc_batches(
+        &self,
+        chunks: &[&[Pubkey]],
+    ) -> Vec<Result<Vec<Option<AccountSharedData>>>> {
+        if chunks.len() <= 1 {
+            return chunks
+                .iter()
+                .map(|&chunk| self.provider.get_multiple_accounts(chunk))
+                .collect();
+        }
 
-        // Process results and update caches
+        let provider = &self.provider;
+        std::thread::scope(|s| {
+            let handles: Vec<_> = chunks
+                .iter()
+                .map(|&chunk| {
+                    let provider = Arc::clone(provider);
+                    s.spawn(move || provider.get_multiple_accounts(chunk))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().expect("RPC batch thread panicked")).collect()
+        })
+    }
+
+    fn apply_rpc_results(
+        &mut self,
+        chunks: &[&[Pubkey]],
+        batch_results: Vec<Result<Vec<Option<AccountSharedData>>>>,
+        total_count: usize,
+        destination: &mut HashMap<Pubkey, AccountSharedData>,
+    ) -> Result<usize> {
         let mut requested_count = 0usize;
         let mut fetched_count = 0usize;
         for (&chunk, result) in chunks.iter().zip(batch_results) {
@@ -232,15 +288,7 @@ impl AccountFetcher {
                 }
             }
         }
-
-        self.notify(FetchEvent::RpcFinished {
-            requested: total_count,
-            fetched: fetched_count,
-            missing: total_count.saturating_sub(fetched_count),
-        });
-
-        debug!("Successfully fetched {} accounts from RPC", total_count);
-        Ok(())
+        Ok(fetched_count)
     }
 
     fn notify(&self, event: FetchEvent) {

--- a/crates/sonar-sim/src/account_loader.rs
+++ b/crates/sonar-sim/src/account_loader.rs
@@ -102,29 +102,20 @@ impl AccountLoader {
         let initial = collect_initial_accounts(plans);
         let mut accounts = HashMap::with_capacity(initial.len());
 
-        self.fetcher.fetch_accounts(&initial, &mut accounts).map_err(|e| {
-            SonarSimError::AccountData {
-                pubkey: None,
-                reason: format!(
-                    "Failed to fetch initial accounts (static + sysvars + lookups): {e}"
-                ),
-            }
-        })?;
-        self.resolve_all_dependencies(&mut accounts)?;
+        self.fetch_then_resolve(
+            &initial,
+            &mut accounts,
+            "Failed to fetch initial accounts (static + sysvars + lookups)",
+        )?;
 
         let (lookups, lookup_pubkeys) = self.resolve_all_lookups(plans, &mut accounts)?;
 
         if !lookup_pubkeys.is_empty() {
-            self.fetcher.fetch_accounts(&lookup_pubkeys, &mut accounts).map_err(|e| {
-                SonarSimError::AccountData {
-                    pubkey: None,
-                    reason: format!(
-                        "Failed to load accounts from address lookup tables: [{}]: {e}",
-                        format_pubkeys(&lookup_pubkeys)
-                    ),
-                }
-            })?;
-            self.resolve_all_dependencies(&mut accounts)?;
+            self.fetch_then_resolve(
+                &lookup_pubkeys,
+                &mut accounts,
+                "Failed to load accounts from address lookup tables",
+            )?;
         }
 
         Ok(ResolvedAccounts { accounts, lookups })
@@ -164,17 +155,25 @@ impl AccountLoader {
         if pubkeys.is_empty() {
             return Ok(());
         }
-        self.fetcher.fetch_accounts(pubkeys, &mut resolved.accounts).map_err(|e| {
-            SonarSimError::AccountData {
-                pubkey: None,
-                reason: format!(
-                    "Failed to fetch appended accounts: [{}]: {e}",
-                    format_pubkeys(pubkeys)
-                ),
-            }
-        })?;
-        self.resolve_all_dependencies(&mut resolved.accounts)?;
+        self.fetch_then_resolve(
+            pubkeys,
+            &mut resolved.accounts,
+            "Failed to fetch appended accounts",
+        )?;
         Ok(())
+    }
+
+    fn fetch_then_resolve(
+        &mut self,
+        pubkeys: &[Pubkey],
+        accounts: &mut HashMap<Pubkey, AccountSharedData>,
+        context: &str,
+    ) -> Result<()> {
+        self.fetcher.fetch_accounts(pubkeys, accounts).map_err(|e| SonarSimError::AccountData {
+            pubkey: None,
+            reason: format!("{context}: [{}]: {e}", format_pubkeys(pubkeys)),
+        })?;
+        self.resolve_all_dependencies(accounts)
     }
 
     /// Runs built-in dependency rules in a loop until no new dependencies emerge.

--- a/crates/sonar-sim/src/funding/mod.rs
+++ b/crates/sonar-sim/src/funding/mod.rs
@@ -18,6 +18,16 @@ use crate::types::{
     AccountAppender, PreparedTokenFunding, ResolvedAccounts, TokenAmount, TokenFunding,
 };
 
+struct TokenIdentity {
+    mint: Pubkey,
+    owner: Pubkey,
+}
+
+struct MintContext {
+    decimals: u8,
+    program_kind: TokenProgramKind,
+}
+
 pub fn prepare_token_fundings(
     loader: &mut dyn AccountAppender,
     resolved: &ResolvedAccounts,
@@ -67,64 +77,113 @@ fn prepare_single_token_funding(
         }
     })?;
 
-    let (mint, owner) = if let Some(account) = lookup_account(resolved, extras, &request.account) {
+    let identity = resolve_token_identity(resolved, extras, request)?;
+    let mint_context = load_mint_context(loader, resolved, extras, identity.mint)?;
+
+    let amount_raw = resolve_token_amount(&request.amount, mint_context.decimals).map_err(|e| {
+        SonarSimError::Token {
+            account: Some(request.account),
+            reason: format!("Failed to resolve token amount for {}: {e}", request.account),
+        }
+    })?;
+
+    if let Some(account) = lookup_account(resolved, extras, &request.account) {
+        ensure_same_program(
+            mint_context.program_kind,
+            account.owner(),
+            "token account",
+            request.account,
+        )?;
+    }
+
+    Ok(PreparedTokenFunding {
+        account: request.account,
+        mint: identity.mint,
+        owner: identity.owner,
+        decimals: mint_context.decimals,
+        amount_raw,
+        ui_amount: raw_to_ui_amount(amount_raw, mint_context.decimals),
+        program_kind: mint_context.program_kind,
+    })
+}
+
+fn resolve_token_identity(
+    resolved: &ResolvedAccounts,
+    extras: &HashMap<Pubkey, AccountSharedData>,
+    request: &TokenFunding,
+) -> Result<TokenIdentity> {
+    if let Some(account) = lookup_account(resolved, extras, &request.account) {
         let decoded = decode_existing_token_account(account, &request.account)?;
+        validate_requested_identity(request, decoded.mint, decoded.owner)?;
+        return Ok(TokenIdentity { mint: decoded.mint, owner: decoded.owner });
+    }
 
-        if let Some(requested_mint) = request.mint {
-            if decoded.mint != requested_mint {
-                return Err(SonarSimError::Token {
-                    account: Some(request.account),
-                    reason: format!(
-                        "Token account {} is associated with mint {}, but CLI requested mint {}",
-                        request.account, decoded.mint, requested_mint
-                    ),
-                });
-            }
+    let mint = request.mint.ok_or_else(|| SonarSimError::Token {
+        account: Some(request.account),
+        reason: format!(
+            "Token account {} does not exist on-chain; \
+             you must specify mint and owner using \
+             <ACCOUNT>:<MINT>:<OWNER>=<AMOUNT> format",
+            request.account
+        ),
+    })?;
+    let owner = request.owner.ok_or_else(|| SonarSimError::Token {
+        account: Some(request.account),
+        reason: format!(
+            "Token account {} does not exist on-chain; \
+             you must specify the owner using \
+             <ACCOUNT>:<MINT>:<OWNER>=<AMOUNT> format",
+            request.account
+        ),
+    })?;
+
+    Ok(TokenIdentity { mint, owner })
+}
+
+fn validate_requested_identity(
+    request: &TokenFunding,
+    actual_mint: Pubkey,
+    actual_owner: Pubkey,
+) -> Result<()> {
+    if let Some(requested_mint) = request.mint {
+        if actual_mint != requested_mint {
+            return Err(SonarSimError::Token {
+                account: Some(request.account),
+                reason: format!(
+                    "Token account {} is associated with mint {}, but CLI requested mint {}",
+                    request.account, actual_mint, requested_mint
+                ),
+            });
         }
+    }
 
-        if let Some(requested_owner) = request.owner {
-            if decoded.owner != requested_owner {
-                return Err(SonarSimError::Token {
-                    account: Some(request.account),
-                    reason: format!(
-                        "Token account {} has owner {}, but CLI specified owner {}",
-                        request.account, decoded.owner, requested_owner
-                    ),
-                });
-            }
+    if let Some(requested_owner) = request.owner {
+        if actual_owner != requested_owner {
+            return Err(SonarSimError::Token {
+                account: Some(request.account),
+                reason: format!(
+                    "Token account {} has owner {}, but CLI specified owner {}",
+                    request.account, actual_owner, requested_owner
+                ),
+            });
         }
+    }
 
-        (decoded.mint, decoded.owner)
-    } else {
-        let mint = request.mint.ok_or_else(|| SonarSimError::Token {
-            account: Some(request.account),
-            reason: format!(
-                "Token account {} does not exist on-chain; \
-                 you must specify mint and owner using \
-                 <ACCOUNT>:<MINT>:<OWNER>=<AMOUNT> format",
-                request.account
-            ),
-        })?;
-        let owner = request.owner.ok_or_else(|| SonarSimError::Token {
-            account: Some(request.account),
-            reason: format!(
-                "Token account {} does not exist on-chain; \
-                 you must specify the owner using \
-                 <ACCOUNT>:<MINT>:<OWNER>=<AMOUNT> format",
-                request.account
-            ),
-        })?;
+    Ok(())
+}
 
-        (mint, owner)
-    };
-
+fn load_mint_context(
+    loader: &mut dyn AccountAppender,
+    resolved: &ResolvedAccounts,
+    extras: &mut HashMap<Pubkey, AccountSharedData>,
+    mint: Pubkey,
+) -> Result<MintContext> {
     ensure_account_loaded(loader, resolved, extras, &mint).map_err(|e| SonarSimError::Token {
         account: Some(mint),
         reason: format!("Failed to load mint account {}: {e}", mint),
     })?;
     let mint_account = lookup_account(resolved, extras, &mint)
-        .ok_or(SonarSimError::AccountNotFound { pubkey: mint })?
-        .clone();
+        .ok_or(SonarSimError::AccountNotFound { pubkey: mint })?;
 
     let program_kind =
         TokenProgramKind::from_owner(mint_account.owner()).ok_or_else(|| SonarSimError::Token {
@@ -135,27 +194,9 @@ fn prepare_single_token_funding(
             ),
         })?;
 
-    let decimals = token_decode::read_mint_decimals(&mint_account)?;
+    let decimals = token_decode::read_mint_decimals(mint_account)?;
 
-    let amount_raw =
-        resolve_token_amount(&request.amount, decimals).map_err(|e| SonarSimError::Token {
-            account: Some(request.account),
-            reason: format!("Failed to resolve token amount for {}: {e}", request.account),
-        })?;
-
-    if let Some(account) = lookup_account(resolved, extras, &request.account) {
-        ensure_same_program(program_kind, account.owner(), "token account", request.account)?;
-    }
-
-    Ok(PreparedTokenFunding {
-        account: request.account,
-        mint,
-        owner,
-        decimals,
-        amount_raw,
-        ui_amount: raw_to_ui_amount(amount_raw, decimals),
-        program_kind,
-    })
+    Ok(MintContext { decimals, program_kind })
 }
 
 pub fn apply_token_fundings<B: SvmBackend + ?Sized>(
@@ -174,55 +215,70 @@ fn apply_single_token_funding<B: SvmBackend + ?Sized>(
     funding: &PreparedTokenFunding,
     resolved: &ResolvedAccounts,
 ) -> Result<()> {
-    let kind = funding.program_kind;
-
     let mut account = if let Some(existing) = svm.get_account(&funding.account) {
         existing
     } else {
-        let rent = read_rent_from_svm(svm)?;
-        let mint_account = resolved
-            .accounts
-            .get(&funding.mint)
-            .ok_or(SonarSimError::AccountNotFound { pubkey: funding.mint })?;
-        match kind {
-            TokenProgramKind::Legacy => token_legacy::build_token_account(
-                &funding.account,
-                &funding.mint,
-                &funding.owner,
-                &rent,
-            )?,
-            TokenProgramKind::Token2022 => token2022::build_token_account_with_extensions(
-                &funding.account,
-                &funding.mint,
-                &funding.owner,
-                mint_account,
-                &rent,
-            )?,
-        }
+        build_funding_account(svm, funding, resolved)?
     };
 
-    let _ = match kind {
-        TokenProgramKind::Legacy => token_legacy::update_token_balance_in_account(
-            &mut account,
-            &funding.account,
-            &funding.mint,
-            &funding.owner,
-            funding.amount_raw,
-            funding.decimals,
-        )?,
-        TokenProgramKind::Token2022 => token2022::update_token_balance_in_account(
-            &mut account,
-            &funding.account,
-            &funding.mint,
-            &funding.owner,
-            funding.amount_raw,
-            funding.decimals,
-        )?,
-    };
+    update_funding_account(&mut account, funding)?;
 
     svm.set_account(funding.account, account).map_err(|e| SonarSimError::Svm {
         reason: format!("Failed to set token funding account `{}`: {}", funding.account, e),
     })?;
+    Ok(())
+}
+
+fn build_funding_account<B: SvmBackend + ?Sized>(
+    svm: &B,
+    funding: &PreparedTokenFunding,
+    resolved: &ResolvedAccounts,
+) -> Result<AccountSharedData> {
+    let rent = read_rent_from_svm(svm)?;
+    let mint_account = resolved
+        .accounts
+        .get(&funding.mint)
+        .ok_or(SonarSimError::AccountNotFound { pubkey: funding.mint })?;
+
+    match funding.program_kind {
+        TokenProgramKind::Legacy => token_legacy::build_token_account(
+            &funding.account,
+            &funding.mint,
+            &funding.owner,
+            &rent,
+        ),
+        TokenProgramKind::Token2022 => token2022::build_token_account_with_extensions(
+            &funding.account,
+            &funding.mint,
+            &funding.owner,
+            mint_account,
+            &rent,
+        ),
+    }
+}
+
+fn update_funding_account(
+    account: &mut AccountSharedData,
+    funding: &PreparedTokenFunding,
+) -> Result<()> {
+    match funding.program_kind {
+        TokenProgramKind::Legacy => token_legacy::update_token_balance_in_account(
+            account,
+            &funding.account,
+            &funding.mint,
+            &funding.owner,
+            funding.amount_raw,
+            funding.decimals,
+        ),
+        TokenProgramKind::Token2022 => token2022::update_token_balance_in_account(
+            account,
+            &funding.account,
+            &funding.mint,
+            &funding.owner,
+            funding.amount_raw,
+            funding.decimals,
+        ),
+    }?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- split AccountFetcher account loading into explicit fetch stages
- centralize AccountLoader fetch-and-resolve flow
- extract token funding identity/mint context helpers and simplify apply-time branching

## Verification
- rustfmt --check crates/sonar-sim/src/account_fetcher.rs crates/sonar-sim/src/account_loader.rs crates/sonar-sim/src/funding/mod.rs
- cargo check -p sonar-sim
- cargo test -p sonar-sim

Note: repo-wide cargo fmt --check still reports pre-existing formatting drift outside this PR.