### PR TITLE
feat(simulate)!: unify instruction-account ops with --insert/--remove

### DIFF
--- a/crates/sonar-sim/src/internals.rs
+++ b/crates/sonar-sim/src/internals.rs
@@ -7,8 +7,8 @@
 
 pub use crate::transaction::{
     AddressLookupPlan, LookupLocation, MessageAccountPlan, ParsedTransaction,
-    RawTransactionEncoding, apply_ix_account_appends, apply_ix_account_patches,
-    apply_ix_data_patches, build_lookup_locations, parse_raw_transaction,
+    RawTransactionEncoding, apply_ix_account_ops, apply_ix_data_patches, build_lookup_locations,
+    parse_raw_transaction,
 };
 
 // ── Account loading ──
@@ -19,8 +19,8 @@ pub use crate::account_loader::AccountLoader;
 // ── Account types ──
 
 pub use crate::types::{
-    AccountDataPatch, AccountOverride, InstructionAccountAppend, InstructionAccountPatch,
-    InstructionDataPatch, ResolvedAccounts, ResolvedLookup,
+    AccountDataPatch, AccountOverride, InstructionAccountOp, InstructionDataPatch,
+    ResolvedAccounts, ResolvedLookup,
 };
 
 // ── Funding ──

--- a/crates/sonar-sim/src/mutations.rs
+++ b/crates/sonar-sim/src/mutations.rs
@@ -5,15 +5,14 @@
 use solana_pubkey::Pubkey;
 
 use crate::types::{
-    AccountDataPatch, AccountOverride, InstructionAccountAppend, InstructionAccountPatch,
-    InstructionDataPatch, SolFunding, TokenFunding,
+    AccountDataPatch, AccountOverride, InstructionAccountOp, InstructionDataPatch, SolFunding,
+    TokenFunding,
 };
 
 /// Instruction-level mutations applied to the raw transaction before simulation.
 #[derive(Debug, Clone, Default)]
 pub struct TransactionMutations {
-    pub(crate) ix_account_patches: Vec<InstructionAccountPatch>,
-    pub(crate) ix_account_appends: Vec<InstructionAccountAppend>,
+    pub(crate) ix_account_ops: Vec<InstructionAccountOp>,
     pub(crate) ix_data_patches: Vec<InstructionDataPatch>,
 }
 
