### PR TITLE
refactor(idl): clarify decode fallback handling

### DIFF
--- a/crates/sonar-idl/src/decode.rs
+++ b/crates/sonar-idl/src/decode.rs
@@ -174,13 +174,7 @@ pub(crate) fn parse_simple_type(
             (IdlValue::Bool(value), 1)
         }
         "string" => {
-            check_data_len(data, start, 4)?;
-            let length = u32::from_le_bytes([
-                data[start],
-                data[start + 1],
-                data[start + 2],
-                data[start + 3],
-            ]) as usize;
+            let length = read_len_prefix(data, start)?;
             let content_start = start + 4;
             check_data_len(data, content_start, length)?;
             let string_data = &data[content_start..content_start + length];
@@ -188,23 +182,13 @@ pub(crate) fn parse_simple_type(
             (IdlValue::String(value), 4 + length)
         }
         "bytes" => {
-            check_data_len(data, start, 4)?;
-            let length = u32::from_le_bytes([
-                data[start],
-                data[start + 1],
-                data[start + 2],
-                data[start + 3],
-            ]) as usize;
+            let length = read_len_prefix(data, start)?;
             let content_start = start + 4;
             check_data_len(data, content_start, length)?;
             let bytes = data[content_start..content_start + length].to_vec();
             (IdlValue::Bytes(bytes), 4 + length)
         }
-        _ => {
-            let remaining = &data[start..];
-            let bytes_read = remaining.len().min(32);
-            (raw_unparsed_value("simple_type", type_name, &remaining[..bytes_read]), bytes_read)
-        }
+        _ => (consume_raw_fallback(data, &mut *offset, "simple_type", type_name), 0),
     };
 
     *offset += bytes_read;
@@ -217,12 +201,7 @@ pub(crate) fn parse_vec_type(
     element_type: &IdlType,
     indexed: &IndexedIdl,
 ) -> Result<IdlValue> {
-    let start = *offset;
-    check_data_len(data, start, 4)?;
-
-    let length =
-        u32::from_le_bytes([data[start], data[start + 1], data[start + 2], data[start + 3]])
-            as usize;
+    let length = read_len_prefix(data, *offset)?;
     *offset += 4;
 
     let mut elements = Vec::with_capacity(length);
@@ -278,11 +257,7 @@ fn parse_defined_type(
         return parse_type_definition(data, offset, type_def, indexed);
     }
 
-    let start = *offset;
-    let remaining = &data[start..];
-    let bytes_read = remaining.len().min(32);
-    *offset += bytes_read;
-    Ok(raw_unparsed_value("defined_type", defined.name(), &remaining[..bytes_read]))
+    Ok(consume_raw_fallback(data, offset, "defined_type", defined.name()))
 }
 
 pub(crate) fn parse_type_definition(
@@ -318,11 +293,7 @@ pub(crate) fn parse_type_definition(
         IdlTypeDefinitionKind::Other(_) => {}
     }
 
-    let start = *offset;
-    let remaining = &data[start..];
-    let bytes_read = remaining.len().min(32);
-    *offset += bytes_read;
-    Ok(raw_unparsed_value("type_definition", &type_def.name, &remaining[..bytes_read]))
+    Ok(consume_raw_fallback(data, offset, "type_definition", &type_def.name))
 }
 
 fn check_data_len(data: &[u8], offset: usize, required: usize) -> Result<()> {
@@ -336,4 +307,25 @@ fn check_data_len(data: &[u8], offset: usize, required: usize) -> Result<()> {
     } else {
         Ok(())
     }
+}
+
+/// Read a 4-byte little-endian length prefix at `offset` (Borsh `Vec`/`String`/bytes layout).
+fn read_len_prefix(data: &[u8], offset: usize) -> Result<usize> {
+    check_data_len(data, offset, 4)?;
+    Ok(u32::from_le_bytes([data[offset], data[offset + 1], data[offset + 2], data[offset + 3]])
+        as usize)
+}
+
+/// Decode failure fallback: cap remaining bytes at 32, advance the offset, and
+/// emit an `IdlValue::Struct` carrying context + type hint + raw hex.
+fn consume_raw_fallback(
+    data: &[u8],
+    offset: &mut usize,
+    context: &str,
+    type_name: &str,
+) -> IdlValue {
+    let remaining = &data[*offset..];
+    let bytes_read = remaining.len().min(32);
+    *offset += bytes_read;
+    raw_unparsed_value(context, type_name, &remaining[..bytes_read])
 }

