### PR TITLE
docs: humanize README and simulate docs, add replay to command table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Sonar — Solana Transaction Simulator & Utilities
+# Sonar — Solana transaction simulator & utilities
 
-A CLI tool for local Solana transaction simulation (LiteSVM) plus common developer utilities.
+A CLI for local Solana transaction simulation (LiteSVM) plus developer utilities.
 
-- **Local simulation** without deploying programs — raw tx, signature, or bundle
-- **State manipulation** — override programs/accounts, fund SOL or tokens, patch data
-- **Offline cache & replay** — store accounts once, simulate without RPC
-- **Borsh & Anchor IDL** — serialize/deserialize with a type descriptor DSL
-- **Developer utilities** — decode, convert, PDA, account, program-elf, send, and more
+- Simulate transactions locally without deploying programs (raw tx, signature, or bundle)
+- Override programs/accounts, fund SOL or tokens, patch data
+- Store accounts once, replay without hitting RPC
+- Serialize/deserialize Borsh with a type descriptor DSL
+- Decode, convert, derive PDAs, inspect accounts, pull program ELF, send transactions
 
 ## Installation
 
@@ -17,7 +17,7 @@ cargo build --release
 # Binary at target/release/sonar
 ```
 
-## Quick Start
+## Quick start
 
 ```bash
 # Simulate a transaction locally
@@ -30,31 +30,32 @@ sonar simulate <SIGNATURE> --rpc-url https://api.mainnet-beta.solana.com
 sonar account <PUBKEY> --rpc-url https://api.mainnet-beta.solana.com
 ```
 
-## Command Reference
+## Command reference
 
 | Command | Use when |
 |---------|----------|
-| **`simulate`** | **You want local execution logs, balance changes, and failure reasons** |
-| `decode` | You only need transaction structure (instructions/accounts) without execution |
-| `account` | You want decoded account metadata/data for a pubkey |
-| `program-elf` | You need raw ELF bytes from upgradeable program/buffer accounts |
-| `idl` | You want to fetch/sync Anchor IDLs or derive an IDL account address |
-| `send` | You want to submit a signed transaction to the network |
-| `borsh` | You want to serialize JSON to Borsh bytes or deserialize Borsh bytes to JSON |
-| `convert` | You want explicit and deterministic format conversion |
-| `pda` | You want to derive a PDA from seeds |
-| `config` | You want to inspect or update `~/.config/sonar/config.toml` |
-| `cache` | You want to list, clean, or inspect cached account data |
-| `completions` | You want to generate shell completion scripts |
+| `simulate` | Local execution logs, balance changes, and failure reasons |
+| `decode` | Transaction structure (instructions/accounts) without execution |
+| `replay` | Replay a confirmed transaction from on-chain metadata (no local simulation) |
+| `account` | Decoded account metadata/data for a pubkey |
+| `program-elf` | Raw ELF bytes from upgradeable program/buffer accounts |
+| `idl` | Fetch/sync Anchor IDLs or derive an IDL account address |
+| `send` | Submit a signed transaction to the network |
+| `borsh` | Serialize JSON to Borsh bytes or deserialize Borsh bytes to JSON |
+| `convert` | Format conversion |
+| `pda` | Derive a PDA from seeds |
+| `config` | Inspect or update `~/.config/sonar/config.toml` |
+| `cache` | List, clean, or inspect cached account data |
+| `completions` | Generate shell completion scripts |
 
 ## Documentation
 
-- [Simulate & Decode](docs/simulate.md) — full usage, overrides, funding, patching, cache
-- [Account, PDA, Program ELF, IDL, Send](docs/commands.md) — per-command reference
-- [Borsh](docs/borsh.md) — serialization/deserialization with type descriptor DSL
-- [Convert](docs/convert.md) — format conversion reference
-- [Configuration](docs/configuration.md) — config file, cache, completions
-- [Output Conventions](docs/output-conventions.md) — stdout/stderr contract, permission markers, diagnostics
+- [Simulate & Decode](docs/simulate.md): full usage, overrides, funding, patching, cache
+- [Account, PDA, Program ELF, IDL, Send](docs/commands.md): per-command reference
+- [Borsh](docs/borsh.md): serialization/deserialization with type descriptor DSL
+- [Convert](docs/convert.md): format conversion reference
+- [Configuration](docs/configuration.md): config file, cache, completions
+- [Output Conventions](docs/output-conventions.md): stdout/stderr contract, permission markers, diagnostics
 
 ## License
 

--- a/docs/simulate.md
+++ b/docs/simulate.md
@@ -3,8 +3,8 @@
 ## Simulate
 
 Simulate a Solana transaction locally using LiteSVM (`simulate`, alias: `sim`).
-`sonar simulate --help` groups options by `Input & RPC`, `State Preparation`,
-`Simulation Controls`, and `Output & Debug` for faster scanning.
+`sonar simulate --help` groups options into `Input & RPC`, `State Preparation`,
+`Simulation Controls`, and `Output & Debug`.
 
 ```bash
 # Simulate a transaction with raw Base58/Base64 data
@@ -191,7 +191,7 @@ sonar decode <TX_OR_SIGNATURE> --rpc-url <RPC_URL> --cache-dir /path/to/cache
 
 ## Replay
 
-Replay the historical execution of a confirmed transaction. Fetches the transaction by signature from RPC and reconstructs the execution trace from on-chain metadata — no local simulation needed.
+Replay a confirmed transaction. Fetches it by signature from RPC and reconstructs the execution trace from on-chain metadata (no local simulation).
 
 ```bash
 # Replay a confirmed transaction


### PR DESCRIPTION
## Summary
- Remove AI writing patterns from README (em dashes, bold-label lists, filler adjectives, formulaic "You want..." table rows, title-case headings)
- Tighten prose in docs/simulate.md (drop "for faster scanning", shorten replay description)
- Add missing `replay` entry to the command reference table

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all command reference links still resolve
- [ ] Spot-check that no meaning was lost in the rewrites

🤖 Generated with [Claude Code](https://claude.com/claude-code)