@@ -52,9 +51,7 @@ impl Mutations {
 
 impl TransactionMutations {
     pub fn is_empty(&self) -> bool {
-        self.ix_account_patches.is_empty()
-            && self.ix_account_appends.is_empty()
-            && self.ix_data_patches.is_empty()
+        self.ix_account_ops.is_empty() && self.ix_data_patches.is_empty()
     }
 }
 
@@ -100,13 +97,10 @@ impl MutationsBuilder {
         self
     }
 
-    pub fn patch_ix_account(mut self, patch: InstructionAccountPatch) -> Self {
-        self.inner.transaction.ix_account_patches.push(patch);
-        self
-    }
-
-    pub fn append_ix_account(mut self, append: InstructionAccountAppend) -> Self {
-        self.inner.transaction.ix_account_appends.push(append);
+    /// Append an instruction-account mutation. Operations apply in the order
+    /// added; positions are interpreted at apply time.
+    pub fn add_ix_account_op(mut self, op: InstructionAccountOp) -> Self {
+        self.inner.transaction.ix_account_ops.push(op);
         self
     }
 
@@ -148,6 +142,42 @@ mod tests {
         assert_eq!(m.state.sol_fundings.len(), 1);
         assert_eq!(m.state.sol_fundings[0].pubkey, pk);
         assert_eq!(m.state.sol_fundings[0].amount_lamports, 1_000_000);
+    }
+
+    #[test]
+    fn builder_add_ix_account_op_insert() {
+        let key = Pubkey::new_unique();
+        let m = Mutations::builder()
+            .add_ix_account_op(InstructionAccountOp::Insert {
+                instruction_index: 0,
+                account_position: 2,
+                new_pubkey: key,
+                writable: false,
+            })
+            .build();
+        assert_eq!(m.transaction.ix_account_ops.len(), 1);
+        assert!(matches!(
+            m.transaction.ix_account_ops[0],
+            InstructionAccountOp::Insert { account_position: 2, writable: false, .. }
+        ));
+        assert!(!m.is_empty());
+    }
+
+    #[test]
+    fn builder_add_ix_account_op_remove_preserves_order() {
+        let m = Mutations::builder()
+            .add_ix_account_op(InstructionAccountOp::Remove {
+                instruction_index: 0,
+                account_position: 3,
+            })
+            .add_ix_account_op(InstructionAccountOp::Remove {
+                instruction_index: 0,
+                account_position: 1,
+            })
+            .build();
+        assert_eq!(m.transaction.ix_account_ops.len(), 2);
+        assert_eq!(m.transaction.ix_account_ops[0].account_position(), 3);
+        assert_eq!(m.transaction.ix_account_ops[1].account_position(), 1);
     }
 
     #[test]

--- a/crates/sonar-sim/src/pipeline.rs
+++ b/crates/sonar-sim/src/pipeline.rs
@@ -18,8 +18,7 @@ use crate::mutations::Mutations;
 use crate::result::SimulationResult;
 use crate::rpc_provider::RpcAccountProvider;
 use crate::transaction::{
-    ParsedTransaction, apply_ix_account_appends, apply_ix_account_patches, apply_ix_data_patches,
-    parse_raw_transaction,
+    ParsedTransaction, apply_ix_account_ops, apply_ix_data_patches, parse_raw_transaction,
 };
 use crate::types::{AccountSource, FetchObserver, FetchPolicy, ResolvedAccounts, RpcDecision};
 
@@ -237,11 +236,8 @@ impl Pipeline {
     /// Apply transaction-level mutations (instruction patches) to a single transaction.
     fn apply_tx_mutations(tx: &mut VersionedTransaction, mutations: &Mutations) -> Result<()> {
         let tx_m = &mutations.transaction;
-        if !tx_m.ix_account_patches.is_empty() {
-            apply_ix_account_patches(tx, &tx_m.ix_account_patches)?;
-        }
-        if !tx_m.ix_account_appends.is_empty() {
-            apply_ix_account_appends(tx, &tx_m.ix_account_appends)?;
+        if !tx_m.ix_account_ops.is_empty() {
+            apply_ix_account_ops(tx, &tx_m.ix_account_ops)?;
         }
         if !tx_m.ix_data_patches.is_empty() {
             apply_ix_data_patches(tx, &tx_m.ix_data_patches)?;

--- a/crates/sonar-sim/src/transaction.rs
+++ b/crates/sonar-sim/src/transaction.rs
@@ -187,83 +187,89 @@ pub fn build_lookup_locations(plan: &[AddressLookupPlan]) -> Vec<LookupLocation>
     locations
 }
 
-/// Mutate a transaction in-place to patch account pubkeys within specific instructions.
+/// Apply a list of instruction-account mutations to a transaction in-place.
 ///
-/// Returns the updated `MessageAccountPlan` reflecting any newly appended keys.
+/// Returns the updated `MessageAccountPlan` reflecting any keys added to the
+/// message's static `account_keys` table.
 ///
-/// When a new pubkey must be added to the message's account keys:
+/// Operations apply in the order given; positions are interpreted against the
+/// instruction's state at the time each op runs (not the original list). To
+/// express positions relative to the pre-mutation list, list ops in
+/// descending position order.
+///
+/// When a new pubkey must be added to the message's static `account_keys`:
 /// - **Writable**: inserted just before the read-only non-signer section,
 ///   and all existing indices ≥ the insertion point are shifted by +1.
 /// - **Read-only**: appended at the end and `num_readonly_unsigned_accounts`
 ///   is incremented so the new key falls into the read-only range.
-pub fn apply_ix_account_patches(
-    tx: &mut VersionedTransaction,
-    patches: &[crate::types::InstructionAccountPatch],
-) -> Result<MessageAccountPlan> {
-    for patch in patches {
-        let instructions = tx.message.instructions();
-        if patch.instruction_index >= instructions.len() {
-            return Err(SonarSimError::Validation {
-                reason: format!(
-                    "Instruction index {} is out of range (transaction has {} instructions)",
-                    patch.instruction_index,
-                    instructions.len()
-                ),
-            });
-        }
-        if patch.account_position >= instructions[patch.instruction_index].accounts.len() {
-            return Err(SonarSimError::Validation {
-                reason: format!(
-                    "Account position {} is out of range for instruction {} (has {} accounts)",
-                    patch.account_position,
-                    patch.instruction_index,
-                    instructions[patch.instruction_index].accounts.len()
-                ),
-            });
-        }
-
-        let new_index =
-            find_or_insert_account_key(&mut tx.message, &patch.new_pubkey, patch.writable)?;
-
-        tx.message.instructions_mut()[patch.instruction_index].accounts[patch.account_position] =
-            new_index as u8;
-    }
-
-    Ok(MessageAccountPlan::from_transaction(tx))
-}
-
-/// Append accounts to the end of specific instructions' account lists.
 ///
-/// Returns the updated `MessageAccountPlan` reflecting any newly appended keys.
-/// Uses the same key-insertion logic as `apply_ix_account_patches`:
-/// writable keys are inserted before the read-only section; read-only keys
-/// are appended at the end.
+/// `Remove` does **not** garbage-collect the underlying key from
+/// `account_keys`; the key remains loadable by the runtime even if no
+/// instruction references it (matching how `Patch` leaves the replaced key
+/// in place).
 ///
-/// **Limitation (v0 messages with ALTs):** Duplicate detection only covers
-/// static account keys. If the appended pubkey is already loaded through an
-/// address lookup table, it will be added as a static key too, and the
-/// Solana runtime will reject the message with `AccountLoadedTwice`.
-/// ALT-resolved addresses are not available at mutation time.
-pub fn apply_ix_account_appends(
+/// **Limitation (v0 messages with ALTs):** duplicate detection only covers
+/// static account keys. If a `Patch`/`Insert` pubkey is already loaded
+/// through an address lookup table, it will be added as a static key too,
+/// and the Solana runtime will reject the message with `AccountLoadedTwice`.
+pub fn apply_ix_account_ops(
     tx: &mut VersionedTransaction,
-    appends: &[crate::types::InstructionAccountAppend],
+    ops: &[crate::types::InstructionAccountOp],
 ) -> Result<MessageAccountPlan> {
-    for append in appends {
-        let instructions = tx.message.instructions();
-        if append.instruction_index >= instructions.len() {
+    use crate::types::InstructionAccountOp;
+
+    for op in ops {
+        let ix_index = op.instruction_index();
+        let pos = op.account_position();
+        let ix_count = tx.message.instructions().len();
+        if ix_index >= ix_count {
             return Err(SonarSimError::Validation {
                 reason: format!(
-                    "Instruction index {} is out of range (transaction has {} instructions)",
-                    append.instruction_index,
-                    instructions.len()
+                    "Instruction index {ix_index} is out of range \
+                     (transaction has {ix_count} instructions)"
                 ),
             });
         }
+        let current_len = tx.message.instructions()[ix_index].accounts.len();
 
-        let new_index =
-            find_or_insert_account_key(&mut tx.message, &append.new_pubkey, append.writable)?;
-
-        tx.message.instructions_mut()[append.instruction_index].accounts.push(new_index as u8);
+        match op {
+            InstructionAccountOp::Patch { new_pubkey, writable, .. } => {
+                if pos >= current_len {
+                    return Err(SonarSimError::Validation {
+                        reason: format!(
+                            "Account position {pos} is out of range for instruction \
+                             {ix_index} (has {current_len} accounts)"
+                        ),
+                    });
+                }
+                let new_index = find_or_insert_account_key(&mut tx.message, new_pubkey, *writable)?;
+                tx.message.instructions_mut()[ix_index].accounts[pos] = new_index as u8;
+            }
+            InstructionAccountOp::Insert { new_pubkey, writable, .. } => {
+                if pos > current_len {
+                    return Err(SonarSimError::Validation {
+                        reason: format!(
+                            "Account position {pos} is out of range for instruction \
+                             {ix_index} (has {current_len} accounts; valid insert \
+                             positions are 0..={current_len})"
+                        ),
+                    });
+                }
+                let new_index = find_or_insert_account_key(&mut tx.message, new_pubkey, *writable)?;
+                tx.message.instructions_mut()[ix_index].accounts.insert(pos, new_index as u8);
+            }
+            InstructionAccountOp::Remove { .. } => {
+                if pos >= current_len {
+                    return Err(SonarSimError::Validation {
+                        reason: format!(
+                            "Account position {pos} is out of range for instruction \
+                             {ix_index} (has {current_len} accounts)"
+                        ),
+                    });
+                }
+                tx.message.instructions_mut()[ix_index].accounts.remove(pos);
+            }
+        }
     }
 
     Ok(MessageAccountPlan::from_transaction(tx))
@@ -666,13 +672,13 @@ mod tests {
         // (system_program is readonly unsigned)
         // Layout: [payer(ws)] [recipient(wu)] [system_program(ru)]
         let new_key = Pubkey::new_unique();
-        let patches = vec![crate::types::InstructionAccountPatch {
+        let patches = vec![crate::types::InstructionAccountOp::Patch {
             instruction_index: 0,
             account_position: 1,
             new_pubkey: new_key,
             writable: true,
         }];
-        let plan = apply_ix_account_patches(&mut tx, &patches).unwrap();
+        let plan = apply_ix_account_ops(&mut tx, &patches).unwrap();
         // Writable key inserted at position 2 (before readonly system_program),
         // system_program shifted to index 3.
         assert_eq!(plan.static_accounts.len(), 4);
@@ -687,13 +693,13 @@ mod tests {
     fn apply_ix_account_patches_readonly_appends_at_end() {
         let (mut tx, _payer) = sample_transaction();
         let new_key = Pubkey::new_unique();
-        let patches = vec![crate::types::InstructionAccountPatch {
+        let patches = vec![crate::types::InstructionAccountOp::Patch {
             instruction_index: 0,
             account_position: 1,
             new_pubkey: new_key,
             writable: false,
         }];
-        let plan = apply_ix_account_patches(&mut tx, &patches).unwrap();
+        let plan = apply_ix_account_ops(&mut tx, &patches).unwrap();
         // Read-only key appended at the end (index 3)
         assert_eq!(plan.static_accounts.len(), 4);
         assert_eq!(plan.static_accounts[3], new_key);
@@ -705,13 +711,13 @@ mod tests {
     #[test]
     fn apply_ix_account_patches_reuses_existing_key() {
         let (mut tx, payer) = sample_transaction();
-        let patches = vec![crate::types::InstructionAccountPatch {
+        let patches = vec![crate::types::InstructionAccountOp::Patch {
             instruction_index: 0,
             account_position: 1,
             new_pubkey: payer,
             writable: true,
         }];
-        let plan = apply_ix_account_patches(&mut tx, &patches).unwrap();
+        let plan = apply_ix_account_ops(&mut tx, &patches).unwrap();
         assert_eq!(plan.static_accounts.len(), 3);
         assert_eq!(tx.message.instructions()[0].accounts[1], 0);
     }
@@ -723,13 +729,13 @@ mod tests {
         // system_program is at index 2, readonly unsigned.
         // Patch instruction's account position 1 to system_program with :w.
         let system_program = tx.message.static_account_keys()[2];
-        let patches = vec![crate::types::InstructionAccountPatch {
+        let patches = vec![crate::types::InstructionAccountOp::Patch {
             instruction_index: 0,
             account_position: 1,
             new_pubkey: system_program,
             writable: true,
         }];
-        let plan = apply_ix_account_patches(&mut tx, &patches).unwrap();
+        let plan = apply_ix_account_ops(&mut tx, &patches).unwrap();
         // system_program should now be writable. Since it was the only readonly
         // non-signer, num_readonly_unsigned goes from 1 to 0.
         assert_eq!(tx.message.header().num_readonly_unsigned_accounts, 0);
@@ -743,13 +749,13 @@ mod tests {
         // sample tx: [payer(ws), recipient(wu), system_program(ru)]
         // recipient is at index 1, writable unsigned.
         let recipient = tx.message.static_account_keys()[1];
-        let patches = vec![crate::types::InstructionAccountPatch {
+        let patches = vec![crate::types::InstructionAccountOp::Patch {
             instruction_index: 0,
             account_position: 0,
             new_pubkey: recipient,
             writable: false,
         }];
-        let plan = apply_ix_account_patches(&mut tx, &patches).unwrap();
+        let plan = apply_ix_account_ops(&mut tx, &patches).unwrap();
         // recipient moved to readonly. num_readonly_unsigned goes from 1 to 2.
         assert_eq!(tx.message.header().num_readonly_unsigned_accounts, 2);
         assert_eq!(plan.static_accounts.len(), 3);
@@ -758,26 +764,26 @@ mod tests {
     #[test]
     fn apply_ix_account_patches_rejects_invalid_ix_index() {
         let (mut tx, _) = sample_transaction();
-        let patches = vec![crate::types::InstructionAccountPatch {
+        let patches = vec![crate::types::InstructionAccountOp::Patch {
             instruction_index: 99,
             account_position: 0,
             new_pubkey: Pubkey::new_unique(),
             writable: true,
         }];
-        let err = apply_ix_account_patches(&mut tx, &patches).unwrap_err();
+        let err = apply_ix_account_ops(&mut tx, &patches).unwrap_err();
         assert!(err.to_string().contains("out of range"));
     }
 
     #[test]
     fn apply_ix_account_patches_rejects_invalid_account_position() {
         let (mut tx, _) = sample_transaction();
-        let patches = vec![crate::types::InstructionAccountPatch {
+        let patches = vec![crate::types::InstructionAccountOp::Patch {
             instruction_index: 0,
             account_position: 99,
             new_pubkey: Pubkey::new_unique(),
             writable: true,
         }];
-        let err = apply_ix_account_patches(&mut tx, &patches).unwrap_err();
+        let err = apply_ix_account_ops(&mut tx, &patches).unwrap_err();
         assert!(err.to_string().contains("out of range"));
     }
 
@@ -785,14 +791,14 @@ mod tests {
     fn apply_ix_account_patches_v0_writable_insert_shifts_lookup_indices() {
         let (mut tx, _payer) = sample_v0_transaction_with_lookup_accounts();
         let new_key = Pubkey::new_unique();
-        let patches = vec![crate::types::InstructionAccountPatch {
+        let patches = vec![crate::types::InstructionAccountOp::Patch {
             instruction_index: 0,
             account_position: 0,
             new_pubkey: new_key,
             writable: true,
         }];
 
-        let plan = apply_ix_account_patches(&mut tx, &patches).unwrap();
+        let plan = apply_ix_account_ops(&mut tx, &patches).unwrap();
 
         // New key inserted into static keys before readonly unsigned section:
         // [payer, new_key, program]
@@ -810,14 +816,14 @@ mod tests {
     fn apply_ix_account_patches_v0_readonly_append_shifts_lookup_indices() {
         let (mut tx, _payer) = sample_v0_transaction_with_lookup_accounts();
         let new_key = Pubkey::new_unique();
-        let patches = vec![crate::types::InstructionAccountPatch {
+        let patches = vec![crate::types::InstructionAccountOp::Patch {
             instruction_index: 0,
             account_position: 1,
             new_pubkey: new_key,
             writable: false,
         }];
 
-        let plan = apply_ix_account_patches(&mut tx, &patches).unwrap();
+        let plan = apply_ix_account_ops(&mut tx, &patches).unwrap();
 
         // New readonly unsigned static key is appended at index 2.
         assert_eq!(plan.static_accounts.len(), 3);
@@ -873,156 +879,17 @@ mod tests {
     }
 
     #[test]
-    fn apply_ix_account_appends_writable() {
-        let (mut tx, _payer) = sample_transaction();
-        // sample tx: [payer(ws), recipient(wu), system_program(ru)]
-        // Instruction 0 accounts: [0, 1] with program_id_index=2
-        let new_key = Pubkey::new_unique();
-        let appends = vec![crate::types::InstructionAccountAppend {
-            instruction_index: 0,
-            new_pubkey: new_key,
-            writable: true,
-        }];
-        let plan = apply_ix_account_appends(&mut tx, &appends).unwrap();
-        // Writable key inserted at position 2 (before readonly system_program)
-        assert_eq!(plan.static_accounts.len(), 4);
-        assert_eq!(plan.static_accounts[2], new_key);
-        // The instruction should now have 3 accounts, with the new one appended
-        let ix = &tx.message.instructions()[0];
-        assert_eq!(ix.accounts.len(), 3);
-        assert_eq!(ix.accounts[2], 2); // new key at static index 2
-        // program_id_index should have shifted from 2 to 3
-        assert_eq!(ix.program_id_index, 3);
-    }
-
-    #[test]
-    fn apply_ix_account_appends_readonly() {
-        let (mut tx, _payer) = sample_transaction();
-        let new_key = Pubkey::new_unique();
-        let appends = vec![crate::types::InstructionAccountAppend {
-            instruction_index: 0,
-            new_pubkey: new_key,
-            writable: false,
-        }];
-        let plan = apply_ix_account_appends(&mut tx, &appends).unwrap();
-        // Read-only key appended at end (index 3)
-        assert_eq!(plan.static_accounts.len(), 4);
-        assert_eq!(plan.static_accounts[3], new_key);
-        let ix = &tx.message.instructions()[0];
-        assert_eq!(ix.accounts.len(), 3);
-        assert_eq!(ix.accounts[2], 3);
-        assert_eq!(tx.message.header().num_readonly_unsigned_accounts, 2);
-    }
-
-    #[test]
-    fn apply_ix_account_appends_reuses_existing_key() {
-        let (mut tx, payer) = sample_transaction();
-        let appends = vec![crate::types::InstructionAccountAppend {
-            instruction_index: 0,
-            new_pubkey: payer,
-            writable: true,
-        }];
-        let plan = apply_ix_account_appends(&mut tx, &appends).unwrap();
-        // No new key added
-        assert_eq!(plan.static_accounts.len(), 3);
-        let ix = &tx.message.instructions()[0];
-        assert_eq!(ix.accounts.len(), 3);
-        assert_eq!(ix.accounts[2], 0); // payer is at index 0
-    }
-
-    #[test]
-    fn apply_ix_account_appends_rejects_invalid_ix_index() {
-        let (mut tx, _) = sample_transaction();
-        let appends = vec![crate::types::InstructionAccountAppend {
-            instruction_index: 99,
-            new_pubkey: Pubkey::new_unique(),
-            writable: true,
-        }];
-        let err = apply_ix_account_appends(&mut tx, &appends).unwrap_err();
-        assert!(err.to_string().contains("out of range"));
-    }
-
-    #[test]
-    fn apply_ix_account_appends_multiple() {
-        let (mut tx, _payer) = sample_transaction();
-        let key1 = Pubkey::new_unique();
-        let key2 = Pubkey::new_unique();
-        let appends = vec![
-            crate::types::InstructionAccountAppend {
-                instruction_index: 0,
-                new_pubkey: key1,
-                writable: true,
-            },
-            crate::types::InstructionAccountAppend {
-                instruction_index: 0,
-                new_pubkey: key2,
-                writable: false,
-            },
-        ];
-        let plan = apply_ix_account_appends(&mut tx, &appends).unwrap();
-        assert_eq!(plan.static_accounts.len(), 5);
-        let ix = &tx.message.instructions()[0];
-        assert_eq!(ix.accounts.len(), 4); // original 2 + 2 appended
-    }
-
-    #[test]
-    fn apply_ix_account_appends_v0_writable_shifts_lookup_indices() {
-        let (mut tx, _payer) = sample_v0_transaction_with_lookup_accounts();
-        let new_key = Pubkey::new_unique();
-        let appends = vec![crate::types::InstructionAccountAppend {
-            instruction_index: 0,
-            new_pubkey: new_key,
-            writable: true,
-        }];
-        let plan = apply_ix_account_appends(&mut tx, &appends).unwrap();
-        // [payer, new_key, program] — new key inserted before readonly section
-        assert_eq!(plan.static_accounts.len(), 3);
-        assert_eq!(plan.static_accounts[1], new_key);
-        let ix = &tx.message.instructions()[0];
-        // Original accounts (2,3) shifted to (3,4), new key appended as account index 1
-        assert_eq!(ix.program_id_index, 2);
-        assert_eq!(ix.accounts.len(), 3);
-        assert_eq!(ix.accounts[2], 1); // appended account points to new_key
-    }
-
-    #[test]
-    fn apply_ix_account_appends_rejects_signer_writability_change() {
-        let (mut tx, payer) = sample_transaction();
-        // payer is a writable signer; requesting :r should error
-        let appends = vec![crate::types::InstructionAccountAppend {
-            instruction_index: 0,
-            new_pubkey: payer,
-            writable: false,
-        }];
-        let err = apply_ix_account_appends(&mut tx, &appends).unwrap_err();
-        assert!(err.to_string().contains("signer"));
-    }
-
-    #[test]
     fn apply_ix_account_patches_rejects_signer_writability_change() {
         let (mut tx, payer) = sample_transaction();
         // payer is a writable signer; patching to :r should error
-        let patches = vec![crate::types::InstructionAccountPatch {
+        let patches = vec![crate::types::InstructionAccountOp::Patch {
             instruction_index: 0,
             account_position: 0,
             new_pubkey: payer,
             writable: false,
         }];
-        let err = apply_ix_account_patches(&mut tx, &patches).unwrap_err();
+        let err = apply_ix_account_ops(&mut tx, &patches).unwrap_err();
         assert!(err.to_string().contains("signer"));
-    }
-
-    #[test]
-    fn apply_ix_account_appends_allows_signer_same_writability() {
-        let (mut tx, payer) = sample_transaction();
-        // payer is already writable; requesting :w (same) should succeed
-        let appends = vec![crate::types::InstructionAccountAppend {
-            instruction_index: 0,
-            new_pubkey: payer,
-            writable: true,
-        }];
-        let plan = apply_ix_account_appends(&mut tx, &appends).unwrap();
-        assert_eq!(plan.static_accounts.len(), 3);
     }
 
     #[test]
@@ -1049,15 +916,254 @@ mod tests {
             signatures: vec![Signature::default()],
             message: VersionedMessage::V0(message),
         };
-        // Appending a writable key inserts before readonly section (at pos 1),
-        // which would shift the 255 index to 256 — must error.
-        let appends = vec![crate::types::InstructionAccountAppend {
+        // Inserting a writable key adds it before the readonly section (at static
+        // pos 1), which would shift the existing 255 index to 256 — must error.
+        let inserts = vec![crate::types::InstructionAccountOp::Insert {
             instruction_index: 0,
+            account_position: 1,
             new_pubkey: Pubkey::new_unique(),
             writable: true,
         }];
-        let err = apply_ix_account_appends(&mut tx, &appends).unwrap_err();
+        let err = apply_ix_account_ops(&mut tx, &inserts).unwrap_err();
         assert!(err.to_string().contains("overflow"));
+    }
+
+    #[test]
+    fn apply_ix_account_inserts_at_front() {
+        let (mut tx, _payer) = sample_transaction();
+        // sample tx: [payer(ws), recipient(wu), system_program(ru)]
+        // Instruction 0 accounts: [0, 1] with program_id_index=2
+        let new_key = Pubkey::new_unique();
+        let inserts = vec![crate::types::InstructionAccountOp::Insert {
+            instruction_index: 0,
+            account_position: 0,
+            new_pubkey: new_key,
+            writable: true,
+        }];
+        let plan = apply_ix_account_ops(&mut tx, &inserts).unwrap();
+        // Writable key inserted into static keys at position 2 (before readonly section)
+        assert_eq!(plan.static_accounts.len(), 4);
+        assert_eq!(plan.static_accounts[2], new_key);
+        let ix = &tx.message.instructions()[0];
+        // Original [0, 1] shifted by static-keys insertion: 0 stays, 1 stays.
+        // New key (static index 2) inserted at instruction account_position 0.
+        assert_eq!(ix.accounts.len(), 3);
+        assert_eq!(ix.accounts, vec![2, 0, 1]);
+        // program_id_index should have shifted from 2 to 3
+        assert_eq!(ix.program_id_index, 3);
+    }
+
+    #[test]
+    fn apply_ix_account_inserts_in_middle() {
+        let (mut tx, _payer) = sample_transaction();
+        let new_key = Pubkey::new_unique();
+        let inserts = vec![crate::types::InstructionAccountOp::Insert {
+            instruction_index: 0,
+            account_position: 1,
+            new_pubkey: new_key,
+            writable: false,
+        }];
+        let plan = apply_ix_account_ops(&mut tx, &inserts).unwrap();
+        // Read-only key appended at the end of static keys (index 3)
+        assert_eq!(plan.static_accounts.len(), 4);
+        assert_eq!(plan.static_accounts[3], new_key);
+        let ix = &tx.message.instructions()[0];
+        // Original [0, 1] -> [0, 3, 1]
+        assert_eq!(ix.accounts, vec![0, 3, 1]);
+        assert_eq!(tx.message.header().num_readonly_unsigned_accounts, 2);
+    }
+
+    #[test]
+    fn apply_ix_account_inserts_at_end_equals_append() {
+        let (mut tx, _payer) = sample_transaction();
+        let new_key = Pubkey::new_unique();
+        let current_len = tx.message.instructions()[0].accounts.len();
+        let inserts = vec![crate::types::InstructionAccountOp::Insert {
+            instruction_index: 0,
+            account_position: current_len,
+            new_pubkey: new_key,
+            writable: false,
+        }];
+        let plan = apply_ix_account_ops(&mut tx, &inserts).unwrap();
+        assert_eq!(plan.static_accounts.len(), 4);
+        let ix = &tx.message.instructions()[0];
+        assert_eq!(ix.accounts.len(), current_len + 1);
+        assert_eq!(*ix.accounts.last().unwrap(), 3);
+    }
+
+    #[test]
+    fn apply_ix_account_inserts_reuses_existing_key() {
+        let (mut tx, payer) = sample_transaction();
+        let inserts = vec![crate::types::InstructionAccountOp::Insert {
+            instruction_index: 0,
+            account_position: 0,
+            new_pubkey: payer,
+            writable: true,
+        }];
+        let plan = apply_ix_account_ops(&mut tx, &inserts).unwrap();
+        assert_eq!(plan.static_accounts.len(), 3);
+        let ix = &tx.message.instructions()[0];
+        assert_eq!(ix.accounts.len(), 3);
+        assert_eq!(ix.accounts[0], 0); // payer reused at static index 0
+    }
+
+    #[test]
+    fn apply_ix_account_inserts_rejects_invalid_ix_index() {
+        let (mut tx, _) = sample_transaction();
+        let inserts = vec![crate::types::InstructionAccountOp::Insert {
+            instruction_index: 99,
+            account_position: 0,
+            new_pubkey: Pubkey::new_unique(),
+            writable: true,
+        }];
+        let err = apply_ix_account_ops(&mut tx, &inserts).unwrap_err();
+        assert!(err.to_string().contains("out of range"));
+    }
+
+    #[test]
+    fn apply_ix_account_inserts_rejects_position_past_end() {
+        let (mut tx, _) = sample_transaction();
+        let current_len = tx.message.instructions()[0].accounts.len();
+        let inserts = vec![crate::types::InstructionAccountOp::Insert {
+            instruction_index: 0,
+            account_position: current_len + 1,
+            new_pubkey: Pubkey::new_unique(),
+            writable: true,
+        }];
+        let err = apply_ix_account_ops(&mut tx, &inserts).unwrap_err();
+        assert!(err.to_string().contains("out of range"));
+    }
+
+    #[test]
+    fn apply_ix_account_inserts_v0_writable_shifts_lookup_indices() {
+        let (mut tx, _payer) = sample_v0_transaction_with_lookup_accounts();
+        let new_key = Pubkey::new_unique();
+        let inserts = vec![crate::types::InstructionAccountOp::Insert {
+            instruction_index: 0,
+            account_position: 1,
+            new_pubkey: new_key,
+            writable: true,
+        }];
+        let plan = apply_ix_account_ops(&mut tx, &inserts).unwrap();
+        // [payer, new_key, program] — new key inserted before readonly section
+        assert_eq!(plan.static_accounts.len(), 3);
+        assert_eq!(plan.static_accounts[1], new_key);
+        let ix = &tx.message.instructions()[0];
+        // Program index shifts (1 -> 2). Original instruction accounts (2,3) shift to (3,4),
+        // and new account index 1 is inserted at position 1.
+        assert_eq!(ix.program_id_index, 2);
+        assert_eq!(ix.accounts, vec![3, 1, 4]);
+    }
+
+    #[test]
+    fn apply_ix_account_removes_basic() {
+        let (mut tx, _payer) = sample_transaction();
+        // sample tx instruction 0: accounts = [0, 1] (payer, recipient)
+        let removes = vec![crate::types::InstructionAccountOp::Remove {
+            instruction_index: 0,
+            account_position: 1,
+        }];
+        let plan = apply_ix_account_ops(&mut tx, &removes).unwrap();
+        // Static account_keys is left intact: [payer, recipient, system_program]
+        assert_eq!(plan.static_accounts.len(), 3);
+        let ix = &tx.message.instructions()[0];
+        // Instruction account at position 1 removed; only payer reference remains.
+        assert_eq!(ix.accounts, vec![0]);
+        // program_id_index untouched.
+        assert_eq!(ix.program_id_index, 2);
+    }
+
+    #[test]
+    fn apply_ix_account_removes_at_front() {
+        let (mut tx, _payer) = sample_transaction();
+        let removes = vec![crate::types::InstructionAccountOp::Remove {
+            instruction_index: 0,
+            account_position: 0,
+        }];
+        apply_ix_account_ops(&mut tx, &removes).unwrap();
+        let ix = &tx.message.instructions()[0];
+        // [0, 1] -> [1]
+        assert_eq!(ix.accounts, vec![1]);
+    }
+
+    #[test]
+    fn apply_ix_account_removes_sequential_apply() {
+        // Insert two extra accounts so we have a 4-account list, then remove
+        // positions in user-listed (highest-first) order to demonstrate the
+        // recommended pattern.
+        let (mut tx, _payer) = sample_transaction();
+        let k1 = Pubkey::new_unique();
+        let k2 = Pubkey::new_unique();
+        // Insert at the end of the current accounts list (equivalent to appending).
+        let initial_len = tx.message.instructions()[0].accounts.len();
+        apply_ix_account_ops(
+            &mut tx,
+            &[
+                crate::types::InstructionAccountOp::Insert {
+                    instruction_index: 0,
+                    account_position: initial_len,
+                    new_pubkey: k1,
+                    writable: false,
+                },
+                crate::types::InstructionAccountOp::Insert {
+                    instruction_index: 0,
+                    account_position: initial_len + 1,
+                    new_pubkey: k2,
+                    writable: false,
+                },
+            ],
+        )
+        .unwrap();
+        // Now instruction 0 has 4 accounts.
+        let original = tx.message.instructions()[0].accounts.clone();
+        assert_eq!(original.len(), 4);
+
+        // Remove positions 3 then 1 (sequentially): drops original[3] and original[1].
+        let removes = vec![
+            crate::types::InstructionAccountOp::Remove { instruction_index: 0, account_position: 3 },
+            crate::types::InstructionAccountOp::Remove { instruction_index: 0, account_position: 1 },
+        ];
+        apply_ix_account_ops(&mut tx, &removes).unwrap();
+        let ix = &tx.message.instructions()[0];
+        assert_eq!(ix.accounts, vec![original[0], original[2]]);
+    }
+
+    #[test]
+    fn apply_ix_account_removes_rejects_invalid_ix_index() {
+        let (mut tx, _) = sample_transaction();
+        let removes = vec![crate::types::InstructionAccountOp::Remove {
+            instruction_index: 99,
+            account_position: 0,
+        }];
+        let err = apply_ix_account_ops(&mut tx, &removes).unwrap_err();
+        assert!(err.to_string().contains("out of range"));
+    }
+
+    #[test]
+    fn apply_ix_account_removes_rejects_position_out_of_bounds() {
+        let (mut tx, _) = sample_transaction();
+        let current_len = tx.message.instructions()[0].accounts.len();
+        let removes = vec![crate::types::InstructionAccountOp::Remove {
+            instruction_index: 0,
+            account_position: current_len,
+        }];
+        let err = apply_ix_account_ops(&mut tx, &removes).unwrap_err();
+        assert!(err.to_string().contains("out of range"));
+    }
+
+    #[test]
+    fn apply_ix_account_removes_v0_preserves_lookup_indices() {
+        let (mut tx, _payer) = sample_v0_transaction_with_lookup_accounts();
+        // Original instruction 0 accounts: [2, 3] (lookup-derived).
+        let removes = vec![crate::types::InstructionAccountOp::Remove {
+            instruction_index: 0,
+            account_position: 0,
+        }];
+        apply_ix_account_ops(&mut tx, &removes).unwrap();
+        let ix = &tx.message.instructions()[0];
+        // Static keys untouched, so the surviving lookup index 3 is still valid.
+        assert_eq!(ix.accounts, vec![3]);
+        assert_eq!(ix.program_id_index, 1);
     }
 
     #[test]

--- a/crates/sonar-sim/src/types/accounts.rs
+++ b/crates/sonar-sim/src/types/accounts.rs
@@ -33,21 +33,56 @@ pub struct InstructionDataPatch {
     pub data: Vec<u8>,
 }
 
+/// A mutation to apply to an instruction's account list.
+///
+/// Operations apply in the order they appear in the mutation list. Positions
+/// are interpreted against the instruction's state at the time the op runs,
+/// not the original list. To express positions relative to the pre-mutation
+/// list, specify ops in descending position order.
+///
+/// `account_position` is 0-based at this layer; CLI surfaces convert from
+/// 1-based.
 #[derive(Clone, Debug)]
-pub struct InstructionAccountPatch {
-    pub instruction_index: usize,
-    pub account_position: usize,
-    pub new_pubkey: Pubkey,
-    /// Whether the new account should be writable. Default: `true`.
-    pub writable: bool,
+pub enum InstructionAccountOp {
+    /// Replace the account at `account_position` with `new_pubkey`.
+    Patch {
+        instruction_index: usize,
+        account_position: usize,
+        new_pubkey: Pubkey,
+        writable: bool,
+    },
+    /// Insert `new_pubkey` at `account_position`. Existing accounts at and
+    /// after this position shift right by one. `account_position` may equal
+    /// the current account count to insert at the end.
+    Insert {
+        instruction_index: usize,
+        account_position: usize,
+        new_pubkey: Pubkey,
+        writable: bool,
+    },
+    /// Remove the account reference at `account_position`. Subsequent accounts
+    /// shift left by one. The static `account_keys` table is left untouched:
+    /// the underlying key may now be unreferenced but remains loadable by the
+    /// message (matching how `Patch` leaves the replaced key in place).
+    Remove { instruction_index: usize, account_position: usize },
 }
 
-#[derive(Clone, Debug)]
-pub struct InstructionAccountAppend {
-    pub instruction_index: usize,
-    pub new_pubkey: Pubkey,
-    /// Whether the appended account should be writable. Default: `true`.
-    pub writable: bool,
+impl InstructionAccountOp {
+    pub fn instruction_index(&self) -> usize {
+        match self {
+            Self::Patch { instruction_index, .. }
+            | Self::Insert { instruction_index, .. }
+            | Self::Remove { instruction_index, .. } => *instruction_index,
+        }
+    }
+
+    pub fn account_position(&self) -> usize {
+        match self {
+            Self::Patch { account_position, .. }
+            | Self::Insert { account_position, .. }
+            | Self::Remove { account_position, .. } => *account_position,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/sonar-sim/src/types/mod.rs
+++ b/crates/sonar-sim/src/types/mod.rs
@@ -4,8 +4,8 @@ mod simulation;
 mod traits;
 
 pub use accounts::{
-    AccountDataPatch, AccountOverride, InstructionAccountAppend, InstructionAccountPatch,
-    InstructionDataPatch, ResolvedAccounts, ResolvedLookup,
+    AccountDataPatch, AccountOverride, InstructionAccountOp, InstructionDataPatch,
+    ResolvedAccounts, ResolvedLookup,
 };
 pub use funding::{PreparedTokenFunding, SolFunding, TokenAmount, TokenFunding};
 pub use simulation::{ReturnData, SimulationMetadata};

--- a/docs/simulate.md
+++ b/docs/simulate.md
@@ -90,16 +90,27 @@ sonar simulate <TX> \
 sonar simulate <TX> --rpc-url <RPC_URL> \
   --patch-ix-account 2.3=<NEW_PUBKEY>:r
 
-# Append an account to instruction 1's account list
-# Format: <IX>=<PUBKEY>[:<w|r>] with a 1-based instruction index
-# :w is the default; use :r for read-only (useful for remaining_accounts)
+# Insert an account at a specific position within instruction 1's account list
+# Format: <IX>.<POSITION>=<PUBKEY>[:<w|r>] with 1-based indices
+# Existing accounts at and after POSITION shift right by one.
+# POSITION may equal current_count + 1 to insert at the end (push semantics).
 sonar simulate <TX> --rpc-url <RPC_URL> \
-  --append-ix-account 1=<PUBKEY>
+  --insert-ix-account 1.3=<PUBKEY>:r
 
-# Append multiple accounts (appended in order)
+# Remove an account at a specific position from instruction 1's account list
+# Format: <IX>.<POSITION> with 1-based indices
+# Subsequent accounts shift left by one. The static account_keys table is left
+# intact (unreferenced keys remain, mirroring --patch-ix-account behavior).
 sonar simulate <TX> --rpc-url <RPC_URL> \
-  --append-ix-account 1=<PUBKEY1> \
-  --append-ix-account 1=<PUBKEY2>:r
+  --remove-ix-account 1.4 \
+  --remove-ix-account 1.2
+
+# Ordering note for instruction-account ops:
+# Ops apply in flag order (all patches → all inserts → all removes); within each
+# flag, CLI argument order is preserved. Positions are interpreted at apply time
+# (not against the original list). To express positions relative to the
+# pre-mutation list, list ops in descending position order — e.g. above we
+# remove position 4 before position 2 so both refer to the original numbering.
 
 # Patch instruction data before simulation
 # Format: <IX>=<OFFSET>:<HEX_DATA> with a 1-based instruction index

--- a/src/cli/simulate.rs
+++ b/src/cli/simulate.rs
@@ -68,6 +68,7 @@ pub struct SimulateArgs {
     /// Format: <IX>.<ACCOUNT>=<NEW_PUBKEY>[:<w|r>] (1-based indices)
     /// Append :w (default) for writable, :r for read-only.
     /// Example: --patch-ix-account 1.3=So11111111111111111111111111111111111111112:r
+    /// Ordering: see --insert-ix-account.
     #[arg(
         short = 'A',
         long = "patch-ix-account",
@@ -77,18 +78,38 @@ pub struct SimulateArgs {
         value_parser = clap::builder::NonEmptyStringValueParser::new()
     )]
     pub ix_account_patches: Vec<String>,
-    /// Append an account to the end of a specific instruction's account list.
-    /// Format: <IX>=<PUBKEY>[:<w|r>] (1-based instruction index)
+    /// Insert an account at a specific position within an instruction's account list.
+    /// Format: <IX>.<POSITION>=<PUBKEY>[:<w|r>] (1-based indices)
+    /// Existing accounts at and after POSITION shift right by one.
+    /// To insert at the end, pass POSITION = current_count + 1.
     /// Append :w (default) for writable, :r for read-only.
-    /// Example: --append-ix-account 2=So11111111111111111111111111111111111111112
+    /// Example: --insert-ix-account 1.3=So11111111111111111111111111111111111111112:r
+    /// Ordering: instruction-account ops apply in flag order — all --patch-ix-account
+    /// first, then --insert-ix-account, then --remove-ix-account; within each flag,
+    /// CLI argument order is preserved. Positions are interpreted at apply time, so
+    /// to express positions relative to the pre-mutation list, list ops in
+    /// descending position order.
     #[arg(
-        long = "append-ix-account",
+        long = "insert-ix-account",
         help_heading = HELP_HEADING_STATE_PREPARATION,
-        value_name = "APPEND",
+        value_name = "INSERT",
         num_args = 1..,
         value_parser = clap::builder::NonEmptyStringValueParser::new()
     )]
-    pub ix_account_appends: Vec<String>,
+    pub ix_account_inserts: Vec<String>,
+    /// Remove an account at a specific position from an instruction's account list.
+    /// Format: <IX>.<POSITION> (1-based indices)
+    /// Subsequent accounts in the same instruction shift left by one.
+    /// Example: --remove-ix-account 1.3
+    /// Ordering: see --insert-ix-account.
+    #[arg(
+        long = "remove-ix-account",
+        help_heading = HELP_HEADING_STATE_PREPARATION,
+        value_name = "REMOVE",
+        num_args = 1..,
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
+    )]
+    pub ix_account_removes: Vec<String>,
     /// Patch bytes in an instruction's data field before simulation.
     /// Format: <IX>=<OFFSET>:<HEX_DATA> (1-based instruction index)
     /// HEX_DATA may optionally start with 0x.
@@ -197,8 +218,8 @@ pub struct TransactionInputArgs {
 }
 
 pub use sonar_sim::internals::{
-    AccountDataPatch, AccountOverride, InstructionAccountAppend, InstructionAccountPatch,
-    InstructionDataPatch, SolFunding, TokenAmount, TokenFunding,
+    AccountDataPatch, AccountOverride, InstructionAccountOp, InstructionDataPatch, SolFunding,
+    TokenAmount, TokenFunding,
 };
 
 /// Parse a pubkey string with an optional `:w` (writable) or `:r` (read-only)
@@ -353,12 +374,15 @@ pub fn parse_data_patch(raw: &str) -> Result<AccountDataPatch, String> {
     Ok(AccountDataPatch { pubkey, offset, data })
 }
 
-pub fn parse_ix_account_patch(raw: &str) -> Result<InstructionAccountPatch, String> {
-    let (position_str, value_str) = raw.split_once('=').ok_or_else(|| {
-        "Patch must be in <IX>.<ACCOUNT>=<NEW_PUBKEY>[:<w|r>] format (1-based indices)".to_string()
-    })?;
-    let (ix_str, pos_str) = position_str.split_once('.').ok_or_else(|| {
-        "Patch position must be in <IX>.<ACCOUNT> format (missing `.`)".to_string()
+/// Parse a `<IX>.<POSITION>` head (1-based) optionally followed by `=<rest>`.
+/// Returns 0-based indices and the remainder after `=`, if any.
+fn parse_ix_pos_prefix(raw: &str) -> Result<(usize, usize, Option<&str>), String> {
+    let (head, rest) = match raw.split_once('=') {
+        Some((h, r)) => (h, Some(r)),
+        None => (raw, None),
+    };
+    let (ix_str, pos_str) = head.split_once('.').ok_or_else(|| {
+        "Expected `<IX>.<POSITION>` format (1-based indices, missing `.`)".to_string()
     })?;
     let ix_1based: usize = ix_str
         .trim()
@@ -374,30 +398,33 @@ pub fn parse_ix_account_patch(raw: &str) -> Result<InstructionAccountPatch, Stri
     if pos_1based == 0 {
         return Err("Account position is 1-based and must be >= 1".to_string());
     }
-
-    let (new_pubkey, writable) = parse_pubkey_with_writable_flag(value_str)?;
-    Ok(InstructionAccountPatch {
-        instruction_index: ix_1based - 1,
-        account_position: pos_1based - 1,
-        new_pubkey,
-        writable,
-    })
+    Ok((ix_1based - 1, pos_1based - 1, rest))
 }
 
-pub fn parse_ix_account_append(raw: &str) -> Result<InstructionAccountAppend, String> {
-    let (ix_str, value_str) = raw.split_once('=').ok_or_else(|| {
-        "Append must be in <IX>=<PUBKEY>[:<w|r>] format (1-based instruction index)".to_string()
+pub fn parse_ix_account_patch(raw: &str) -> Result<InstructionAccountOp, String> {
+    let (instruction_index, account_position, rest) = parse_ix_pos_prefix(raw)?;
+    let value_str = rest.ok_or_else(|| {
+        "Patch must be in <IX>.<ACCOUNT>=<NEW_PUBKEY>[:<w|r>] format".to_string()
     })?;
-    let ix_1based: usize = ix_str
-        .trim()
-        .parse()
-        .map_err(|err| format!("Failed to parse instruction index `{ix_str}`: {err}"))?;
-    if ix_1based == 0 {
-        return Err("Instruction index is 1-based and must be >= 1".to_string());
-    }
-
     let (new_pubkey, writable) = parse_pubkey_with_writable_flag(value_str)?;
-    Ok(InstructionAccountAppend { instruction_index: ix_1based - 1, new_pubkey, writable })
+    Ok(InstructionAccountOp::Patch { instruction_index, account_position, new_pubkey, writable })
+}
+
+pub fn parse_ix_account_insert(raw: &str) -> Result<InstructionAccountOp, String> {
+    let (instruction_index, account_position, rest) = parse_ix_pos_prefix(raw)?;
+    let value_str = rest.ok_or_else(|| {
+        "Insert must be in <IX>.<POSITION>=<PUBKEY>[:<w|r>] format".to_string()
+    })?;
+    let (new_pubkey, writable) = parse_pubkey_with_writable_flag(value_str)?;
+    Ok(InstructionAccountOp::Insert { instruction_index, account_position, new_pubkey, writable })
+}
+
+pub fn parse_ix_account_remove(raw: &str) -> Result<InstructionAccountOp, String> {
+    let (instruction_index, account_position, rest) = parse_ix_pos_prefix(raw)?;
+    if rest.is_some() {
+        return Err("Remove must be in <IX>.<POSITION> format (no `=<value>`)".to_string());
+    }
+    Ok(InstructionAccountOp::Remove { instruction_index, account_position })
 }
 
 pub fn parse_ix_data_patch(raw: &str) -> Result<InstructionDataPatch, String> {
@@ -973,9 +1000,14 @@ mod tests {
         let key = Pubkey::new_unique();
         let input = format!("1.3={key}");
         let parsed = parse_ix_account_patch(&input).expect("parses");
-        assert_eq!(parsed.instruction_index, 0); // 1-based → 0-based
-        assert_eq!(parsed.account_position, 2); // 1-based → 0-based
-        assert_eq!(parsed.new_pubkey, key);
+        let InstructionAccountOp::Patch { instruction_index, account_position, new_pubkey, .. } =
+            parsed
+        else {
+            panic!("expected Patch variant");
+        };
+        assert_eq!(instruction_index, 0); // 1-based → 0-based
+        assert_eq!(account_position, 2); // 1-based → 0-based
+        assert_eq!(new_pubkey, key);
     }
 
     #[test]
@@ -1021,27 +1053,28 @@ mod tests {
     #[test]
     fn parse_ix_account_patch_writable_suffix() {
         let key = Pubkey::new_unique();
-        let input = format!("1.1={key}:w");
-        let parsed = parse_ix_account_patch(&input).expect("parses");
-        assert!(parsed.writable);
-        assert_eq!(parsed.new_pubkey, key);
+        let parsed = parse_ix_account_patch(&format!("1.1={key}:w")).expect("parses");
+        assert!(matches!(
+            parsed,
+            InstructionAccountOp::Patch { writable: true, new_pubkey, .. } if new_pubkey == key
+        ));
     }
 
     #[test]
     fn parse_ix_account_patch_readonly_suffix() {
         let key = Pubkey::new_unique();
-        let input = format!("1.1={key}:r");
-        let parsed = parse_ix_account_patch(&input).expect("parses");
-        assert!(!parsed.writable);
-        assert_eq!(parsed.new_pubkey, key);
+        let parsed = parse_ix_account_patch(&format!("1.1={key}:r")).expect("parses");
+        assert!(matches!(
+            parsed,
+            InstructionAccountOp::Patch { writable: false, new_pubkey, .. } if new_pubkey == key
+        ));
     }
 
     #[test]
     fn parse_ix_account_patch_default_writable() {
         let key = Pubkey::new_unique();
-        let input = format!("1.1={key}");
-        let parsed = parse_ix_account_patch(&input).expect("parses");
-        assert!(parsed.writable);
+        let parsed = parse_ix_account_patch(&format!("1.1={key}")).expect("parses");
+        assert!(matches!(parsed, InstructionAccountOp::Patch { writable: true, .. }));
     }
 
     #[test]
@@ -1151,88 +1184,157 @@ mod tests {
     }
 
     #[test]
-    fn parse_ix_account_append_valid_writable() {
+    fn parse_ix_account_insert_basic() {
         let key = Pubkey::new_unique();
-        let input = format!("1={key}");
-        let parsed = parse_ix_account_append(&input).expect("parses");
-        assert_eq!(parsed.instruction_index, 0); // 1-based → 0-based
-        assert_eq!(parsed.new_pubkey, key);
-        assert!(parsed.writable);
+        let parsed = parse_ix_account_insert(&format!("2.3={key}")).unwrap();
+        let InstructionAccountOp::Insert {
+            instruction_index,
+            account_position,
+            new_pubkey,
+            writable,
+        } = parsed
+        else {
+            panic!("expected Insert variant");
+        };
+        assert_eq!(instruction_index, 1);
+        assert_eq!(account_position, 2);
+        assert_eq!(new_pubkey, key);
+        assert!(writable);
     }
 
     #[test]
-    fn parse_ix_account_append_readonly_suffix() {
+    fn parse_ix_account_insert_readonly_suffix() {
         let key = Pubkey::new_unique();
-        let input = format!("2={key}:r");
-        let parsed = parse_ix_account_append(&input).expect("parses");
-        assert_eq!(parsed.instruction_index, 1);
-        assert!(!parsed.writable);
+        let parsed = parse_ix_account_insert(&format!("1.1={key}:r")).unwrap();
+        assert!(matches!(
+            parsed,
+            InstructionAccountOp::Insert {
+                instruction_index: 0,
+                account_position: 0,
+                writable: false,
+                ..
+            }
+        ));
     }
 
     #[test]
-    fn parse_ix_account_append_writable_suffix() {
+    fn parse_ix_account_insert_rejects_zero_indices() {
         let key = Pubkey::new_unique();
-        let input = format!("1={key}:w");
-        let parsed = parse_ix_account_append(&input).expect("parses");
-        assert!(parsed.writable);
+        let err = parse_ix_account_insert(&format!("0.1={key}")).unwrap_err();
+        assert!(err.contains("Instruction index"));
+        let err = parse_ix_account_insert(&format!("1.0={key}")).unwrap_err();
+        assert!(err.contains("Account position"));
     }
 
     #[test]
-    fn parse_ix_account_append_rejects_zero_index() {
+    fn parse_ix_account_insert_rejects_invalid_format() {
         let key = Pubkey::new_unique();
-        let err = parse_ix_account_append(&format!("0={key}")).unwrap_err();
-        assert!(err.contains("1-based"));
-    }
-
-    #[test]
-    fn parse_ix_account_append_rejects_missing_equals() {
-        let err = parse_ix_account_append("1").unwrap_err();
+        let err = parse_ix_account_insert(&format!("1={key}")).unwrap_err();
         assert!(err.contains("format"));
     }
 
     #[test]
-    fn parse_ix_account_append_rejects_invalid_pubkey() {
-        let err = parse_ix_account_append("1=notakey").unwrap_err();
+    fn parse_ix_account_insert_rejects_invalid_pubkey() {
+        let err = parse_ix_account_insert("1.1=notakey").unwrap_err();
         assert!(err.contains("Failed to parse pubkey"));
     }
 
     #[test]
-    fn simulate_accepts_append_ix_account_flag() {
+    fn simulate_accepts_insert_ix_account_flag() {
         let key = Pubkey::new_unique();
         let cli = Cli::try_parse_from([
             "sonar",
             "simulate",
             "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
-            "--append-ix-account",
-            &format!("1={key}"),
+            "--insert-ix-account",
+            &format!("1.2={key}"),
         ])
-        .expect("should parse --append-ix-account");
+        .expect("should parse --insert-ix-account");
 
         let Some(Commands::Simulate(args)) = cli.command else {
             panic!("expected simulate subcommand");
         };
-        assert_eq!(args.ix_account_appends.len(), 1);
+        assert_eq!(args.ix_account_inserts.len(), 1);
     }
 
     #[test]
-    fn simulate_accepts_append_ix_account_multiple() {
+    fn simulate_accepts_insert_ix_account_multiple() {
         let key1 = Pubkey::new_unique();
         let key2 = Pubkey::new_unique();
         let cli = Cli::try_parse_from([
             "sonar",
             "simulate",
             "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
-            "--append-ix-account",
-            &format!("1={key1}"),
-            "--append-ix-account",
-            &format!("2={key2}:r"),
+            "--insert-ix-account",
+            &format!("1.1={key1}"),
+            "--insert-ix-account",
+            &format!("2.3={key2}:r"),
         ])
-        .expect("should parse --append-ix-account multiple times");
+        .expect("should parse --insert-ix-account multiple times");
 
         let Some(Commands::Simulate(args)) = cli.command else {
             panic!("expected simulate subcommand");
         };
-        assert_eq!(args.ix_account_appends.len(), 2);
+        assert_eq!(args.ix_account_inserts.len(), 2);
+    }
+
+    #[test]
+    fn parse_ix_account_remove_basic() {
+        let parsed = parse_ix_account_remove("2.3").unwrap();
+        assert!(matches!(
+            parsed,
+            InstructionAccountOp::Remove { instruction_index: 1, account_position: 2 }
+        ));
+    }
+
+    #[test]
+    fn parse_ix_account_remove_rejects_zero_indices() {
+        let err = parse_ix_account_remove("0.1").unwrap_err();
+        assert!(err.contains("Instruction index"));
+        let err = parse_ix_account_remove("1.0").unwrap_err();
+        assert!(err.contains("Account position"));
+    }
+
+    #[test]
+    fn parse_ix_account_remove_rejects_invalid_format() {
+        let err = parse_ix_account_remove("1=2").unwrap_err();
+        assert!(err.contains("format"));
+    }
+
+    #[test]
+    fn simulate_accepts_remove_ix_account_flag() {
+        let cli = Cli::try_parse_from([
+            "sonar",
+            "simulate",
+            "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "--remove-ix-account",
+            "1.2",
+        ])
+        .expect("should parse --remove-ix-account");
+
+        let Some(Commands::Simulate(args)) = cli.command else {
+            panic!("expected simulate subcommand");
+        };
+        assert_eq!(args.ix_account_removes.len(), 1);
+    }
+
+    #[test]
+    fn simulate_accepts_remove_ix_account_multiple() {
+        let cli = Cli::try_parse_from([
+            "sonar",
+            "simulate",
+            "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "--remove-ix-account",
+            "1.3",
+            "--remove-ix-account",
+            "1.1",
+        ])
+        .expect("should parse --remove-ix-account multiple times");
+
+        let Some(Commands::Simulate(args)) = cli.command else {
+            panic!("expected simulate subcommand");
+        };
+        assert_eq!(args.ix_account_removes.len(), 2);
     }
 
     #[test]

--- a/src/handlers/simulate.rs
+++ b/src/handlers/simulate.rs
@@ -8,8 +8,7 @@ use crate::utils::progress::Progress;
 use crate::{core::account_file, core::transaction, output};
 use sonar_sim::internals::{
     ExecutionOptions, PreparedSimulation, SimulationOptions, StateMutationOptions,
-    apply_ix_account_appends, apply_ix_account_patches, apply_ix_data_patches,
-    prepare_token_fundings,
+    apply_ix_account_ops, apply_ix_data_patches, prepare_token_fundings,
 };
 
 use super::common::{
@@ -26,28 +25,18 @@ fn parse_cli_args<T>(args: Vec<String>, parser: fn(&str) -> Result<T, String>) -
 /// the transaction summary so the renderer sees the updated state.
 fn apply_ix_mutations(
     parsed_tx: &mut transaction::ParsedTransaction,
-    ix_account_patches: &[sonar_sim::internals::InstructionAccountPatch],
-    ix_account_appends: &[sonar_sim::internals::InstructionAccountAppend],
+    ix_account_ops: &[sonar_sim::internals::InstructionAccountOp],
     ix_data_patches: &[sonar_sim::internals::InstructionDataPatch],
 ) -> Result<()> {
-    if !ix_account_patches.is_empty() {
-        parsed_tx.account_plan =
-            apply_ix_account_patches(&mut parsed_tx.transaction, ix_account_patches)
-                .context("Failed to apply instruction account patches")?;
-    }
-    if !ix_account_appends.is_empty() {
-        parsed_tx.account_plan =
-            apply_ix_account_appends(&mut parsed_tx.transaction, ix_account_appends)
-                .context("Failed to apply instruction account appends")?;
+    if !ix_account_ops.is_empty() {
+        parsed_tx.account_plan = apply_ix_account_ops(&mut parsed_tx.transaction, ix_account_ops)
+            .context("Failed to apply instruction account ops")?;
     }
     if !ix_data_patches.is_empty() {
         apply_ix_data_patches(&mut parsed_tx.transaction, ix_data_patches)
             .context("Failed to apply instruction data patches")?;
     }
-    if !ix_account_patches.is_empty()
-        || !ix_account_appends.is_empty()
-        || !ix_data_patches.is_empty()
-    {
+    if !ix_account_ops.is_empty() || !ix_data_patches.is_empty() {
         parsed_tx.summary = transaction::TransactionSummary::from_transaction(
             &parsed_tx.transaction,
             &parsed_tx.account_plan,
@@ -86,7 +75,8 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
         cache_dir,
         refresh_cache,
         no_idl_fetch,
-        ix_account_appends: ix_account_append_args,
+        ix_account_inserts: ix_account_insert_args,
+        ix_account_removes: ix_account_remove_args,
     } = args;
     // --cache-dir or --refresh-cache imply --cache
     let cache = cache || cache_dir.is_some() || refresh_cache;
@@ -101,8 +91,13 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
     let token_funding_requests = parse_cli_args(token_funding_args, cli::parse_token_funding)?;
     let account_data_patches = parse_cli_args(data_patch_args, cli::parse_data_patch)?;
     let account_closures = parse_cli_args(account_closure_args, cli::parse_close_account)?;
-    let ix_account_patches = parse_cli_args(ix_account_patch_args, cli::parse_ix_account_patch)?;
-    let ix_account_appends = parse_cli_args(ix_account_append_args, cli::parse_ix_account_append)?;
+    // CLI flags surface three families separately for ergonomics, but all feed
+    // into one ordered op list. Concatenate in flag-listed order: patches,
+    // inserts, removes. Within each family, CLI argument order is preserved.
+    let mut ix_account_ops: Vec<sonar_sim::internals::InstructionAccountOp> =
+        parse_cli_args(ix_account_patch_args, cli::parse_ix_account_patch)?;
+    ix_account_ops.extend(parse_cli_args(ix_account_insert_args, cli::parse_ix_account_insert)?);
+    ix_account_ops.extend(parse_cli_args(ix_account_remove_args, cli::parse_ix_account_remove)?);
     let ix_data_patches = parse_cli_args(ix_data_patch_args, cli::parse_ix_data_patch)?;
 
     // Build rendering options once; shared across all code paths.
@@ -136,8 +131,7 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
             &rpc_url,
             resolver_cache_location,
             token_funding_requests,
-            ix_account_patches,
-            ix_account_appends,
+            ix_account_ops,
             ix_data_patches,
             sim_opts,
             &render_opts,
@@ -162,7 +156,7 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
     let resolved_from = resolved_input.source.as_str().to_string();
     let mut parsed_tx = resolved_input.parsed_tx;
 
-    apply_ix_mutations(&mut parsed_tx, &ix_account_patches, &ix_account_appends, &ix_data_patches)?;
+    apply_ix_mutations(&mut parsed_tx, &ix_account_ops, &ix_data_patches)?;
 
     let cache_args = CachePrepareArgs {
         rpc_url: &rpc_url,
@@ -282,8 +276,7 @@ fn handle_bundle(
     rpc_url: &str,
     resolver_cache_location: Option<crate::core::cache::CacheLocation>,
     token_funding_requests: Vec<cli::TokenFunding>,
-    ix_account_patches: Vec<sonar_sim::internals::InstructionAccountPatch>,
-    ix_account_appends: Vec<sonar_sim::internals::InstructionAccountAppend>,
+    ix_account_ops: Vec<sonar_sim::internals::InstructionAccountOp>,
     ix_data_patches: Vec<sonar_sim::internals::InstructionDataPatch>,
     mut sim_opts: SimulationOptions,
     render_opts: &output::RenderOptions,
@@ -304,7 +297,7 @@ fn handle_bundle(
     log::info!("Successfully parsed {} transactions", parsed_txs.len());
 
     for parsed_tx in &mut parsed_txs {
-        apply_ix_mutations(parsed_tx, &ix_account_patches, &ix_account_appends, &ix_data_patches)?;
+        apply_ix_mutations(parsed_tx, &ix_account_ops, &ix_data_patches)?;
     }
 
     let cache_args = CachePrepareArgs {


### PR DESCRIPTION
## Summary

- Add `--insert-ix-account <IX>.<POS>=<KEY>[:w|r]` and `--remove-ix-account <IX>.<POS>` to `sonar simulate`, covering middle-insertion and removal cases that `--patch-ix-account` can't express.
- Collapse the three kinds (patch/insert/remove) behind a single `InstructionAccountOp` enum and one `apply_ix_account_ops` applier — eliminates ~140 lines of parallel applier code, parallel `TransactionMutations` vecs, parallel `MutationsBuilder` helpers, and the duplicated `<IX>.<POS>` CLI parser logic.
- Drop `--append-ix-account` (and `apply_ix_account_appends`) — use `--insert-ix-account 1.<count+1>=KEY` for push semantics.

## Behavior notes

- Op application order: `--patch-ix-account` → `--insert-ix-account` → `--remove-ix-account`; within each flag, CLI argument order is preserved.
- Positions are interpreted at apply time (against the current state of the instruction's account list, not the original). To express positions relative to the pre-mutation list, list ops in descending position order.
- `Remove` does not garbage-collect orphaned static keys from `account_keys`, mirroring how `Patch` leaves replaced keys in place.

## Breaking changes

`crates/sonar-sim` is documented as having no semver guarantees in `internals.rs`, but flagging the surface changes for downstream awareness:

- CLI: `--append-ix-account` removed.
- Types: `InstructionAccountPatch`/`InstructionAccountAppend`/`InstructionAccountInsert`/`InstructionAccountRemove` → `InstructionAccountOp` (struct enum with `Patch` / `Insert` / `Remove` variants).
- Builder: `patch_ix_account` / `append_ix_account` / `insert_ix_account` / `remove_ix_account` → `add_ix_account_op(InstructionAccountOp)`.
- Functions: `apply_ix_account_{patches,appends,inserts,removes}` → `apply_ix_account_ops`.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — 588 pass, 7 ignored
- [x] `cargo clippy` clean on touched files
- [x] `sonar simulate --help` renders new flags + ordering note
- [ ] Manual smoke test on a real transaction