--- a/crates/sonar-idl/src/indexed.rs
+++ b/crates/sonar-idl/src/indexed.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::ops::Deref;
 
 use crate::decode::{
     parse_idl_fields_as_parsed_fields, parse_instruction_args, parse_type_definition,
@@ -55,20 +54,6 @@ impl IdlInstructionFields {
         match self {
             Self::Unparsed(raw_args_hex) => Some(raw_args_hex),
             _ => None,
-        }
-    }
-}
-
-/// **Caution:** Returns an empty slice for `Unparsed`, which is indistinguishable from a
-/// zero-arg instruction. Use [`IdlInstructionFields::parsed_fields`] when you need to
-/// differentiate between "no arguments" and "failed to decode".
-impl Deref for IdlInstructionFields {
-    type Target = [IdlParsedField];
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            Self::Parsed(fields) => fields.as_slice(),
-            Self::Unparsed(_) => &[],
         }
     }
 }
@@ -279,41 +264,21 @@ impl IndexedIdl {
     }
 
     pub(crate) fn find_instruction_by_discriminator(&self, data: &[u8]) -> Option<&IdlInstruction> {
-        for (disc, idx) in &self.instruction_discriminators {
-            if data.len() >= disc.len() && data[..disc.len()] == disc[..] {
-                return self.idl.instructions.get(*idx);
-            }
-        }
-        None
+        let (idx, _) = match_disc(&self.instruction_discriminators, data)?;
+        self.idl.instructions.get(idx)
     }
 
     fn find_event_by_discriminator(&self, data: &[u8]) -> Option<(&IdlEvent, usize)> {
-        for (disc, idx) in &self.event_discriminators {
-            if data.len() >= disc.len() && &data[..disc.len()] == disc.as_slice() {
-                return self
-                    .idl
-                    .events
-                    .as_ref()
-                    .and_then(|events| events.get(*idx).map(|e| (e, disc.len())));
-            }
-        }
-        None
+        let (idx, disc_len) = match_disc(&self.event_discriminators, data)?;
+        self.idl.events.as_ref().and_then(|events| events.get(idx).map(|e| (e, disc_len)))
     }
 
     fn find_account_type_by_discriminator(
         &self,
         data: &[u8],
     ) -> Option<(&IdlTypeDefinition, usize)> {
-        for (disc, idx) in &self.account_discriminators {
-            if data.len() >= disc.len() && &data[..disc.len()] == disc.as_slice() {
-                return self
-                    .idl
-                    .types
-                    .as_ref()
-                    .and_then(|types| types.get(*idx).map(|td| (td, disc.len())));
-            }
-        }
-        None
+        let (idx, disc_len) = match_disc(&self.account_discriminators, data)?;
+        self.idl.types.as_ref().and_then(|types| types.get(idx).map(|td| (td, disc_len)))
     }
 
     pub(crate) fn find_type_definition(&self, name: &str) -> Option<&IdlTypeDefinition> {
@@ -346,6 +311,20 @@ pub fn is_cpi_event_data(data: &[u8]) -> bool {
 }
 
 // ── Internal helpers ──
+
+/// Longest-prefix match against a discriminator table.
+///
+/// Tables are sorted longest-first by the caller so the first prefix hit is
+/// the most specific one. Returns the matched index into the source collection
+/// plus the discriminator length (so callers can skip it).
+fn match_disc(discs: &[(Vec<u8>, usize)], data: &[u8]) -> Option<(usize, usize)> {
+    for (disc, idx) in discs {
+        if data.len() >= disc.len() && data[..disc.len()] == disc[..] {
+            return Some((*idx, disc.len()));
+        }
+    }
+    None
+}
 
 fn flatten_account_names(accounts: &[IdlAccountItem]) -> Vec<String> {
     let mut names = Vec::new();

--- a/crates/sonar-idl/src/tests/decode.rs
+++ b/crates/sonar-idl/src/tests/decode.rs
@@ -354,10 +354,11 @@ fn parse_instruction_with_defined_tuple_struct_arg_supports_nested_types() {
 
     let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
 
-    assert_eq!(parsed.fields.len(), 1);
-    assert_eq!(parsed.fields[0].name, "payload");
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name, "payload");
     assert_eq!(
-        parsed.fields[0].value,
+        fields[0].value,
         IdlValue::Array(vec![
             IdlValue::U32(777),
             IdlValue::Struct(vec![("amount".into(), IdlValue::U16(42))]),
@@ -403,7 +404,8 @@ fn parse_enum_with_struct_variant() {
     data.extend_from_slice(&100u16.to_le_bytes());
 
     let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
-    let val = &parsed.fields[0].value;
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    let val = &fields[0].value;
     assert_eq!(
         *val,
         IdlValue::Struct(vec![(
@@ -448,7 +450,8 @@ fn parse_enum_with_tuple_variant() {
     data.extend_from_slice(&222u32.to_le_bytes());
 
     let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
-    let val = &parsed.fields[0].value;
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    let val = &fields[0].value;
     assert_eq!(
         *val,
         IdlValue::Struct(vec![(
@@ -485,7 +488,8 @@ fn parse_enum_out_of_range_variant_index_falls_through() {
     data.push(99);
 
     let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
-    if let IdlValue::Struct(entries) = &parsed.fields[0].value {
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    if let IdlValue::Struct(entries) = &fields[0].value {
         let keys: Vec<&str> = entries.iter().map(|(k, _)| k.as_str()).collect();
         assert!(keys.contains(&"raw_hex"));
     } else {

--- a/crates/sonar-idl/src/tests/event.rs
+++ b/crates/sonar-idl/src/tests/event.rs
@@ -62,9 +62,10 @@ fn indexed_idl_parse_cpi_event_data_parses_event_fields() {
     let parsed = result.expect("should parse event");
 
     assert_eq!(parsed.name, "TransferDone");
-    assert_eq!(parsed.fields.len(), 1);
-    assert_eq!(parsed.fields[0].name, "amount");
-    assert_eq!(parsed.fields[0].value, IdlValue::U64(500));
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name, "amount");
+    assert_eq!(fields[0].value, IdlValue::U64(500));
     assert_eq!(parsed.account_names, vec!["event_authority"]);
 }
 
@@ -134,10 +135,11 @@ fn indexed_idl_parse_cpi_event_data_parses_tuple_event_fields() {
     let parsed = result.expect("should parse tuple event");
 
     assert_eq!(parsed.name, "PairEvent");
-    assert_eq!(parsed.fields.len(), 2);
-    assert_eq!(parsed.fields[0].name, "field_0");
-    assert_eq!(parsed.fields[0].value, IdlValue::U32(9));
-    assert_eq!(parsed.fields[1].name, "field_1");
-    assert_eq!(parsed.fields[1].value, IdlValue::U16(7));
+    let fields = parsed.fields.parsed_fields().expect("should parse tuple event");
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0].name, "field_0");
+    assert_eq!(fields[0].value, IdlValue::U32(9));
+    assert_eq!(fields[1].name, "field_1");
+    assert_eq!(fields[1].value, IdlValue::U16(7));
     assert_eq!(parsed.account_names, vec!["event_authority"]);
 }

--- a/crates/sonar-idl/src/tests/idl.rs
+++ b/crates/sonar-idl/src/tests/idl.rs
@@ -131,9 +131,10 @@ fn idl_type_tuple_serde_and_decode() {
 
     let parsed = indexed.parse_instruction(&data).unwrap().expect("should parse");
     assert_eq!(parsed.name, "submit");
-    assert_eq!(parsed.fields.len(), 1);
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    assert_eq!(fields.len(), 1);
     assert_eq!(
-        parsed.fields[0].value,
+        fields[0].value,
         IdlValue::Array(vec![
             IdlValue::Array(vec![IdlValue::U8(1), IdlValue::U32(1000)]),
             IdlValue::Array(vec![IdlValue::U8(2), IdlValue::U32(2000)]),
@@ -183,9 +184,10 @@ fn parse_current_idl_format() {
     let parsed = indexed.parse_instruction(&data).unwrap().expect("should parse");
 
     assert_eq!(parsed.name, "initialize");
-    assert_eq!(parsed.fields.len(), 1);
-    assert_eq!(parsed.fields[0].name, "data");
-    assert_eq!(parsed.fields[0].value, IdlValue::U64(42));
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name, "data");
+    assert_eq!(fields[0].value, IdlValue::U64(42));
 }
 
 #[test]
@@ -209,7 +211,7 @@ fn current_idl_instruction_gets_auto_discriminator() {
     let parsed = indexed.parse_instruction(&data).unwrap().expect("should parse");
 
     assert_eq!(parsed.name, "doSomething");
-    assert!(parsed.fields.is_empty());
+    assert!(parsed.fields.parsed_fields().expect("should parse").is_empty());
 }
 
 #[test]
@@ -238,9 +240,10 @@ fn current_idl_event_gets_auto_discriminator() {
     let parsed = indexed.parse_cpi_event_data(&data).unwrap().expect("should parse event");
 
     assert_eq!(parsed.name, "TransferEvent");
-    assert_eq!(parsed.fields.len(), 1);
-    assert_eq!(parsed.fields[0].name, "amount");
-    assert_eq!(parsed.fields[0].value, IdlValue::U64(7));
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name, "amount");
+    assert_eq!(fields[0].value, IdlValue::U64(7));
     assert!(is_cpi_event_data(&data));
 }
 
@@ -271,11 +274,12 @@ fn current_idl_event_fields_support_tuple_types() {
     let parsed = indexed.parse_cpi_event_data(&data).unwrap().expect("should parse tuple event");
 
     assert_eq!(parsed.name, "PairEvent");
-    assert_eq!(parsed.fields.len(), 2);
-    assert_eq!(parsed.fields[0].name, "field_0");
-    assert_eq!(parsed.fields[0].value, IdlValue::U32(9));
-    assert_eq!(parsed.fields[1].name, "field_1");
-    assert_eq!(parsed.fields[1].value, IdlValue::U16(7));
+    let fields = parsed.fields.parsed_fields().expect("should parse tuple event");
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0].name, "field_0");
+    assert_eq!(fields[0].value, IdlValue::U32(9));
+    assert_eq!(fields[1].name, "field_1");
+    assert_eq!(fields[1].value, IdlValue::U16(7));
 }
 
 #[test]
@@ -318,9 +322,10 @@ fn parse_legacy_idl_and_into_indexed_idl() {
     let parsed = indexed.parse_instruction(&data).unwrap().expect("should parse");
 
     assert_eq!(parsed.name, "doSomething");
-    assert_eq!(parsed.fields.len(), 1);
-    assert_eq!(parsed.fields[0].name, "amount");
-    assert_eq!(parsed.fields[0].value, IdlValue::U64(123));
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name, "amount");
+    assert_eq!(fields[0].value, IdlValue::U64(123));
 }
 
 #[test]
@@ -368,7 +373,8 @@ fn legacy_event_gets_auto_discriminator() {
     let parsed = indexed.parse_cpi_event_data(&data).unwrap().expect("should parse event");
 
     assert_eq!(parsed.name, "TransferEvent");
-    assert_eq!(parsed.fields.len(), 1);
-    assert_eq!(parsed.fields[0].name, "amount");
-    assert_eq!(parsed.fields[0].value, IdlValue::U64(7));
+    let fields = parsed.fields.parsed_fields().expect("should parse event");
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name, "amount");
+    assert_eq!(fields[0].value, IdlValue::U64(7));
 }

--- a/crates/sonar-idl/src/tests/instruction.rs
+++ b/crates/sonar-idl/src/tests/instruction.rs
@@ -137,9 +137,10 @@ fn indexed_idl_parse_instruction_matches_discriminator_and_reads_u64_arg() {
     let parsed = result.expect("should match");
 
     assert_eq!(parsed.name, "initialize");
-    assert_eq!(parsed.fields.len(), 1);
-    assert_eq!(parsed.fields[0].name, "data");
-    assert_eq!(parsed.fields[0].value, IdlValue::U64(42));
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name, "data");
+    assert_eq!(fields[0].value, IdlValue::U64(42));
 }
 
 #[test]
@@ -162,7 +163,7 @@ fn indexed_idl_normalizes_current_format_instruction_discriminator() {
     let parsed = result.expect("should match");
 
     assert_eq!(parsed.name, "doSomething");
-    assert!(parsed.fields.is_empty());
+    assert!(parsed.fields.parsed_fields().expect("should parse").is_empty());
 }
 
 #[test]
@@ -205,10 +206,11 @@ fn indexed_idl_parse_instruction_multiple_primitive_args() {
     data.extend_from_slice(string);
 
     let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
-    assert_eq!(parsed.fields[0].value, IdlValue::U8(42));
-    assert_eq!(parsed.fields[1].value, IdlValue::Bool(true));
-    assert_eq!(parsed.fields[2].value, IdlValue::I16(-5));
-    assert_eq!(parsed.fields[3].value, IdlValue::String("hello".into()));
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    assert_eq!(fields[0].value, IdlValue::U8(42));
+    assert_eq!(fields[1].value, IdlValue::Bool(true));
+    assert_eq!(fields[2].value, IdlValue::I16(-5));
+    assert_eq!(fields[3].value, IdlValue::String("hello".into()));
 }
 
 /// IDL with two required `u32` args, used by the trailing-arg boundary tests below.
@@ -303,9 +305,10 @@ fn indexed_idl_parse_instruction_with_defined_struct_arg() {
     data.extend_from_slice(&200u32.to_le_bytes());
 
     let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
-    assert_eq!(parsed.fields[0].name, "params");
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    assert_eq!(fields[0].name, "params");
     assert_eq!(
-        parsed.fields[0].value,
+        fields[0].value,
         IdlValue::Struct(vec![("x".into(), IdlValue::U32(100)), ("y".into(), IdlValue::U32(200)),])
     );
 }
@@ -380,8 +383,9 @@ fn indexed_idl_parse_instruction_preserves_named_field_order() {
     let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
 
     // Verify field order is preserved (zeta before alpha, matching IDL definition)
+    let fields = parsed.fields.parsed_fields().expect("should parse");
     assert_eq!(
-        parsed.fields[0].value,
+        fields[0].value,
         IdlValue::Struct(vec![
             ("zeta".into(), IdlValue::U32(100)),
             ("alpha".into(), IdlValue::U32(200)),
@@ -417,11 +421,13 @@ fn indexed_idl_parse_instruction_with_enum_arg() {
 
     let mut data = vec![1, 1, 1, 1, 1, 1, 1, 1, 0];
     let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
-    assert_eq!(parsed.fields[0].value, IdlValue::EnumUnit("Start".into()));
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    assert_eq!(fields[0].value, IdlValue::EnumUnit("Start".into()));
 
     data[8] = 1;
     let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
-    assert_eq!(parsed.fields[0].value, IdlValue::EnumUnit("Stop".into()));
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    assert_eq!(fields[0].value, IdlValue::EnumUnit("Stop".into()));
 }
 
 #[test]
@@ -448,8 +454,9 @@ fn indexed_idl_parse_instruction_with_vec_arg() {
     data.extend_from_slice(&30u16.to_le_bytes());
 
     let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
+    let fields = parsed.fields.parsed_fields().expect("should parse");
     assert_eq!(
-        parsed.fields[0].value,
+        fields[0].value,
         IdlValue::Array(vec![IdlValue::U16(10), IdlValue::U16(20), IdlValue::U16(30)])
     );
 }
@@ -474,11 +481,13 @@ fn indexed_idl_parse_instruction_with_option_arg() {
     let mut data = vec![3, 3, 3, 3, 3, 3, 3, 3, 1];
     data.extend_from_slice(&777u32.to_le_bytes());
     let parsed = indexed.parse_instruction(&data).unwrap().unwrap();
-    assert_eq!(parsed.fields[0].value, IdlValue::U32(777));
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    assert_eq!(fields[0].value, IdlValue::U32(777));
 
     let data_none = vec![3, 3, 3, 3, 3, 3, 3, 3, 0];
     let parsed = indexed.parse_instruction(&data_none).unwrap().unwrap();
-    assert_eq!(parsed.fields[0].value, IdlValue::Null);
+    let fields = parsed.fields.parsed_fields().expect("should parse");
+    assert_eq!(fields[0].value, IdlValue::Null);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- factor out shared length-prefix and raw fallback handling in IDL decoding
- use shared discriminator prefix matching for instructions, events, and accounts
- update sonar-idl tests to explicitly inspect parsed fields

## Tests
- cargo test -p sonar-idl