### PR TITLE
feat(config): support SONAR_CONFIG env var for custom config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ sonar account <PUBKEY> --rpc-url https://api.mainnet-beta.solana.com
 | `borsh` | Serialize JSON to Borsh bytes or deserialize Borsh bytes to JSON |
 | `convert` | Format conversion |
 | `pda` | Derive a PDA from seeds |
-| `config` | Inspect or update `~/.config/sonar/config.toml` |
+| `config` | Inspect or update the config file (`SONAR_CONFIG` or `~/.config/sonar/config.toml`) |
 | `cache` | List, clean, or inspect cached account data |
 | `completions` | Generate shell completion scripts |
 

--- a/crates/sonar-idl/src/decode.rs
+++ b/crates/sonar-idl/src/decode.rs
@@ -392,8 +392,7 @@ pub(crate) fn parse_type_definition(
                     let variant = &variants[variant_index];
                     return Ok(match variant.fields.as_ref() {
                         Some(fields) => {
-                            let payload =
-                                parse_idl_fields_value(data, offset, fields, indexed)?;
+                            let payload = parse_idl_fields_value(data, offset, fields, indexed)?;
                             IdlValue::Struct(vec![(variant.name.clone(), payload)])
                         }
                         None => IdlValue::EnumUnit(variant.name.clone()),

--- a/crates/sonar-sim/src/rpc_transport.rs
+++ b/crates/sonar-sim/src/rpc_transport.rs
@@ -60,9 +60,9 @@ impl RpcTransport {
                     if let Some(err) = rpc.error {
                         return Err(SonarSimError::Rpc { reason: err.to_string() });
                     }
-                    return rpc.result.ok_or_else(|| SonarSimError::Rpc {
-                        reason: "empty result".into(),
-                    });
+                    return rpc
+                        .result
+                        .ok_or_else(|| SonarSimError::Rpc { reason: "empty result".into() });
                 }
                 Err(ureq::Error::StatusCode(status_code))
                     if (status_code == 429 || status_code == 503) && attempt < MAX_RETRIES =>
@@ -76,8 +76,7 @@ impl RpcTransport {
                         MAX_RETRIES,
                     );
                     thread::sleep(delay);
-                    last_err =
-                        Some(SonarSimError::Rpc { reason: format!("HTTP {status_code}") });
+                    last_err = Some(SonarSimError::Rpc { reason: format!("HTTP {status_code}") });
                 }
                 Err(e) => {
                     return Err(SonarSimError::Rpc { reason: e.to_string() });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,8 @@
 
 ## Config File
 
-Sonar reads configuration from `~/.config/sonar/config.toml`:
+Sonar reads configuration from `$SONAR_CONFIG` when set, otherwise from
+`~/.config/sonar/config.toml`:
 
 ```toml
 rpc_url = "https://api.mainnet-beta.solana.com"
@@ -29,10 +30,12 @@ cache_dir = "~/.sonar/cache"
 ```
 
 Priority: CLI arguments > environment variables > config file > defaults.
+`SONAR_CONFIG` may be an absolute path, relative path, or `~/` path.
 
 ## Config Command
 
-View or modify `~/.config/sonar/config.toml`:
+View or modify the resolved config file (`$SONAR_CONFIG` when set, otherwise
+`~/.config/sonar/config.toml`):
 
 ```bash
 # List all supported config items

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -2,7 +2,7 @@
 
 use clap::{Args, Subcommand};
 
-/// View or modify `~/.config/sonar/config.toml`.
+/// View or modify the resolved config file (`SONAR_CONFIG` or the default path).
 #[derive(Args, Debug)]
 #[command(after_help = "\
 EXAMPLES:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -116,7 +116,7 @@ pub enum Commands {
     /// Serialize or deserialize data using Borsh-compatible type descriptors
     #[command(next_line_help = true)]
     Borsh(BorshArgs),
-    /// View or modify ~/.config/sonar/config.toml
+    /// View or modify the resolved config file
     #[command(next_line_help = true)]
     Config(ConfigArgs),
 }

--- a/src/core/rpc_client.rs
+++ b/src/core/rpc_client.rs
@@ -13,8 +13,8 @@ use solana_transaction_status_client_types::{
     EncodedTransaction, TransactionStatus, UiTransactionEncoding, UiTransactionStatusMeta,
 };
 
-use sonar_sim::internals::rpc_json::{RpcAccountInfo, RpcResultValue};
 use sonar_sim::internals::RpcTransport;
+use sonar_sim::internals::rpc_json::{RpcAccountInfo, RpcResultValue};
 
 /// Lightweight Solana JSON-RPC client backed by [`RpcTransport`].
 pub struct RpcClient {

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn print_subcommand_help(name: &str) -> Result<()> {
 fn run() -> Result<()> {
     init_logger();
 
-    // Load ~/.config/sonar/config.toml and inject values into env vars
+    // Load the resolved config file and inject values into env vars
     // before clap parses, so that CLI arg > env var > config file > default.
     crate::utils::config::load_and_apply();
 

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -964,9 +964,7 @@ fn leaf_str(value: &Value) -> Cow<'_, str> {
     match value {
         Value::String(s) => {
             if s.chars().any(|c| c.is_control()) {
-                Cow::Owned(
-                    s.chars().map(|c| if c.is_control() { '\u{FFFD}' } else { c }).collect(),
-                )
+                Cow::Owned(s.chars().map(|c| if c.is_control() { '\u{FFFD}' } else { c }).collect())
             } else {
                 Cow::Borrowed(s.as_str())
             }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -1,8 +1,13 @@
 //! Configuration file support for sonar.
 //!
-//! Loads settings from `~/.config/sonar/config.toml` and applies them as
-//! environment variables before CLI parsing, so that clap's built-in
-//! priority chain (CLI arg > env var > default) is preserved.
+//! Loads settings from a config file and applies them as environment variables
+//! before CLI parsing, so that clap's built-in priority chain
+//! (CLI arg > env var > default) is preserved.
+//!
+//! ## Config file location
+//!
+//! 1. `$SONAR_CONFIG` environment variable (with tilde expansion), or
+//! 2. `$HOME/.config/sonar/config.toml` (default)
 //!
 //! # Example config
 //!
@@ -21,7 +26,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
-/// User configuration loaded from `~/.config/sonar/config.toml`.
+/// User configuration loaded from the config file.
+///
+/// See [module-level docs](index.html#config-file-location) for path resolution.
 #[derive(Debug, Deserialize, Default)]
 pub struct SonarConfig {
     /// Default Solana RPC URL.  Maps to `RPC_URL` env var.
@@ -158,15 +165,23 @@ pub fn parse_config_key(key: &str) -> Option<ConfigKey> {
     }
 }
 
-/// Returns the default config file path: `$HOME/.config/sonar/config.toml`.
+/// Returns the config file path.
+///
+/// When the `SONAR_CONFIG` environment variable is set, its value is used
+/// (with tilde expansion). Otherwise falls back to `$HOME/.config/sonar/config.toml`.
 fn default_config_path() -> Option<PathBuf> {
+    if let Ok(custom) = std::env::var("SONAR_CONFIG") {
+        return Some(PathBuf::from(expand_tilde(&custom)));
+    }
     let home = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")).ok()?;
     Some(PathBuf::from(home).join(".config").join("sonar").join("config.toml"))
 }
 
-/// Returns the default config file path as a fallible API.
+/// Returns the resolved config file path as a fallible API.
+///
+/// Respects `$SONAR_CONFIG`; falls back to `~/.config/sonar/config.toml`.
 pub fn config_path() -> Result<PathBuf> {
-    default_config_path().context("Unable to determine home directory for config file path")
+    default_config_path().context("Unable to determine config file path")
 }
 
 /// Expand a leading `~` to the user's home directory.
@@ -179,7 +194,9 @@ pub(crate) fn expand_tilde(path: &str) -> String {
     path.to_string()
 }
 
-/// Load config from the default location.
+/// Load config from the resolved config file path.
+///
+/// Respects `$SONAR_CONFIG`; falls back to `~/.config/sonar/config.toml`.
 ///
 /// Returns `SonarConfig::default()` when the file does not exist or cannot be parsed.
 pub fn load_config() -> SonarConfig {
@@ -462,6 +479,43 @@ mod tests {
                 .unwrap_err();
         assert!(err.to_string().contains("Failed to parse config file"));
 
+        cleanup_temp_path(&path);
+    }
+
+    #[test]
+    fn sonar_config_env_var_overrides_path() {
+        let custom = unique_temp_path("env-override");
+        std::env::set_var("SONAR_CONFIG", custom.to_str().unwrap());
+        let resolved = default_config_path().expect("path should resolve");
+        std::env::remove_var("SONAR_CONFIG");
+        assert_eq!(resolved, custom);
+        cleanup_temp_path(&custom);
+    }
+
+    #[test]
+    fn sonar_config_env_var_expands_tilde() {
+        if std::env::var("HOME").is_ok() {
+            let home = std::env::var("HOME").unwrap();
+            std::env::set_var("SONAR_CONFIG", "~/test-sonar-config.toml");
+            let resolved = default_config_path().expect("path should resolve");
+            std::env::remove_var("SONAR_CONFIG");
+            assert!(resolved.starts_with(&home));
+            assert!(resolved.ends_with("test-sonar-config.toml"));
+        }
+    }
+
+    #[test]
+    fn load_config_reads_from_sonar_config_env() {
+        let path = unique_temp_path("load-env");
+        // Write a config file with a custom rpc_url
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "rpc_url = \"https://sonar-config-env.example.com\"\n").unwrap();
+
+        std::env::set_var("SONAR_CONFIG", path.to_str().unwrap());
+        let config = load_config();
+        std::env::remove_var("SONAR_CONFIG");
+
+        assert_eq!(config.rpc_url.as_deref(), Some("https://sonar-config-env.example.com"));
         cleanup_temp_path(&path);
     }
 


### PR DESCRIPTION
## Summary

Adds support for the `SONAR_CONFIG` environment variable to specify a custom config file path, with tilde expansion.

## Changes

- **`src/utils/config.rs`**: `default_config_path()` now checks `$SONAR_CONFIG` first (with tilde expansion), falls back to `~/.config/sonar/config.toml`
- Updated module docs and function docs to document the new resolution order
- Added three unit tests:
  - `sonar_config_env_var_overrides_path` — env var overrides default
  - `sonar_config_env_var_expands_tilde` — tilde expansion works
  - `load_config_reads_from_sonar_config_env` — config loads from env-specified path
- Minor formatting fixes in `decode.rs`, `rpc_transport.rs`, `rpc_client.rs`, `text.rs`

## Config file location priority

1. `$SONAR_CONFIG` environment variable (with tilde expansion)
2. `$HOME/.config/sonar/config.toml` (default)