### PR TITLE
feat(simulate): add --insert-ix / --remove-ix whole-instruction mutations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4159,6 +4159,7 @@ dependencies = [
  "solana-address-lookup-table-interface",
  "solana-clock",
  "solana-hash 3.1.0",
+ "solana-instruction",
  "solana-keypair",
  "solana-loader-v3-interface",
  "solana-message",

--- a/crates/sonar-cli/src/cli/simulate.rs
+++ b/crates/sonar-cli/src/cli/simulate.rs
@@ -23,6 +23,8 @@ EXAMPLES:
   sonar simulate <TX1> <TX2>                    Bundle (atomic multi-tx)
   sonar simulate --payer <PUBKEY> --ix <DSL>    Instruction input
   sonar simulate <TX> --fund-sol ALICE=1sol     Fund account before sim
+  sonar simulate <TX> --remove-ix 2              Drop a whole instruction
+  sonar simulate <TX> --insert-ix 1='program=..' Insert a whole instruction
   sonar simulate <TX> --override PROG=prog.so   Override on-chain program")]
 pub struct SimulateArgs {
     #[command(flatten, next_help_heading = HELP_HEADING_INPUT_RPC)]
@@ -148,6 +150,42 @@ pub struct SimulateArgs {
         value_parser = clap::builder::NonEmptyStringValueParser::new()
     )]
     pub ix_account_removes: Vec<String>,
+    /// Remove a whole instruction from the transaction before simulation.
+    /// Format: <IX> (1-based instruction index)
+    /// Subsequent instructions shift left by one.
+    /// Example: --remove-ix 2
+    /// Ordering: whole-instruction ops run before account/data mutations;
+    /// see --insert-ix.
+    #[arg(
+        long = "remove-ix",
+        help_heading = HELP_HEADING_STATE_PREPARATION,
+        value_name = "INDEX",
+        num_args = 1..,
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
+    )]
+    pub ix_removes: Vec<String>,
+    /// Insert a whole instruction into the transaction at a 1-based position.
+    /// Format: <POS>=<SPEC> (1-based; the new instruction becomes POS-th).
+    /// POS=1 prepends; POS = current_count + 1 appends.
+    /// <SPEC> reuses the --ix grammar: DSL, JSON object/array, or @file.
+    /// When SPEC is a JSON array of N instructions, they occupy POS..POS+N-1.
+    /// Example: --insert-ix 1="program=Memo.. data=0x.."
+    /// Example: --insert-ix 2=@extra.json
+    /// Ordering: whole-instruction ops (all --insert-ix, then all --remove-ix)
+    /// run BEFORE account-level ops (--patch-ix-account etc.) and data patches
+    /// (--patch-ix-data), so the latter target the post-restructure list.
+    /// Within --insert-ix, CLI argument order is preserved; positions are
+    /// interpreted at apply time, so list ops in descending position order to
+    /// express positions relative to the pre-mutation list.
+    #[arg(
+        long = "insert-ix",
+        help_heading = HELP_HEADING_STATE_PREPARATION,
+        value_name = "INSERT",
+        verbatim_doc_comment,
+        num_args = 1,
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
+    )]
+    pub ix_inserts: Vec<String>,
     /// Patch bytes in an instruction's data field before simulation.
     /// Format: <IX>=<OFFSET>:<HEX_DATA> (1-based instruction index)
     /// HEX_DATA may optionally start with 0x.
@@ -257,8 +295,8 @@ pub struct TransactionInputArgs {
 }
 
 pub use sonar_sim::internals::{
-    AccountDataPatch, AccountOverride, InstructionAccountOp, InstructionDataPatch, SolFunding,
-    TokenAmount, TokenFunding,
+    AccountDataPatch, AccountOverride, InstructionAccountOp, InstructionDataPatch, InstructionOp,
+    SolFunding, TokenAmount, TokenFunding,
 };
 
 /// Parse the `<NEW_PUBKEY>[:<flags>]` value of an instruction-account op using
@@ -462,6 +500,50 @@ pub fn parse_ix_account_remove(raw: &str) -> Result<InstructionAccountOp, String
         return Err("Remove must be in <IX>.<POSITION> format (no `=<value>`)".to_string());
     }
     Ok(InstructionAccountOp::Remove { instruction_index, account_position })
+}
+
+/// Parse `--remove-ix` (`<IX>`, 1-based) into an [`InstructionOp::Remove`].
+/// Rejects a trailing `=<value>` since removals take no payload.
+pub fn parse_ix_remove(raw: &str) -> Result<InstructionOp, String> {
+    if let Some((_, _)) = raw.split_once('=') {
+        return Err(
+            "--remove-ix must be a single 1-based index (e.g. `2`), no `=<value>`".to_string()
+        );
+    }
+    let ix_1based: usize = raw
+        .trim()
+        .parse()
+        .map_err(|err| format!("Failed to parse --remove-ix index `{raw}`: {err}"))?;
+    if ix_1based == 0 {
+        return Err("--remove-ix index is 1-based and must be >= 1".to_string());
+    }
+    Ok(InstructionOp::Remove { index: ix_1based - 1 })
+}
+
+/// Parse `--insert-ix` (`<POS>=<SPEC>`, 1-based position) into the 0-based
+/// insertion position plus the raw instruction spec.
+///
+/// The spec (DSL / JSON / `@file`) is decoded later by the handler, which
+/// already owns the `--ix` parsing machinery. A JSON array spec yields several
+/// consecutive inserts starting at the returned position.
+pub fn parse_ix_insert(raw: &str) -> Result<(usize, String), String> {
+    let (pos_str, spec) = raw.split_once('=').ok_or_else(|| {
+        "--insert-ix must be in <POS>=<SPEC> format (1-based position; SPEC reuses the --ix grammar)"
+            .to_string()
+    })?;
+    let pos_1based: usize = pos_str
+        .trim()
+        .parse()
+        .map_err(|err| format!("Failed to parse --insert-ix position `{pos_str}`: {err}"))?;
+    if pos_1based == 0 {
+        return Err("--insert-ix position is 1-based and must be >= 1".to_string());
+    }
+    let spec = spec.trim_start();
+    if spec.is_empty() {
+        return Err("--insert-ix <SPEC> is empty after `=`; provide a DSL, JSON, or @file value"
+            .to_string());
+    }
+    Ok((pos_1based - 1, spec.to_string()))
 }
 
 pub fn parse_ix_data_patch(raw: &str) -> Result<InstructionDataPatch, String> {
@@ -1482,6 +1564,110 @@ mod tests {
             panic!("expected simulate subcommand");
         };
         assert_eq!(args.ix_account_removes.len(), 2);
+    }
+
+    #[test]
+    fn parse_ix_remove_basic() {
+        let parsed = parse_ix_remove("2").unwrap();
+        assert!(matches!(parsed, InstructionOp::Remove { index: 1 }));
+    }
+
+    #[test]
+    fn parse_ix_remove_rejects_zero_index() {
+        let err = parse_ix_remove("0").unwrap_err();
+        assert!(err.contains("1-based"));
+    }
+
+    #[test]
+    fn parse_ix_remove_rejects_value_suffix() {
+        let err = parse_ix_remove("2=foo").unwrap_err();
+        assert!(err.contains("no `=<value>`"));
+    }
+
+    #[test]
+    fn parse_ix_remove_rejects_non_numeric() {
+        let err = parse_ix_remove("abc").unwrap_err();
+        assert!(err.contains("Failed to parse"));
+    }
+
+    #[test]
+    fn simulate_accepts_remove_ix_flag() {
+        let cli = Cli::try_parse_from([
+            "sonar",
+            "simulate",
+            "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "--remove-ix",
+            "2",
+            "--remove-ix",
+            "1",
+        ])
+        .expect("should parse --remove-ix");
+
+        let Some(Commands::Simulate(args)) = cli.command else {
+            panic!("expected simulate subcommand");
+        };
+        assert_eq!(args.ix_removes.len(), 2);
+    }
+
+    #[test]
+    fn parse_ix_insert_basic() {
+        let (pos, spec) =
+            parse_ix_insert("1=program=MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr").unwrap();
+        assert_eq!(pos, 0);
+        assert_eq!(spec, "program=MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
+    }
+
+    #[test]
+    fn parse_ix_insert_preserves_at_file_spec() {
+        let (pos, spec) = parse_ix_insert("3=@ix.json").unwrap();
+        assert_eq!(pos, 2);
+        assert_eq!(spec, "@ix.json");
+    }
+
+    #[test]
+    fn parse_ix_insert_preserves_json_spec() {
+        let (pos, spec) =
+            parse_ix_insert("2={\"program\":\"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA\"}")
+                .unwrap();
+        assert_eq!(pos, 1);
+        assert!(spec.starts_with('{'));
+    }
+
+    #[test]
+    fn parse_ix_insert_rejects_zero_position() {
+        let err = parse_ix_insert("0=program=x").unwrap_err();
+        assert!(err.contains("1-based"));
+    }
+
+    #[test]
+    fn parse_ix_insert_rejects_missing_equals() {
+        let err = parse_ix_insert("1program").unwrap_err();
+        assert!(err.contains("<POS>=<SPEC>"));
+    }
+
+    #[test]
+    fn parse_ix_insert_rejects_empty_spec() {
+        let err = parse_ix_insert("1=").unwrap_err();
+        assert!(err.contains("empty"));
+    }
+
+    #[test]
+    fn simulate_accepts_insert_ix_flag() {
+        let cli = Cli::try_parse_from([
+            "sonar",
+            "simulate",
+            "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "--insert-ix",
+            "1=program=MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
+            "--insert-ix",
+            "2=@extra.json",
+        ])
+        .expect("should parse --insert-ix");
+
+        let Some(Commands::Simulate(args)) = cli.command else {
+            panic!("expected simulate subcommand");
+        };
+        assert_eq!(args.ix_inserts.len(), 2);
     }
 
     #[test]

--- a/crates/sonar-cli/src/core/transaction.rs
+++ b/crates/sonar-cli/src/core/transaction.rs
@@ -92,6 +92,25 @@ pub struct InstructionInput {
     pub data: Vec<u8>,
 }
 
+impl InstructionInput {
+    /// Convert this parsed instruction into a `solana_instruction::Instruction`,
+    /// mapping the `is_writable`/`is_signer` flags onto `AccountMeta`.
+    pub fn to_instruction(&self) -> Instruction {
+        let accounts = self
+            .accounts
+            .iter()
+            .map(|account| {
+                if account.is_writable {
+                    AccountMeta::new(account.pubkey, account.is_signer)
+                } else {
+                    AccountMeta::new_readonly(account.pubkey, account.is_signer)
+                }
+            })
+            .collect();
+        Instruction { program_id: self.program, accounts, data: self.data.clone() }
+    }
+}
+
 /// Encoding for an instruction's `data` field. Defaults to hex; set it
 /// explicitly (the JSON `encoding` field or the DSL `encoding=` field) to
 /// decode base64 or base58 instead. Base58 matches how Solana RPC encodes
@@ -387,23 +406,7 @@ pub fn build_transaction_from_instructions(
         anyhow::bail!("Instruction input must contain at least one instruction");
     }
 
-    let instructions: Vec<_> = inputs
-        .iter()
-        .map(|input| {
-            let accounts = input
-                .accounts
-                .iter()
-                .map(|account| {
-                    if account.is_writable {
-                        AccountMeta::new(account.pubkey, account.is_signer)
-                    } else {
-                        AccountMeta::new_readonly(account.pubkey, account.is_signer)
-                    }
-                })
-                .collect();
-            Instruction { program_id: input.program, accounts, data: input.data.clone() }
-        })
-        .collect();
+    let instructions: Vec<_> = inputs.iter().map(InstructionInput::to_instruction).collect();
 
     let message = Message::new(&instructions, Some(&payer));
     let signature_count = message.header.num_required_signatures as usize;

--- a/crates/sonar-cli/src/handlers/decode.rs
+++ b/crates/sonar-cli/src/handlers/decode.rs
@@ -57,7 +57,11 @@ pub(crate) fn handle(args: DecodeArgs, json: bool) -> Result<()> {
     if is_bundle {
         log::info!("Bundle decode mode: {} transactions", parsed_txs.len());
         if json {
-            output::render_decode_bundle_json(&parsed_txs, &resolved_accounts, &mut parser_registry)?;
+            output::render_decode_bundle_json(
+                &parsed_txs,
+                &resolved_accounts,
+                &mut parser_registry,
+            )?;
         } else {
             for (i, parsed_tx) in parsed_txs.iter().enumerate() {
                 output::render_transaction_only(

--- a/crates/sonar-cli/src/handlers/pipeline_prep.rs
+++ b/crates/sonar-cli/src/handlers/pipeline_prep.rs
@@ -110,7 +110,8 @@ pub(crate) fn resolve_mutate_prepare(
     mut mutate: impl FnMut(&mut transaction::ParsedTransaction) -> Result<()>,
 ) -> Result<PreparedPipeline> {
     // 1. Resolve inputs into transactions and derive the cache key.
-    let (resolved_txs, cache_key) = resolve_inputs(source, resolver_cache_location, cache_args, progress)?;
+    let (resolved_txs, cache_key) =
+        resolve_inputs(source, resolver_cache_location, cache_args, progress)?;
 
     // 2. Separate provenance from the parsed form, then apply the caller's
     //    mutation. The account set to load depends on the post-mutation
@@ -185,8 +186,10 @@ fn resolve_inputs(
             let parsed_tx = transaction::build_transaction_from_instructions(payer, &inputs)
                 .context("Failed to build transaction from instruction inputs")?;
             let raw_tx_base64 = transaction::encode_transaction_to_base64(&parsed_tx.transaction)?;
-            let cache_key =
-                crate::core::cache::derive_cache_key_single(source.as_str(), &parsed_tx.transaction);
+            let cache_key = crate::core::cache::derive_cache_key_single(
+                source.as_str(),
+                &parsed_tx.transaction,
+            );
             let resolved_txs = vec![transaction::ResolvedTxInput {
                 original_input: source.as_str().to_string(),
                 raw_tx_base64,

--- a/crates/sonar-cli/src/handlers/simulate.rs
+++ b/crates/sonar-cli/src/handlers/simulate.rs
@@ -10,7 +10,7 @@ use crate::utils::progress::Progress;
 use crate::{core::account_file, core::transaction, output};
 use sonar_sim::internals::{
     ExecutionOptions, PreparedSimulation, SimulationOptions, StateMutationOptions,
-    apply_ix_account_ops, apply_ix_data_patches, prepare_token_fundings,
+    apply_instruction_ops, apply_ix_account_ops, apply_ix_data_patches, prepare_token_fundings,
 };
 
 use super::pipeline_prep::{
@@ -113,13 +113,23 @@ fn parse_cli_args<T>(args: Vec<String>, parser: fn(&str) -> Result<T, String>) -
     args.iter().map(|raw| parser(raw).map_err(anyhow::Error::msg)).collect()
 }
 
-/// Apply instruction-level mutations (account patches, data patches) and rebuild
-/// the transaction summary so the renderer sees the updated state.
+/// Apply instruction-level mutations (whole-ix insert/remove, account
+/// patches, data patches) and rebuild the transaction summary so the renderer
+/// sees the updated state.
+///
+/// Apply order: whole-instruction ops first (they restructure the instruction
+/// list), then account-level ops, then data patches — so the latter target the
+/// post-restructure list.
 fn apply_ix_mutations(
     parsed_tx: &mut transaction::ParsedTransaction,
+    instruction_ops: &[sonar_sim::internals::InstructionOp],
     ix_account_ops: &[sonar_sim::internals::InstructionAccountOp],
     ix_data_patches: &[sonar_sim::internals::InstructionDataPatch],
 ) -> Result<()> {
+    if !instruction_ops.is_empty() {
+        parsed_tx.account_plan = apply_instruction_ops(&mut parsed_tx.transaction, instruction_ops)
+            .context("Failed to apply instruction ops")?;
+    }
     if !ix_account_ops.is_empty() {
         parsed_tx.account_plan = apply_ix_account_ops(&mut parsed_tx.transaction, ix_account_ops)
             .context("Failed to apply instruction account ops")?;
@@ -128,7 +138,7 @@ fn apply_ix_mutations(
         apply_ix_data_patches(&mut parsed_tx.transaction, ix_data_patches)
             .context("Failed to apply instruction data patches")?;
     }
-    if !ix_account_ops.is_empty() || !ix_data_patches.is_empty() {
+    if !instruction_ops.is_empty() || !ix_account_ops.is_empty() || !ix_data_patches.is_empty() {
         parsed_tx.summary = transaction::TransactionSummary::from_transaction(
             &parsed_tx.transaction,
             &parsed_tx.account_plan,
@@ -166,6 +176,8 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
         no_idl_fetch,
         ix_account_inserts: ix_account_insert_args,
         ix_account_removes: ix_account_remove_args,
+        ix_removes: ix_remove_args,
+        ix_inserts: ix_insert_args,
     } = args;
     // --cache-dir or --refresh-cache imply --cache
     let cache = cache || cache_dir.is_some() || refresh_cache;
@@ -203,6 +215,22 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
     ix_account_ops.extend(parse_cli_args(ix_account_insert_args, cli::parse_ix_account_insert)?);
     ix_account_ops.extend(parse_cli_args(ix_account_remove_args, cli::parse_ix_account_remove)?);
     let ix_data_patches = parse_cli_args(ix_data_patch_args, cli::parse_ix_data_patch)?;
+    // Whole-instruction ops: --insert-ix first (in CLI order; a JSON array
+    // spec expands to consecutive positions starting at the given position),
+    // then --remove-ix. These run before account/data mutations so the latter
+    // target the post-restructure instruction list.
+    let mut instruction_ops: Vec<sonar_sim::internals::InstructionOp> = Vec::new();
+    for raw in &ix_insert_args {
+        let (position, spec) = cli::parse_ix_insert(raw).map_err(anyhow::Error::msg)?;
+        let inputs = load_instruction_arg(&spec)?;
+        for (offset, input) in inputs.into_iter().enumerate() {
+            instruction_ops.push(sonar_sim::internals::InstructionOp::Insert {
+                position: position + offset,
+                instruction: input.to_instruction(),
+            });
+        }
+    }
+    instruction_ops.extend(parse_cli_args(ix_remove_args, cli::parse_ix_remove)?);
 
     // Build rendering options once; shared across all code paths.
     let render_opts = output::RenderOptions {
@@ -235,6 +263,7 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
                 &rpc_url,
                 resolver_cache_location,
                 token_funding_requests,
+                instruction_ops,
                 ix_account_ops,
                 ix_data_patches,
                 sim_opts,
@@ -269,17 +298,14 @@ pub(crate) fn handle(args: SimulateArgs, json: bool) -> Result<()> {
         &cache_args,
         &mut parser_registry,
         &progress,
-        |parsed_tx| apply_ix_mutations(parsed_tx, &ix_account_ops, &ix_data_patches),
+        |parsed_tx| {
+            apply_ix_mutations(parsed_tx, &instruction_ops, &ix_account_ops, &ix_data_patches)
+        },
     )?;
 
-    let mut parsed_tx = prepared
-        .parsed_txs
-        .pop()
-        .expect("single input resolve should produce one transaction");
-    let origin = prepared
-        .origins
-        .pop()
-        .expect("single input resolve should produce one origin");
+    let mut parsed_tx =
+        prepared.parsed_txs.pop().expect("single input resolve should produce one transaction");
+    let origin = prepared.origins.pop().expect("single input resolve should produce one origin");
     let raw_input = origin.original_input;
     let cached_raw_tx = origin.raw_tx_base64;
     let resolved_from = origin.resolved_from;
@@ -385,6 +411,7 @@ fn handle_bundle(
     rpc_url: &str,
     resolver_cache_location: Option<crate::core::cache::CacheLocation>,
     token_funding_requests: Vec<cli::TokenFunding>,
+    instruction_ops: Vec<sonar_sim::internals::InstructionOp>,
     ix_account_ops: Vec<sonar_sim::internals::InstructionAccountOp>,
     ix_data_patches: Vec<sonar_sim::internals::InstructionDataPatch>,
     mut sim_opts: SimulationOptions,
@@ -413,7 +440,9 @@ fn handle_bundle(
         &cache_args,
         parser_registry,
         progress,
-        |parsed_tx| apply_ix_mutations(parsed_tx, &ix_account_ops, &ix_data_patches),
+        |parsed_tx| {
+            apply_ix_mutations(parsed_tx, &instruction_ops, &ix_account_ops, &ix_data_patches)
+        },
     )?;
     log::info!("Successfully parsed {} transactions", prepared.parsed_txs.len());
 

--- a/crates/sonar-cli/tests/e2e_cli_output_streams.rs
+++ b/crates/sonar-cli/tests/e2e_cli_output_streams.rs
@@ -217,6 +217,110 @@ fn simulate_ix_accepts_mixed_dsl_and_json_in_one_invocation() {
     );
 }
 
+/// Build a signed 2-instruction transaction (two system transfers) and return
+/// its base64 encoding, for exercising whole-instruction restructuring flags.
+fn two_instruction_transfer_tx_b64() -> String {
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+    use solana_hash::Hash;
+    use solana_keypair::Keypair;
+    use solana_message::Message;
+    use solana_pubkey::Pubkey;
+    use solana_signer::Signer;
+    use solana_system_interface::instruction as system_instruction;
+    use solana_transaction::Transaction;
+    use solana_transaction::versioned::VersionedTransaction;
+
+    let payer = Keypair::new();
+    let recipient1 = Pubkey::new_unique();
+    let recipient2 = Pubkey::new_unique();
+    let blockhash = Hash::new_unique();
+    let ix1 = system_instruction::transfer(&payer.pubkey(), &recipient1, 1);
+    let ix2 = system_instruction::transfer(&payer.pubkey(), &recipient2, 2);
+    let message = Message::new(&[ix1, ix2], Some(&payer.pubkey()));
+    let tx = Transaction::new(&[&payer], message, blockhash);
+    let bytes = bincode::serialize(&VersionedTransaction::from(tx)).expect("serialize tx");
+    BASE64_STANDARD.encode(bytes)
+}
+
+#[test]
+fn simulate_remove_ix_valid_index_reaches_execution() {
+    // A valid --remove-ix restructures the message and proceeds to account
+    // loading, so the only failure is the unreachable RPC — not a mutation error.
+    let tx = two_instruction_transfer_tx_b64();
+    let mut cmd = cargo_bin_cmd!("sonar");
+    cmd.arg("simulate")
+        .arg(&tx)
+        .arg("--rpc-url")
+        .arg("http://127.0.0.1:1")
+        .arg("--remove-ix")
+        .arg("1");
+    let assert = cmd.assert().failure();
+    let output = assert.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("out of range") && !stderr.contains("Failed to apply instruction ops"),
+        "valid --remove-ix should not fail at mutation, got: {stderr}"
+    );
+}
+
+#[test]
+fn simulate_remove_ix_out_of_range_fails_at_mutation() {
+    let tx = two_instruction_transfer_tx_b64();
+    let mut cmd = cargo_bin_cmd!("sonar");
+    cmd.arg("simulate")
+        .arg(&tx)
+        .arg("--rpc-url")
+        .arg("http://127.0.0.1:1")
+        .arg("--remove-ix")
+        .arg("9");
+    let assert = cmd.assert().failure();
+    let output = assert.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("out of range"),
+        "out-of-range --remove-ix should fail at mutation, got: {stderr}"
+    );
+}
+
+#[test]
+fn simulate_insert_ix_valid_spec_reaches_execution() {
+    let tx = two_instruction_transfer_tx_b64();
+    let mut cmd = cargo_bin_cmd!("sonar");
+    cmd.arg("simulate")
+        .arg(&tx)
+        .arg("--rpc-url")
+        .arg("http://127.0.0.1:1")
+        .arg("--insert-ix")
+        .arg("1=program=MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr data=0x6869");
+    let assert = cmd.assert().failure();
+    let output = assert.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Failed to apply instruction ops") && !stderr.contains("<POS>=<SPEC>"),
+        "valid --insert-ix should not fail at mutation/parse, got: {stderr}"
+    );
+}
+
+#[test]
+fn simulate_insert_ix_out_of_range_position_fails_at_mutation() {
+    let tx = two_instruction_transfer_tx_b64();
+    let mut cmd = cargo_bin_cmd!("sonar");
+    cmd.arg("simulate")
+        .arg(&tx)
+        .arg("--rpc-url")
+        .arg("http://127.0.0.1:1")
+        .arg("--insert-ix")
+        .arg("99=program=MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr data=0x6869");
+    let assert = cmd.assert().failure();
+    let output = assert.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("out of range"),
+        "out-of-range --insert-ix position should fail at mutation, got: {stderr}"
+    );
+}
+
 #[test]
 fn decode_omitted_tx_empty_stdin_fails_with_actionable_message() {
     let mut cmd = cargo_bin_cmd!("sonar");

--- a/crates/sonar-sim/Cargo.toml
+++ b/crates/sonar-sim/Cargo.toml
@@ -22,6 +22,7 @@ serde_json.workspace = true
 ureq.workspace = true
 solana-clock.workspace = true
 solana-hash.workspace = true
+solana-instruction.workspace = true
 solana-loader-v3-interface.workspace = true
 solana-message.workspace = true
 solana-native-token.workspace = true

--- a/crates/sonar-sim/src/account_fetcher.rs
+++ b/crates/sonar-sim/src/account_fetcher.rs
@@ -382,7 +382,7 @@ mod tests {
                     return Ok(HashMap::new());
                 }
                 let mut found = HashMap::new();
-                if pubkeys.iter().any(|k| *k == self.key) {
+                if pubkeys.contains(&self.key) {
                     found.insert(self.key, self.account.clone());
                 }
                 Ok(found)

--- a/crates/sonar-sim/src/executor.rs
+++ b/crates/sonar-sim/src/executor.rs
@@ -536,6 +536,7 @@ mod tests {
     use solana_hash::Hash;
     use solana_keypair::Keypair;
     use solana_message::Message;
+    use solana_rent::Rent;
     use solana_signer::Signer;
     use solana_system_interface::instruction as system_instruction;
     use solana_transaction::Transaction;
@@ -550,6 +551,15 @@ mod tests {
         let message = Message::new(&[instruction], Some(&payer.pubkey()));
         let transaction = Transaction::new(&[payer], message, blockhash);
         VersionedTransaction::from(transaction)
+    }
+
+    /// Lamports required to make a freshly-created 0-byte account rent-exempt.
+    ///
+    /// LiteSVM (matching mainnet) rejects transactions that leave a new account
+    /// below the rent-exempt threshold, so test transfers funding brand-new
+    /// recipients must transfer at least this much.
+    fn rent_exempt_amount() -> u64 {
+        Rent::default().minimum_balance(0)
     }
 
     fn shared_system_account(lamports: u64) -> AccountSharedData {
@@ -568,8 +578,9 @@ mod tests {
         let recipient1 = Pubkey::new_unique();
         let recipient2 = Pubkey::new_unique();
 
-        let tx1 = create_transfer_transaction(&payer, &recipient1, 1000);
-        let tx2 = create_transfer_transaction(&payer, &recipient2, 2000);
+        let amount = rent_exempt_amount();
+        let tx1 = create_transfer_transaction(&payer, &recipient1, amount);
+        let tx2 = create_transfer_transaction(&payer, &recipient2, amount);
 
         let tx_refs: Vec<&VersionedTransaction> = vec![&tx1, &tx2];
 
@@ -624,8 +635,9 @@ mod tests {
         let payer = Keypair::new();
         let recipient = Pubkey::new_unique();
 
-        let tx1 = create_transfer_transaction(&payer, &recipient, 1_000);
-        let tx2 = create_transfer_transaction(&payer, &recipient, 2_000);
+        let amount = rent_exempt_amount();
+        let tx1 = create_transfer_transaction(&payer, &recipient, amount);
+        let tx2 = create_transfer_transaction(&payer, &recipient, amount);
 
         let tx_refs: Vec<&VersionedTransaction> = vec![&tx1, &tx2];
 
@@ -655,7 +667,8 @@ mod tests {
         let payer = Keypair::new();
         let recipient = Pubkey::new_unique();
 
-        let tx = create_transfer_transaction(&payer, &recipient, 1_000);
+        let amount = rent_exempt_amount();
+        let tx = create_transfer_transaction(&payer, &recipient, amount);
 
         let mut accounts = HashMap::new();
         accounts.insert(payer.pubkey(), shared_system_account(10_000_000_000));
@@ -676,7 +689,8 @@ mod tests {
         let payer = Keypair::new();
         let recipient = Pubkey::new_unique();
 
-        let tx = create_transfer_transaction(&payer, &recipient, 1_000);
+        let amount = rent_exempt_amount();
+        let tx = create_transfer_transaction(&payer, &recipient, amount);
 
         let accounts = HashMap::new();
         let resolved = ResolvedAccounts { accounts, lookups: vec![] };
@@ -719,7 +733,8 @@ mod tests {
     fn prepared_simulation_into_runner_executes() {
         let payer = Keypair::new();
         let recipient = Pubkey::new_unique();
-        let tx = create_transfer_transaction(&payer, &recipient, 1_000);
+        let amount = rent_exempt_amount();
+        let tx = create_transfer_transaction(&payer, &recipient, amount);
 
         let mut accounts = HashMap::new();
         accounts.insert(payer.pubkey(), shared_system_account(10_000_000_000));

--- a/crates/sonar-sim/src/internals.rs
+++ b/crates/sonar-sim/src/internals.rs
@@ -12,8 +12,8 @@
 
 pub use crate::transaction::{
     AddressLookupPlan, LookupLocation, MessageAccountPlan, ParsedTransaction,
-    RawTransactionEncoding, apply_ix_account_ops, apply_ix_data_patches, build_lookup_locations,
-    parse_raw_transaction,
+    RawTransactionEncoding, apply_instruction_ops, apply_ix_account_ops, apply_ix_data_patches,
+    build_lookup_locations, parse_raw_transaction,
 };
 
 // ── Account loading ──
@@ -24,7 +24,7 @@ pub use crate::account_loader::AccountLoader;
 // ── Account types ──
 
 pub use crate::types::{
-    AccountDataPatch, AccountOverride, InstructionAccountOp, InstructionDataPatch,
+    AccountDataPatch, AccountOverride, InstructionAccountOp, InstructionDataPatch, InstructionOp,
     ResolvedAccounts, ResolvedLookup,
 };
 

--- a/crates/sonar-sim/src/mutations.rs
+++ b/crates/sonar-sim/src/mutations.rs
@@ -5,13 +5,14 @@
 use solana_pubkey::Pubkey;
 
 use crate::types::{
-    AccountDataPatch, AccountOverride, InstructionAccountOp, InstructionDataPatch, SolFunding,
-    TokenFunding,
+    AccountDataPatch, AccountOverride, InstructionAccountOp, InstructionDataPatch, InstructionOp,
+    SolFunding, TokenFunding,
 };
 
 /// Instruction-level mutations applied to the raw transaction before simulation.
 #[derive(Debug, Clone, Default)]
 pub struct TransactionMutations {
+    pub(crate) instruction_ops: Vec<InstructionOp>,
     pub(crate) ix_account_ops: Vec<InstructionAccountOp>,
     pub(crate) ix_data_patches: Vec<InstructionDataPatch>,
 }
@@ -51,7 +52,9 @@ impl Mutations {
 
 impl TransactionMutations {
     pub fn is_empty(&self) -> bool {
-        self.ix_account_ops.is_empty() && self.ix_data_patches.is_empty()
+        self.instruction_ops.is_empty()
+            && self.ix_account_ops.is_empty()
+            && self.ix_data_patches.is_empty()
     }
 }
 
@@ -94,6 +97,14 @@ impl MutationsBuilder {
 
     pub fn patch_account_data(mut self, patch: AccountDataPatch) -> Self {
         self.inner.state.account_data_patches.push(patch);
+        self
+    }
+
+    /// Append a whole-instruction mutation (insert / remove). Operations apply
+    /// in the order added; intended to run before account/data mutations so
+    /// that later phases target the post-restructure instruction list.
+    pub fn add_instruction_op(mut self, op: InstructionOp) -> Self {
+        self.inner.transaction.instruction_ops.push(op);
         self
     }
 
@@ -178,6 +189,29 @@ mod tests {
         assert_eq!(m.transaction.ix_account_ops.len(), 2);
         assert_eq!(m.transaction.ix_account_ops[0].account_position(), 3);
         assert_eq!(m.transaction.ix_account_ops[1].account_position(), 1);
+    }
+
+    #[test]
+    fn builder_add_instruction_op_remove() {
+        let m = Mutations::builder().add_instruction_op(InstructionOp::Remove { index: 2 }).build();
+        assert_eq!(m.transaction.instruction_ops.len(), 1);
+        assert_eq!(m.transaction.instruction_ops[0].position(), None);
+        assert!(!m.is_empty());
+    }
+
+    #[test]
+    fn builder_instruction_ops_independent_from_account_ops() {
+        let m = Mutations::builder()
+            .add_instruction_op(InstructionOp::Remove { index: 0 })
+            .add_ix_account_op(InstructionAccountOp::Patch {
+                instruction_index: 0,
+                account_position: 0,
+                new_pubkey: Pubkey::new_unique(),
+                writable: true,
+            })
+            .build();
+        assert_eq!(m.transaction.instruction_ops.len(), 1);
+        assert_eq!(m.transaction.ix_account_ops.len(), 1);
     }
 
     #[test]

--- a/crates/sonar-sim/src/pipeline.rs
+++ b/crates/sonar-sim/src/pipeline.rs
@@ -9,8 +9,10 @@
 //! rather than runtime errors. Single-transaction and bundle pipelines are
 //! likewise separate types, so `execute`/`execute_bundle` can't be mismatched.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
+use solana_pubkey::Pubkey;
 use solana_transaction::versioned::VersionedTransaction;
 
 use crate::account_loader::AccountLoader;
@@ -25,7 +27,8 @@ use crate::mutations::Mutations;
 use crate::result::SimulationResult;
 use crate::rpc_provider::RpcAccountProvider;
 use crate::transaction::{
-    ParsedTransaction, apply_ix_account_ops, apply_ix_data_patches, parse_raw_transaction,
+    MessageAccountPlan, ParsedTransaction, apply_instruction_ops, apply_ix_account_ops,
+    apply_ix_data_patches, parse_raw_transaction,
 };
 use crate::types::{AccountSource, FetchObserver, FetchPolicy, ResolvedAccounts, RpcDecision};
 
@@ -34,7 +37,7 @@ use crate::types::{AccountSource, FetchObserver, FetchPolicy, ResolvedAccounts, 
 struct OfflinePolicy;
 
 impl FetchPolicy for OfflinePolicy {
-    fn decide_rpc(&self, _unresolved: &[solana_pubkey::Pubkey]) -> RpcDecision {
+    fn decide_rpc(&self, _unresolved: &[Pubkey]) -> RpcDecision {
         RpcDecision::Deny
     }
 }
@@ -117,8 +120,14 @@ impl PipelineConfig {
 }
 
 /// Apply transaction-level mutations (instruction patches) to a transaction.
+///
+/// Whole-instruction ops (insert / remove) run first so account-level and
+/// data mutations target the post-restructure instruction list.
 fn apply_tx_mutations(tx: &mut VersionedTransaction, mutations: &Mutations) -> Result<()> {
     let tx_m = &mutations.transaction;
+    if !tx_m.instruction_ops.is_empty() {
+        apply_instruction_ops(tx, &tx_m.instruction_ops)?;
+    }
     if !tx_m.ix_account_ops.is_empty() {
         apply_ix_account_ops(tx, &tx_m.ix_account_ops)?;
     }
@@ -126,6 +135,48 @@ fn apply_tx_mutations(tx: &mut VersionedTransaction, mutations: &Mutations) -> R
         apply_ix_data_patches(tx, &tx_m.ix_data_patches)?;
     }
     Ok(())
+}
+
+/// Fetch any accounts that transaction-level mutations (e.g. an inserted
+/// instruction) introduced beyond those resolved by `load_accounts`.
+///
+/// `load_accounts` runs against the pre-mutation transaction(s); mutations
+/// are applied later (in [`LoadedPipeline::execute`] /
+/// [`LoadedBundlePipeline::execute_bundle`]). Without this step, accounts an
+/// inserted instruction references would never be fetched or
+/// dependency-resolved, leaving execution to run against missing state. The
+/// new keys (and their auto-discovered dependencies) are merged into
+/// `resolved` via the loader's [`AccountAppender`](crate::types::AccountAppender)
+/// implementation.
+fn load_introduced_accounts(
+    txs: &[&VersionedTransaction],
+    loader: &mut AccountLoader,
+    resolved: &mut ResolvedAccounts,
+) -> Result<()> {
+    let missing = collect_introduced_keys(txs, resolved);
+    if missing.is_empty() {
+        return Ok(());
+    }
+    use crate::types::AccountAppender;
+    loader.append_accounts(resolved, &missing)
+}
+
+/// Static account keys referenced by `txs` that are absent from `resolved`.
+/// Deduplicated; order is first-seen.
+fn collect_introduced_keys(
+    txs: &[&VersionedTransaction],
+    resolved: &ResolvedAccounts,
+) -> Vec<Pubkey> {
+    let mut missing = Vec::new();
+    let mut seen = HashSet::new();
+    for tx in txs {
+        for key in MessageAccountPlan::from_transaction(tx).static_accounts {
+            if !resolved.accounts.contains_key(&key) && seen.insert(key) {
+                missing.push(key);
+            }
+        }
+    }
+    missing
 }
 
 /// Prepare a ready-to-run [`SimulationRunner`] from resolved accounts and
@@ -317,10 +368,21 @@ impl LoadedPipeline {
     /// Execute the transaction simulation.
     pub fn execute(self) -> Result<SimulationResult> {
         let mutations = self.mutations.unwrap_or_default();
+        let has_tx_mutations = !mutations.transaction.is_empty();
         let mut tx = self.parsed.transaction;
         apply_tx_mutations(&mut tx, &mutations)?;
 
-        let mut runner = build_runner(&self.config, self.loader, self.resolved, mutations)?;
+        // `load_accounts` ran against the pre-mutation transaction, so accounts
+        // a mutation introduced (e.g. an inserted instruction's program) are
+        // not yet resolved. Fetch them now so execution runs with complete
+        // state. See [`load_introduced_accounts`].
+        let mut loader = self.loader;
+        let mut resolved = self.resolved;
+        if has_tx_mutations {
+            load_introduced_accounts(&[&tx], &mut loader, &mut resolved)?;
+        }
+
+        let mut runner = build_runner(&self.config, loader, resolved, mutations)?;
         let exec_result = runner.execute(&tx)?;
         Ok(SimulationResult::from_execution(exec_result))
     }
@@ -356,6 +418,7 @@ impl LoadedBundlePipeline {
     /// to detect transactions that were never attempted due to a prior failure.
     pub fn execute_bundle(self) -> Result<BundleResult<Result<SimulationResult>>> {
         let mutations = self.mutations.unwrap_or_default();
+        let has_tx_mutations = !mutations.transaction.is_empty();
 
         let mut txs: Vec<VersionedTransaction> = Vec::with_capacity(self.parsed.len());
         for parsed in &self.parsed {
@@ -364,7 +427,16 @@ impl LoadedBundlePipeline {
             txs.push(tx);
         }
 
-        let mut runner = build_runner(&self.config, self.loader, self.resolved, mutations)?;
+        // Fetch accounts the mutations introduced across the whole bundle; see
+        // [`load_introduced_accounts`].
+        let mut loader = self.loader;
+        let mut resolved = self.resolved;
+        if has_tx_mutations {
+            let tx_refs: Vec<&VersionedTransaction> = txs.iter().collect();
+            load_introduced_accounts(&tx_refs, &mut loader, &mut resolved)?;
+        }
+
+        let mut runner = build_runner(&self.config, loader, resolved, mutations)?;
 
         let tx_refs: Vec<&VersionedTransaction> = txs.iter().collect();
         let bundle = runner.execute_bundle(&tx_refs);
@@ -418,5 +490,118 @@ mod tests {
         let br_full = crate::executor::BundleResult::new(vec![Ok::<_, String>(())], 1);
         assert_eq!(br_full.skipped_count(), 0);
         assert!(br_full.is_complete());
+    }
+
+    #[test]
+    fn execute_fetches_accounts_introduced_by_inserted_instruction() {
+        // `load_accounts` runs against the pre-mutation transaction, so accounts
+        // an inserted instruction references would never be loaded without an
+        // explicit append-fetch step during execute(). Verify the inserted keys
+        // are requested from the provider.
+        use std::sync::Mutex;
+
+        use solana_account::AccountSharedData;
+
+        use crate::rpc_provider::RpcAccountProvider;
+
+        struct RecordingProvider {
+            requested: Arc<Mutex<Vec<Pubkey>>>,
+        }
+        impl RpcAccountProvider for RecordingProvider {
+            fn get_multiple_accounts(
+                &self,
+                pubkeys: &[Pubkey],
+            ) -> Result<Vec<Option<AccountSharedData>>> {
+                self.requested.lock().unwrap().extend_from_slice(pubkeys);
+                Ok(vec![None; pubkeys.len()])
+            }
+        }
+
+        let requested = Arc::new(Mutex::new(Vec::new()));
+        let provider = Arc::new(RecordingProvider { requested: requested.clone() });
+
+        // Two brand-new keys absent from the original transfer transaction.
+        let inserted_program = Pubkey::new_unique();
+        let inserted_account = Pubkey::new_unique();
+        let insert_ix = solana_instruction::Instruction {
+            program_id: inserted_program,
+            accounts: vec![solana_instruction::AccountMeta::new_readonly(inserted_account, false)],
+            data: vec![],
+        };
+        let mutations = Mutations::builder()
+            .add_instruction_op(crate::types::InstructionOp::Insert {
+                position: 0,
+                instruction: insert_ix,
+            })
+            .build();
+
+        let pipeline = Pipeline::with_provider(provider)
+            .parse(TEST_TX_BASE64)
+            .unwrap()
+            .load_accounts()
+            .unwrap()
+            .with_mutations(mutations);
+
+        // execute() fails at simulation (inserted program is not executable),
+        // but the append-fetch of introduced keys happens before that point.
+        let _ = pipeline.execute();
+
+        let requested = requested.lock().unwrap();
+        assert!(
+            requested.contains(&inserted_program),
+            "inserted instruction's program must be fetched after mutation; got: {:?}",
+            *requested
+        );
+        assert!(
+            requested.contains(&inserted_account),
+            "inserted instruction's account must be fetched after mutation; got: {:?}",
+            *requested
+        );
+    }
+
+    #[test]
+    fn execute_without_mutations_does_not_refetch_accounts() {
+        // When no transaction mutations are present, execute() must not perform
+        // any extra fetches (the append-fetch step is skipped entirely).
+        use std::sync::Mutex;
+
+        use solana_account::AccountSharedData;
+
+        use crate::rpc_provider::RpcAccountProvider;
+
+        struct CountingProvider {
+            requested: Arc<Mutex<Vec<Pubkey>>>,
+        }
+        impl RpcAccountProvider for CountingProvider {
+            fn get_multiple_accounts(
+                &self,
+                pubkeys: &[Pubkey],
+            ) -> Result<Vec<Option<AccountSharedData>>> {
+                self.requested.lock().unwrap().extend_from_slice(pubkeys);
+                Ok(vec![None; pubkeys.len()])
+            }
+        }
+
+        let requested = Arc::new(Mutex::new(Vec::new()));
+        let provider = Arc::new(CountingProvider { requested: requested.clone() });
+
+        // No mutations: load_accounts fetches the original keys; execute()
+        // should not append-fetch anything.
+        let pipeline = Pipeline::with_provider(provider)
+            .parse(TEST_TX_BASE64)
+            .unwrap()
+            .load_accounts()
+            .unwrap();
+        let load_keys = requested.lock().unwrap().clone();
+        assert!(!load_keys.is_empty());
+        let _ = pipeline.execute();
+        let after = requested.lock().unwrap().clone();
+        assert_eq!(
+            after.len(),
+            load_keys.len(),
+            "execute() without mutations must not fetch any extra accounts; load fetched {:?}, after execute got {:?}",
+            load_keys,
+            after
+        );
     }
 }

--- a/crates/sonar-sim/src/transaction.rs
+++ b/crates/sonar-sim/src/transaction.rs
@@ -1,13 +1,16 @@
+use std::collections::HashMap;
 use std::fmt;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use bs58::decode::Error as Base58Error;
 use serde::Serialize;
+use solana_instruction::Instruction;
 use solana_message::MessageHeader;
 use solana_message::VersionedMessage;
 use solana_message::compiled_instruction::CompiledInstruction;
 use solana_pubkey::Pubkey;
+use solana_signature::Signature;
 use solana_transaction::versioned::{TransactionVersion, VersionedTransaction};
 
 use crate::error::{Result, SonarSimError};
@@ -185,6 +188,304 @@ pub fn build_lookup_locations(plan: &[AddressLookupPlan]) -> Vec<LookupLocation>
     }
 
     locations
+}
+
+/// Apply a list of whole-instruction mutations (insert / remove) to a
+/// transaction in-place.
+///
+/// Returns the updated `MessageAccountPlan` reflecting any keys added to the
+/// message's static `account_keys` table.
+///
+/// Operations apply in the order given; indices and positions are interpreted
+/// against the instruction list at the time each op runs. To express
+/// positions relative to the pre-mutation list, list ops in descending
+/// position order.
+///
+/// Intended to run *before* account-level ([`apply_ix_account_ops`]) and data
+/// ([`apply_ix_data_patches`]) mutations, so those can target the
+/// post-restructure instruction list.
+///
+/// `Remove` does not garbage-collect account keys (matching account-level
+/// `Remove`). `Insert` merges the new instruction's accounts into the message
+/// with **union** privileges: an existing key is never demoted, only promoted,
+/// so the inserted instruction cannot weaken privileges an existing
+/// instruction already requires. New non-signer accounts are appended (writable
+/// before the read-only section), and new signer accounts are inserted into the
+/// signer section with a placeholder signature. An account already present as
+/// a non-signer cannot be promoted to signer.
+///
+/// **Limitation (v0 messages with ALTs):** like [`apply_ix_account_ops`],
+/// duplicate detection only covers static account keys.
+pub fn apply_instruction_ops(
+    tx: &mut VersionedTransaction,
+    ops: &[crate::types::InstructionOp],
+) -> Result<MessageAccountPlan> {
+    for op in ops {
+        let count = tx.message.instructions().len();
+        match op {
+            crate::types::InstructionOp::Remove { index } => {
+                if *index >= count {
+                    return Err(SonarSimError::Validation {
+                        reason: format!(
+                            "Instruction index {index} is out of range \
+                             (transaction has {count} instructions)"
+                        ),
+                    });
+                }
+                tx.message.instructions_mut().remove(*index);
+            }
+            crate::types::InstructionOp::Insert { position, instruction } => {
+                if *position > count {
+                    return Err(SonarSimError::Validation {
+                        reason: format!(
+                            "Insert position {position} is out of range for the \
+                             instruction list (has {count} instructions; valid insert \
+                             positions are 0..={count})"
+                        ),
+                    });
+                }
+                let compiled = compile_instruction(tx, instruction)?;
+                tx.message.instructions_mut().insert(*position, compiled);
+            }
+        }
+    }
+
+    Ok(MessageAccountPlan::from_transaction(tx))
+}
+
+/// Compile a decoded [`Instruction`] into a [`CompiledInstruction`] against
+/// the transaction's current message, inserting any missing account keys
+/// (including new signers) and returning the resolved program/account indices.
+///
+/// All keys are inserted/ensured *before* resolving indices, so the returned
+/// indices are stable regardless of the order in which keys get added.
+fn compile_instruction(
+    tx: &mut VersionedTransaction,
+    instruction: &Instruction,
+) -> Result<CompiledInstruction> {
+    // Phase 1: merge every referenced key into the message with **union**
+    // privileges — an existing key is never demoted, only promoted — so the
+    // inserted instruction cannot weaken privileges an existing instruction
+    // already requires (Solana message privileges are global across all
+    // instructions). Programs are always read-only non-signers.
+    //
+    // Aggregate the signer/writable requirements PER PUBKEY before mutating,
+    // because Solana unions duplicate account privileges within an
+    // instruction regardless of meta order. Without aggregation, a pubkey
+    // listed first as a non-signer and later as a signer would be inserted as
+    // a non-signer by the first meta and then rejected ("unsupported
+    // promotion") by the second. `order` preserves first-seen order purely
+    // for deterministic placement; actual position is governed by privilege
+    // region.
+    let mut order: Vec<Pubkey> = Vec::new();
+    let mut requirements: HashMap<Pubkey, (bool, bool)> = HashMap::new();
+    // Program first as an implicit read-only non-signer meta; any explicit
+    // account-list occurrence of the same key unions on top of it.
+    if requirements.insert(instruction.program_id, (false, false)).is_none() {
+        order.push(instruction.program_id);
+    }
+    for account in &instruction.accounts {
+        match requirements.get_mut(&account.pubkey) {
+            Some((want_signer, want_writable)) => {
+                *want_signer |= account.is_signer;
+                *want_writable |= account.is_writable;
+            }
+            None => {
+                requirements.insert(account.pubkey, (account.is_signer, account.is_writable));
+                order.push(account.pubkey);
+            }
+        }
+    }
+    for pubkey in &order {
+        let (want_signer, want_writable) = requirements[pubkey];
+        merge_or_insert_account_key(tx, pubkey, want_signer, want_writable)?;
+    }
+
+    // Phase 2: re-resolve every index by pubkey lookup so the result is
+    // unaffected by any index shifting that the insertions performed above.
+    let keys = tx.message.account_keys();
+    let program_id_index =
+        keys.iter().position(|k| *k == instruction.program_id).ok_or_else(|| {
+            SonarSimError::Validation {
+                reason: "Internal error: program key missing after insert".into(),
+            }
+        })?;
+    let accounts = instruction
+        .accounts
+        .iter()
+        .map(|account| {
+            keys.iter().position(|k| *k == account.pubkey).map(|i| i as u8).ok_or_else(|| {
+                SonarSimError::Validation {
+                    reason: "Internal error: account key missing after insert".into(),
+                }
+            })
+        })
+        .collect::<Result<Vec<u8>>>()?;
+
+    Ok(CompiledInstruction {
+        program_id_index: program_id_index as u8,
+        accounts,
+        data: instruction.data.clone(),
+    })
+}
+
+/// Merge an account reference into the message applying **union** privileges.
+///
+/// Solana message privileges (signer / writable) are global across all
+/// instructions: an account is a signer if *any* instruction needs it as one,
+/// and writable if *any* instruction needs it writable. Consequently an
+/// existing key is **never demoted** — only promoted — when a new instruction
+/// references it. This is the correctness rule used while compiling an inserted
+/// instruction, so it cannot silently strip write access that an existing
+/// instruction already requires.
+///
+/// `want_signer` / `want_writable` express only what *this* reference needs;
+/// the resulting privileges are the union with whatever the key already has.
+///
+/// Returns the key's resulting index (which may change if a promotion swaps it
+/// to a different position).
+fn merge_or_insert_account_key(
+    tx: &mut VersionedTransaction,
+    pubkey: &Pubkey,
+    want_signer: bool,
+    want_writable: bool,
+) -> Result<usize> {
+    let message = &mut tx.message;
+    let Some(pos) = message.account_keys().iter().position(|k| *k == *pubkey) else {
+        // Absent: insert with the exact privileges this reference needs.
+        return if want_signer {
+            insert_signer_account_key(tx, pubkey, want_writable)
+        } else {
+            find_or_insert_account_key(&mut tx.message, pubkey, want_writable)
+        };
+    };
+
+    let num_sigs = message.header().num_required_signatures as usize;
+    let cur_signer = pos < num_sigs;
+    // Union of signer-ness: promoting a non-signer to a signer is unsupported
+    // (it requires rebuilding the header and signature layout).
+    if want_signer && !cur_signer {
+        let key = message.static_account_keys()[pos];
+        return Err(SonarSimError::Validation {
+            reason: format!(
+                "Cannot declare account {key} as a signer for the inserted instruction: \
+                 it already appears in the message as a non-signer account. Promoting a \
+                 non-signer to a signer is not supported."
+            ),
+        });
+    }
+
+    // Union of writability: never demote. Only promote readonly -> writable.
+    let cur_writable = account_is_writable(message, pos);
+    if cur_writable || !want_writable {
+        // Already writable, or this reference doesn't need writable: keep the
+        // current (possibly stronger) privileges untouched.
+        return Ok(pos);
+    }
+    promote_to_writable(tx, pos, cur_signer)
+}
+
+/// Whether the key at `pos` is writable under the current message header.
+///
+/// Signers are writable in `[0, num_required_signatures -
+/// num_readonly_signed_accounts)`; non-signers are writable before the
+/// readonly-unsigned region.
+fn account_is_writable(message: &VersionedMessage, pos: usize) -> bool {
+    let header = message.header();
+    let num_sigs = header.num_required_signatures as usize;
+    let num_readonly_signed = header.num_readonly_signed_accounts as usize;
+    if pos < num_sigs {
+        pos < num_sigs - num_readonly_signed
+    } else {
+        let total = message.static_account_keys().len();
+        let readonly_unsigned = header.num_readonly_unsigned_accounts as usize;
+        pos < total - readonly_unsigned
+    }
+}
+
+/// Promote an existing readonly key at `pos` to writable, relocating it into
+/// the writable region and shrinking the corresponding readonly header count.
+/// Signer and non-signer promotions are handled symmetrically. Returns the
+/// key's new position after the swap.
+///
+/// Caller invariant: `pos` currently holds a readonly key (signer or
+/// non-signer), so the relevant readonly header count is non-zero.
+fn promote_to_writable(tx: &mut VersionedTransaction, pos: usize, signer: bool) -> Result<usize> {
+    if signer {
+        // Promote readonly-signer -> writable-signer: swap with the first
+        // readonly signer (the writable/readonly signer boundary) and shrink
+        // the readonly-signed region by one. Both positions are signers, so
+        // the signature slots must move with their keys — use
+        // [`swap_signer_positions`] to preserve the VersionedTransaction
+        // invariant that signatures line up with signer keys.
+        let (num_sigs, num_readonly_signed) = {
+            let header = tx.message.header();
+            (header.num_required_signatures as usize, header.num_readonly_signed_accounts as usize)
+        };
+        debug_assert!(
+            num_readonly_signed > 0,
+            "readonly-signer promotion requires a non-empty readonly-signed region"
+        );
+        let boundary = num_sigs - num_readonly_signed;
+        swap_signer_positions(tx, pos, boundary);
+        tx.message.header_mut().num_readonly_signed_accounts -= 1;
+        Ok(boundary)
+    } else {
+        // Promote readonly non-signer -> writable non-signer: swap with the
+        // first readonly non-signer and shrink the readonly-unsigned region.
+        let message = &mut tx.message;
+        let total = message.static_account_keys().len();
+        let readonly_unsigned = message.header().num_readonly_unsigned_accounts as usize;
+        debug_assert!(
+            readonly_unsigned > 0,
+            "readonly non-signer promotion requires a non-empty readonly-unsigned region"
+        );
+        let readonly_start = total - readonly_unsigned;
+        swap_account_positions(message, pos, readonly_start);
+        message.header_mut().num_readonly_unsigned_accounts -= 1;
+        Ok(readonly_start)
+    }
+}
+
+/// Insert a brand-new signer account into the message's signer section.
+///
+/// The caller MUST ensure `pubkey` is not already present — the present-key
+/// union case is handled by [`merge_or_insert_account_key`]. The key is
+/// inserted into the signer section (writable signers before readonly
+/// signers), all existing instruction indices at or past the insertion point
+/// are shifted by +1, the header's signer counts are bumped, and a placeholder
+/// signature is appended at the matching signer slot so existing signatures
+/// keep aligning with their signers.
+fn insert_signer_account_key(
+    tx: &mut VersionedTransaction,
+    pubkey: &Pubkey,
+    writable: bool,
+) -> Result<usize> {
+    let message = &mut tx.message;
+    let total = message.account_keys().len();
+    if total >= u8::MAX as usize {
+        return Err(SonarSimError::Validation {
+            reason: "Cannot add signer account key: would exceed u8 index limit".into(),
+        });
+    }
+
+    let num_sigs = message.header().num_required_signatures as usize;
+    let num_readonly_signed = message.header().num_readonly_signed_accounts as usize;
+    // Writable signers precede readonly signers within the signer section.
+    let insert_pos = if writable { num_sigs - num_readonly_signed } else { num_sigs };
+
+    message.account_keys_mut().insert(insert_pos, *pubkey);
+    shift_indices(message.instructions_mut(), insert_pos)?;
+    message.header_mut().num_required_signatures += 1;
+    if !writable {
+        message.header_mut().num_readonly_signed_accounts += 1;
+    }
+    // Keep `signatures` length in sync with `num_required_signatures`, inserting
+    // a placeholder at the same slot so existing signatures still align with
+    // their signers. Simulation does not cryptographically verify these unless
+    // the caller opts in, so a default signature is sufficient.
+    tx.signatures.insert(insert_pos, Signature::default());
+    Ok(insert_pos)
 }
 
 /// Apply a list of instruction-account mutations to a transaction in-place.
@@ -419,6 +720,12 @@ fn ensure_account_writability(
 }
 
 /// Swap two positions in the account_keys and update all instruction references.
+///
+/// Only safe for positions outside the signer region (`>=
+/// num_required_signatures`): swapping signer keys without also swapping their
+/// signature slots would violate the [`VersionedTransaction`] invariant that
+/// `signatures[i]` belongs to the signer at `account_keys[i]`. Use
+/// [`swap_signer_positions`] when either position is a signer.
 fn swap_account_positions(message: &mut VersionedMessage, a: usize, b: usize) {
     if a == b {
         return;
@@ -426,6 +733,27 @@ fn swap_account_positions(message: &mut VersionedMessage, a: usize, b: usize) {
     let (a_u8, b_u8) = (a as u8, b as u8);
     message.account_keys_mut().swap(a, b);
     remap_indices(message.instructions_mut(), a_u8, b_u8);
+}
+
+/// Swap two signer positions, keeping `signatures` aligned with their signer
+/// keys.
+///
+/// [`VersionedTransaction`] requires `signatures[i]` to be the signature for
+/// the signer at `account_keys[i]` (for `i < num_required_signatures`). When
+/// two signer keys are swapped in `account_keys`, their signature slots must
+/// be swapped in lockstep, or downstream signature verification would
+/// associate each signature with the wrong signer. Both `a` and `b` must be
+/// in the signer region.
+fn swap_signer_positions(tx: &mut VersionedTransaction, a: usize, b: usize) {
+    if a == b {
+        return;
+    }
+    debug_assert!(
+        a < tx.signatures.len() && b < tx.signatures.len(),
+        "swap_signer_positions indices must be within the signer region"
+    );
+    swap_account_positions(&mut tx.message, a, b);
+    tx.signatures.swap(a, b);
 }
 
 /// Swap all instruction references between indices `a` and `b`.
@@ -1190,5 +1518,536 @@ mod tests {
         assert!(!locations[1].writable);
         assert_eq!(locations[2].table_index, 21);
         assert!(!locations[2].writable);
+    }
+
+    // ── apply_instruction_ops: remove ──
+
+    #[test]
+    fn apply_instruction_remove_drops_instruction() {
+        let (mut tx, _payer) = sample_transaction();
+        // Start with one instruction; remove it.
+        assert_eq!(tx.message.instructions().len(), 1);
+        apply_instruction_ops(&mut tx, &[crate::types::InstructionOp::Remove { index: 0 }])
+            .unwrap();
+        assert!(tx.message.instructions().is_empty());
+    }
+
+    #[test]
+    fn apply_instruction_remove_shifts_subsequent_indices() {
+        // Build a 2-instruction transaction so we can observe index shifting.
+        let payer = Keypair::new();
+        let recipient = Pubkey::new_unique();
+        let blockhash = Hash::new_unique();
+        let ix1 = system_instruction::transfer(&payer.pubkey(), &recipient, 1);
+        let ix2 = system_instruction::transfer(&payer.pubkey(), &recipient, 2);
+        let message = Message::new(&[ix1, ix2], Some(&payer.pubkey()));
+        let transaction = Transaction::new(&[&payer], message, blockhash);
+        let mut tx = VersionedTransaction::from(transaction);
+        assert_eq!(tx.message.instructions().len(), 2);
+
+        // Remove instruction 0; the second instruction becomes the first.
+        apply_instruction_ops(&mut tx, &[crate::types::InstructionOp::Remove { index: 0 }])
+            .unwrap();
+        assert_eq!(tx.message.instructions().len(), 1);
+        // The surviving instruction carries ix2's data (amount = 2 lamports,
+        // encoded as little-endian u64 at the start of the data after the
+        // 4-byte transfer discriminator).
+        let data = &tx.message.instructions()[0].data;
+        let amount = u64::from_le_bytes(data[4..12].try_into().unwrap());
+        assert_eq!(amount, 2);
+    }
+
+    #[test]
+    fn apply_instruction_remove_rejects_out_of_range() {
+        let (mut tx, _payer) = sample_transaction();
+        let err =
+            apply_instruction_ops(&mut tx, &[crate::types::InstructionOp::Remove { index: 5 }])
+                .unwrap_err();
+        assert!(err.to_string().contains("out of range"));
+    }
+
+    // ── apply_instruction_ops: insert ──
+
+    fn memo_instruction(payer: Pubkey, text: &str) -> Instruction {
+        // Memo program: no accounts, data is the raw UTF-8 text. Add the payer
+        // as a writable signer so we exercise the signer-insert path.
+        Instruction {
+            program_id: solana_pubkey::pubkey!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
+            accounts: vec![solana_instruction::AccountMeta::new(payer, true)],
+            data: text.as_bytes().to_vec(),
+        }
+    }
+
+    #[test]
+    fn apply_instruction_insert_appends_with_existing_keys() {
+        let (mut tx, payer) = sample_transaction();
+        // Insert a transfer that reuses the payer (existing signer) and the
+        // existing system program — no new keys should be added.
+        let recipient = tx.message.static_account_keys()[1];
+        let system_program = tx.message.static_account_keys()[2];
+        let ix = Instruction {
+            program_id: system_program,
+            accounts: vec![
+                solana_instruction::AccountMeta::new(payer, true),
+                solana_instruction::AccountMeta::new(recipient, false),
+            ],
+            data: vec![2, 0, 0, 0, 99, 0, 0, 0, 0, 0, 0, 0],
+        };
+        let count = tx.message.instructions().len();
+        apply_instruction_ops(
+            &mut tx,
+            &[crate::types::InstructionOp::Insert { position: count, instruction: ix }],
+        )
+        .unwrap();
+
+        assert_eq!(tx.message.instructions().len(), count + 1);
+        // No new keys: account table unchanged.
+        assert_eq!(tx.message.static_account_keys().len(), 3);
+        let inserted = &tx.message.instructions()[count];
+        assert_eq!(inserted.program_id_index, 2);
+        assert_eq!(inserted.accounts, vec![0, 1]);
+    }
+
+    #[test]
+    fn apply_instruction_insert_new_non_signer_keys() {
+        let (mut tx, payer) = sample_transaction();
+        let new_program = Pubkey::new_unique();
+        let new_writable = Pubkey::new_unique();
+        let new_readonly = Pubkey::new_unique();
+        let ix = Instruction {
+            program_id: new_program,
+            accounts: vec![
+                solana_instruction::AccountMeta::new(payer, true),
+                solana_instruction::AccountMeta::new(new_writable, false),
+                solana_instruction::AccountMeta::new_readonly(new_readonly, false),
+            ],
+            data: vec![0xab],
+        };
+        apply_instruction_ops(
+            &mut tx,
+            &[crate::types::InstructionOp::Insert { position: 0, instruction: ix }],
+        )
+        .unwrap();
+
+        // Original: [payer(ws,0), recipient(wu,1), system_program(ru,2)]
+        // Adds: new_program(readonly unsigned, appended), new_writable (wu,
+        //   inserted before readonly section), new_readonly (readonly unsigned).
+        // Final static layout:
+        //   [payer(0), recipient(1), new_writable(2), system_program(3),
+        //    new_program(4), new_readonly(5)]
+        let keys = tx.message.static_account_keys();
+        assert_eq!(keys.len(), 6);
+        assert_eq!(keys[2], new_writable);
+        assert_eq!(keys[4], new_program);
+        assert_eq!(keys[5], new_readonly);
+        let ix0 = &tx.message.instructions()[0];
+        assert_eq!(ix0.program_id_index, 4);
+        assert_eq!(ix0.accounts, vec![0, 2, 5]);
+        // num_readonly_unsigned grew by 3 (system_program + new_program + new_readonly
+        // all readonly unsigned): originally 1, now 3.
+        assert_eq!(tx.message.header().num_readonly_unsigned_accounts, 3);
+    }
+
+    #[test]
+    fn apply_instruction_insert_new_signer_bumps_header_and_signature() {
+        let (mut tx, _payer) = sample_transaction();
+        // Original header: num_required_signatures=1, readonly_signed=0.
+        let new_signer = Pubkey::new_unique();
+        let ix = Instruction {
+            program_id: tx.message.static_account_keys()[2], // system program
+            accounts: vec![solana_instruction::AccountMeta::new(new_signer, true)],
+            data: vec![],
+        };
+        assert_eq!(tx.signatures.len(), 1);
+        apply_instruction_ops(
+            &mut tx,
+            &[crate::types::InstructionOp::Insert { position: 0, instruction: ix }],
+        )
+        .unwrap();
+
+        // New signer inserted into the writable-signer region (before any
+        // readonly signers); num_required_signatures bumps to 2.
+        assert_eq!(tx.message.header().num_required_signatures, 2);
+        assert_eq!(tx.message.header().num_readonly_signed_accounts, 0);
+        assert_eq!(tx.signatures.len(), 2);
+        // The new signer lands at index 1 (after the existing writable payer at 0).
+        assert_eq!(tx.message.static_account_keys()[1], new_signer);
+        let ix0 = &tx.message.instructions()[0];
+        assert_eq!(ix0.accounts, vec![1]);
+    }
+
+    #[test]
+    fn apply_instruction_insert_readonly_signer_appended_to_signer_section() {
+        let (mut tx, _payer) = sample_transaction();
+        let new_signer = Pubkey::new_unique();
+        let system_program = tx.message.static_account_keys()[2];
+        let ix = Instruction {
+            program_id: system_program,
+            accounts: vec![solana_instruction::AccountMeta::new_readonly(new_signer, true)],
+            data: vec![],
+        };
+        apply_instruction_ops(
+            &mut tx,
+            &[crate::types::InstructionOp::Insert { position: 0, instruction: ix }],
+        )
+        .unwrap();
+
+        // Read-only signer sits at the end of the signer section (index 1),
+        // so readonly_signed bumps to 1 while num_required_signatures bumps to 2.
+        assert_eq!(tx.message.header().num_required_signatures, 2);
+        assert_eq!(tx.message.header().num_readonly_signed_accounts, 1);
+        assert_eq!(tx.message.static_account_keys()[1], new_signer);
+        assert_eq!(tx.signatures.len(), 2);
+        let ix0 = &tx.message.instructions()[0];
+        assert_eq!(ix0.accounts, vec![1]);
+    }
+
+    #[test]
+    fn apply_instruction_insert_rejects_promoting_non_signer_to_signer() {
+        let (mut tx, _payer) = sample_transaction();
+        // recipient is a writable non-signer at index 1; try to insert an ix
+        // that declares it as a signer.
+        let recipient = tx.message.static_account_keys()[1];
+        let system_program = tx.message.static_account_keys()[2];
+        let ix = Instruction {
+            program_id: system_program,
+            accounts: vec![solana_instruction::AccountMeta::new(recipient, true)],
+            data: vec![],
+        };
+        let err = apply_instruction_ops(
+            &mut tx,
+            &[crate::types::InstructionOp::Insert { position: 0, instruction: ix }],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("non-signer"), "got: {err}");
+    }
+
+    #[test]
+    fn apply_instruction_insert_rejects_out_of_range_position() {
+        let (mut tx, _payer) = sample_transaction();
+        let count = tx.message.instructions().len();
+        let program = tx.message.static_account_keys()[2];
+        let ix = Instruction { program_id: program, accounts: vec![], data: vec![] };
+        let err = apply_instruction_ops(
+            &mut tx,
+            &[crate::types::InstructionOp::Insert { position: count + 1, instruction: ix }],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("out of range"));
+    }
+
+    // ── apply_instruction_ops: union privileges (never demote, only promote) ──
+
+    /// Builds a tx whose message header has both a writable signer and a
+    /// readonly signer, returning the two signer keys plus the (readonly)
+    /// system program key. Layout: [writable_signer(ws), readonly_signer(rs),
+    /// system_program(ru)].
+    fn sample_transaction_with_readonly_signer() -> (VersionedTransaction, Pubkey, Pubkey) {
+        let writable_signer = Keypair::new();
+        let readonly_signer = Keypair::new();
+        let blockhash = Hash::new_unique();
+        // A harmless instruction to system program listing both signers so the
+        // message header reflects their roles. Empty data keeps it inert.
+        let ix = Instruction {
+            program_id: solana_sdk_ids::system_program::id(),
+            accounts: vec![
+                solana_instruction::AccountMeta::new(writable_signer.pubkey(), true),
+                solana_instruction::AccountMeta::new_readonly(readonly_signer.pubkey(), true),
+                solana_instruction::AccountMeta::new_readonly(
+                    solana_sdk_ids::system_program::id(),
+                    false,
+                ),
+            ],
+            data: vec![],
+        };
+        let message = Message::new(&[ix], Some(&writable_signer.pubkey()));
+        let transaction =
+            Transaction::new(&[&writable_signer, &readonly_signer], message, blockhash);
+        (
+            VersionedTransaction::from(transaction),
+            writable_signer.pubkey(),
+            readonly_signer.pubkey(),
+        )
+    }
+
+    /// Like [`sample_transaction_with_readonly_signer`] but with **two** readonly
+    /// signers, so layout is:
+    /// `[writable_signer(ws,0), readonly_signer_a(rs,1), readonly_signer_b(rs,2),
+    /// system_program(ru,3)]`. The second readonly signer (index 2) is NOT at the
+    /// writable/readonly-signer boundary (index 1), which is the exact shape that
+    /// makes a signer-promotion swap non-trivial and can misalign signatures.
+    fn sample_transaction_with_two_readonly_signers() -> (VersionedTransaction, Pubkey, Pubkey) {
+        let writable_signer = Keypair::new();
+        let readonly_signer_a = Keypair::new();
+        let readonly_signer_b = Keypair::new();
+        let blockhash = Hash::new_unique();
+        let ix = Instruction {
+            program_id: solana_sdk_ids::system_program::id(),
+            accounts: vec![
+                solana_instruction::AccountMeta::new(writable_signer.pubkey(), true),
+                solana_instruction::AccountMeta::new_readonly(readonly_signer_a.pubkey(), true),
+                solana_instruction::AccountMeta::new_readonly(readonly_signer_b.pubkey(), true),
+                solana_instruction::AccountMeta::new_readonly(
+                    solana_sdk_ids::system_program::id(),
+                    false,
+                ),
+            ],
+            data: vec![],
+        };
+        let message = Message::new(&[ix], Some(&writable_signer.pubkey()));
+        let transaction = Transaction::new(
+            &[&writable_signer, &readonly_signer_a, &readonly_signer_b],
+            message,
+            blockhash,
+        );
+        (
+            VersionedTransaction::from(transaction),
+            readonly_signer_a.pubkey(),
+            readonly_signer_b.pubkey(),
+        )
+    }
+
+    #[test]
+    fn apply_instruction_insert_does_not_demote_writable_non_signer() {
+        let (mut tx, _payer) = sample_transaction();
+        // sample tx: [payer(ws,0), recipient(wu,1), system_program(ru,2)].
+        // The original transfer needs `recipient` writable. Insert an
+        // instruction that references `recipient` as read-only: union rules
+        // must keep it writable so the existing instruction keeps working.
+        let recipient = tx.message.static_account_keys()[1];
+        let system_program = tx.message.static_account_keys()[2];
+        let ix = Instruction {
+            program_id: system_program,
+            accounts: vec![solana_instruction::AccountMeta::new_readonly(recipient, false)],
+            data: vec![],
+        };
+        let readonly_unsigned_before = tx.message.header().num_readonly_unsigned_accounts;
+        apply_instruction_ops(
+            &mut tx,
+            &[crate::types::InstructionOp::Insert { position: 0, instruction: ix }],
+        )
+        .unwrap();
+
+        // No new keys added, no writability header change.
+        assert_eq!(tx.message.static_account_keys().len(), 3);
+        assert_eq!(tx.message.header().num_readonly_unsigned_accounts, readonly_unsigned_before);
+        let recipient_pos =
+            tx.message.static_account_keys().iter().position(|k| *k == recipient).unwrap();
+        assert!(account_is_writable(&tx.message, recipient_pos));
+    }
+
+    #[test]
+    fn apply_instruction_insert_does_not_demote_writable_signer() {
+        let (mut tx, payer) = sample_transaction();
+        // payer is a writable signer. Insert an instruction referencing it as a
+        // readonly signer: before the fix this errored ("signer writability is
+        // fixed"); union rules must keep it writable with no error.
+        let system_program = tx.message.static_account_keys()[2];
+        let ix = Instruction {
+            program_id: system_program,
+            accounts: vec![solana_instruction::AccountMeta::new_readonly(payer, true)],
+            data: vec![],
+        };
+        apply_instruction_ops(
+            &mut tx,
+            &[crate::types::InstructionOp::Insert { position: 0, instruction: ix }],
+        )
+        .expect("referencing a writable signer as readonly-signer must not error");
+
+        let payer_pos = tx.message.static_account_keys().iter().position(|k| *k == payer).unwrap();
+        assert!(account_is_writable(&tx.message, payer_pos));
+        // Still a single signer; not promoted/demoted.
+        assert_eq!(tx.message.header().num_required_signatures, 1);
+        assert_eq!(tx.message.header().num_readonly_signed_accounts, 0);
+    }
+
+    #[test]
+    fn apply_instruction_insert_promotes_readonly_non_signer_to_writable() {
+        let (mut tx, _payer) = sample_transaction();
+        // system_program is readonly unsigned (index 2). Insert an instruction
+        // referencing it as writable: union must promote it.
+        let system_program = tx.message.static_account_keys()[2];
+        let ix = Instruction {
+            program_id: system_program,
+            accounts: vec![solana_instruction::AccountMeta::new(system_program, false)],
+            data: vec![],
+        };
+        assert_eq!(tx.message.header().num_readonly_unsigned_accounts, 1);
+        apply_instruction_ops(
+            &mut tx,
+            &[crate::types::InstructionOp::Insert { position: 0, instruction: ix }],
+        )
+        .unwrap();
+
+        let pos =
+            tx.message.static_account_keys().iter().position(|k| *k == system_program).unwrap();
+        assert!(account_is_writable(&tx.message, pos));
+        assert_eq!(tx.message.header().num_readonly_unsigned_accounts, 0);
+    }
+
+    #[test]
+    fn apply_instruction_insert_promotes_readonly_signer_to_writable_signer() {
+        let (mut tx, _writable_signer, readonly_signer) = sample_transaction_with_readonly_signer();
+        // Layout: [writable_signer(ws,0), readonly_signer(rs,1), system_program(ru,2)].
+        assert_eq!(tx.message.header().num_readonly_signed_accounts, 1);
+        let system_program = tx.message.static_account_keys()[2];
+        let ix = Instruction {
+            program_id: system_program,
+            accounts: vec![solana_instruction::AccountMeta::new(readonly_signer, true)],
+            data: vec![],
+        };
+        apply_instruction_ops(
+            &mut tx,
+            &[crate::types::InstructionOp::Insert { position: 0, instruction: ix }],
+        )
+        .expect("promoting a readonly signer to writable-signer must succeed");
+
+        let pos =
+            tx.message.static_account_keys().iter().position(|k| *k == readonly_signer).unwrap();
+        assert!(account_is_writable(&tx.message, pos), "readonly signer should now be writable");
+        // The readonly-signed region shrank to zero.
+        assert_eq!(tx.message.header().num_readonly_signed_accounts, 0);
+        assert_eq!(tx.message.header().num_required_signatures, 2);
+    }
+
+    #[test]
+    fn apply_instruction_insert_signer_promotion_keeps_signatures_aligned() {
+        // Regression: promoting a readonly signer that is NOT at the
+        // writable/readonly-signer boundary performs a non-trivial key swap.
+        // Swapping keys without also swapping the matching signature slots
+        // breaks the VersionedTransaction invariant that `signatures[i]`
+        // belongs to the signer at `account_keys[i]`.
+        let (mut tx, _rs_a, rs_b) = sample_transaction_with_two_readonly_signers();
+        // Layout: [ws(0), rs_a(1), rs_b(2), system_program(3,ru)].
+        // Promoting rs_b (pos 2): boundary = num_sigs(3) - readonly_signed(2)
+        // = 1, so swap(2, 1) is non-trivial — the case where a key-only swap
+        // would misalign signatures.
+        assert_eq!(tx.message.header().num_required_signatures, 3);
+        assert_eq!(tx.message.header().num_readonly_signed_accounts, 2);
+
+        // Record each signer's original signature by key.
+        let orig: Vec<(Pubkey, Signature)> = (0..tx.message.header().num_required_signatures
+            as usize)
+            .map(|i| (tx.message.static_account_keys()[i], tx.signatures[i]))
+            .collect();
+
+        let system_program = tx.message.static_account_keys()[3];
+        let ix = Instruction {
+            program_id: system_program,
+            accounts: vec![solana_instruction::AccountMeta::new(rs_b, true)],
+            data: vec![],
+        };
+        apply_instruction_ops(
+            &mut tx,
+            &[crate::types::InstructionOp::Insert { position: 0, instruction: ix }],
+        )
+        .expect("promoting a readonly signer to writable-signer must succeed");
+
+        // After promotion, each signer key must still carry its ORIGINAL
+        // signature (they just moved position together).
+        assert_eq!(tx.message.header().num_required_signatures, 3);
+        for i in 0..tx.message.header().num_required_signatures as usize {
+            let key = tx.message.static_account_keys()[i];
+            let sig = tx.signatures[i];
+            let expected = orig
+                .iter()
+                .find(|(k, _)| *k == key)
+                .map(|(_, s)| *s)
+                .expect("signer key should have a recorded signature");
+            assert_eq!(
+                sig, expected,
+                "signature at position {i} (key {key}) is misaligned after signer promotion"
+            );
+        }
+
+        // rs_b is now writable and landed at the writable/readonly boundary (pos 1).
+        let pos = tx.message.static_account_keys().iter().position(|k| *k == rs_b).unwrap();
+        assert_eq!(pos, 1);
+        assert!(account_is_writable(&tx.message, pos));
+        assert_eq!(tx.message.header().num_readonly_signed_accounts, 1);
+    }
+
+    #[test]
+    fn apply_instruction_insert_keeps_signer_when_referenced_as_non_signer() {
+        // Union: an existing signer referenced as a non-signer stays a signer
+        // (never demoted), and a non-signer meta never adds signer privilege.
+        let (mut tx, payer) = sample_transaction();
+        let system_program = tx.message.static_account_keys()[2];
+        // Reference payer as a writable non-signer.
+        let ix = Instruction {
+            program_id: system_program,
+            accounts: vec![solana_instruction::AccountMeta::new(payer, false)],
+            data: vec![],
+        };
+        apply_instruction_ops(
+            &mut tx,
+            &[crate::types::InstructionOp::Insert { position: 0, instruction: ix }],
+        )
+        .unwrap();
+        assert_eq!(tx.message.header().num_required_signatures, 1);
+        let payer_pos = tx.message.static_account_keys().iter().position(|k| *k == payer).unwrap();
+        assert!(account_is_writable(&tx.message, payer_pos));
+    }
+
+    #[test]
+    fn apply_instruction_insert_unions_duplicate_metas_regardless_of_order() {
+        // Solana unions duplicate account privileges within an instruction
+        // regardless of meta order. An account listed first as a non-signer and
+        // later as a signer must end up a signer; without per-pubkey
+        // aggregation, the first meta inserts it as a non-signer and the
+        // second rejects the promotion as unsupported.
+        let (mut tx, _payer) = sample_transaction();
+        let dup = Pubkey::new_unique();
+        let system_program = tx.message.static_account_keys()[2];
+        // Same pubkey twice: readonly non-signer FIRST, then writable signer.
+        let ix = Instruction {
+            program_id: system_program,
+            accounts: vec![
+                solana_instruction::AccountMeta::new_readonly(dup, false),
+                solana_instruction::AccountMeta::new(dup, true),
+            ],
+            data: vec![],
+        };
+        apply_instruction_ops(
+            &mut tx,
+            &[crate::types::InstructionOp::Insert { position: 0, instruction: ix }],
+        )
+        .expect("duplicate metas must be unioned, not rejected by meta order");
+
+        let pos = tx.message.static_account_keys().iter().position(|k| *k == dup).unwrap();
+        // Union: signer AND writable.
+        assert!(pos < tx.message.header().num_required_signatures as usize, "must be a signer");
+        assert!(account_is_writable(&tx.message, pos), "must be writable");
+        // One new key, one new signature.
+        assert_eq!(tx.message.header().num_required_signatures, 2);
+        assert_eq!(tx.signatures.len(), 2);
+        // The compiled instruction references the single unioned index for both
+        // metas.
+        let compiled = &tx.message.instructions()[0];
+        assert_eq!(compiled.accounts.len(), 2);
+        assert_eq!(compiled.accounts[0], compiled.accounts[1]);
+    }
+
+    #[test]
+    fn apply_instruction_ops_runs_in_order() {
+        // Insert two instructions (positions 0 and 1), then remove index 0.
+        let (mut tx, payer) = sample_transaction();
+        let first = memo_instruction(payer, "first");
+        let second = memo_instruction(payer, "second");
+
+        apply_instruction_ops(
+            &mut tx,
+            &[
+                crate::types::InstructionOp::Insert { position: 0, instruction: first },
+                crate::types::InstructionOp::Insert { position: 1, instruction: second },
+                crate::types::InstructionOp::Remove { index: 0 },
+            ],
+        )
+        .unwrap();
+
+        // After inserting two at the front then removing the first, only the
+        // "second" memo survives at index 0.
+        assert_eq!(tx.message.instructions().len(), 2);
+        assert_eq!(tx.message.instructions()[0].data, b"second");
     }
 }

--- a/crates/sonar-sim/src/types/accounts.rs
+++ b/crates/sonar-sim/src/types/accounts.rs
@@ -75,6 +75,45 @@ impl InstructionAccountOp {
     }
 }
 
+/// A whole-instruction mutation: insert a new instruction, or remove an
+/// existing one.
+///
+/// Operations apply in the order they appear in the mutation list. Indices and
+/// positions are 0-based at this layer; CLI surfaces convert from 1-based.
+///
+/// Whole-instruction ops are intended to run as a restructuring phase
+/// *before* account-level ([`InstructionAccountOp`]) and data
+/// ([`InstructionDataPatch`]) mutations, so that the latter can target the
+/// post-restructure instruction list.
+#[derive(Clone, Debug)]
+pub enum InstructionOp {
+    /// Remove the instruction at `index`. Subsequent instructions shift left
+    /// by one. Does not garbage-collect account keys from the message —
+    /// unreferenced keys remain loadable (matching account-level `Remove`).
+    Remove { index: usize },
+    /// Insert `instruction` at `position` (0-based). Existing instructions at
+    /// and after `position` shift right by one. `position` may equal the
+    /// current instruction count to append.
+    ///
+    /// The instruction's accounts are merged into the message's account table.
+    /// New non-signer accounts are appended (writable keys before the
+    /// read-only section; read-only keys at the end) and new signer accounts
+    /// are inserted into the signer section with a placeholder signature.
+    /// An account that already appears as a non-signer cannot be promoted to
+    /// signer in the same op.
+    Insert { position: usize, instruction: solana_instruction::Instruction },
+}
+
+impl InstructionOp {
+    /// Returns the insertion position for `Insert`, or `None` for `Remove`.
+    pub fn position(&self) -> Option<usize> {
+        match self {
+            Self::Insert { position, .. } => Some(*position),
+            Self::Remove { .. } => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ResolvedAccounts {
     pub accounts: HashMap<Pubkey, AccountSharedData>,

--- a/crates/sonar-sim/src/types/mod.rs
+++ b/crates/sonar-sim/src/types/mod.rs
@@ -4,7 +4,7 @@ mod simulation;
 mod traits;
 
 pub use accounts::{
-    AccountDataPatch, AccountOverride, InstructionAccountOp, InstructionDataPatch,
+    AccountDataPatch, AccountOverride, InstructionAccountOp, InstructionDataPatch, InstructionOp,
     ResolvedAccounts, ResolvedLookup,
 };
 pub use funding::{PreparedTokenFunding, SolFunding, TokenAmount, TokenFunding};

--- a/docs/simulate.md
+++ b/docs/simulate.md
@@ -184,6 +184,48 @@ sonar simulate <TX> --rpc-url <RPC_URL> \
 # pre-mutation list, list ops in descending position order — e.g. above we
 # remove position 4 before position 2 so both refer to the original numbering.
 
+#### Whole-instruction insert / remove
+
+```bash
+# Remove a whole instruction (1-based index). Subsequent instructions shift
+# left by one. The account_keys table is left intact (unreferenced keys remain
+# loadable, mirroring --remove-ix-account).
+sonar simulate <TX> --rpc-url <RPC_URL> --remove-ix 2
+
+# Insert a whole instruction at a 1-based position. POS=1 prepends;
+# POS = current_count + 1 appends. The new instruction becomes the POS-th.
+# <SPEC> reuses the --ix grammar: DSL, JSON object/array, or @file.
+sonar simulate <TX> --rpc-url <RPC_URL> \
+  --insert-ix 1='program=MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr data=0x6869'
+
+# A JSON array spec expands to consecutive positions starting at POS:
+sonar simulate <TX> --rpc-url <RPC_URL> \
+  --insert-ix 2=@extra_instructions.json
+
+# Signer accounts are supported: new signers are inserted into the message's
+# signer section (with a placeholder signature), and the header's signer counts
+# are bumped accordingly. An account already present as a non-signer cannot be
+# promoted to signer in the same op.
+#
+# Privilege semantics: Solana message privileges are the union across all
+# instructions, so referencing an existing account never weakens it. A key that
+# is already writable stays writable even if this instruction lists it
+# read-only, and a key already a signer stays a signer. Inserted references can
+# only PROMOTE an existing key (e.g. readonly -> writable); they never demote
+# it, so existing instructions keep the privileges they need.
+
+# Accounts the inserted instruction introduces that weren't in the original
+# transaction are fetched/dependency-resolved automatically before simulation.
+
+# Ordering note for whole-instruction ops:
+# They run as a restructuring phase BEFORE account-level ops (--patch-ix-account
+# etc.) and data patches (--patch-ix-data), so the latter target the
+# post-restructure list. Within the phase, all --insert-ix apply first (in CLI
+# order) then all --remove-ix. Positions are interpreted at apply time; to
+# express positions relative to the pre-mutation list, list ops in descending
+# position order.
+```
+
 # Patch instruction data before simulation
 # Format: <IX>=<OFFSET>:<HEX_DATA> with a 1-based instruction index
 # HEX_DATA may optionally start with 0x


### PR DESCRIPTION
## Summary

Add whole-instruction restructuring as a mutation phase that runs **before** account-level and data patches. Two new `simulate` flags drive it:

```bash
sonar simulate <TX> --insert-ix 1='program=.. data=0x..'   # insert at 1-based position
sonar simulate <TX> --remove-ix 2                          # drop a whole instruction (1-based)
```

- `--insert-ix <POS>=<SPEC>` — `SPEC` reuses the `--ix` grammar (DSL, JSON object/array, or `@file`); a JSON array expands to consecutive positions. Signer accounts are supported.
- `--remove-ix <IX>` — drops an instruction; the `account_keys` table is left intact (mirroring `--remove-ix-account`).
- Whole-instruction ops run as a restructuring phase first (all `--insert-ix`, then all `--remove-ix`), so account/data mutations target the post-restructure list.

**Privilege semantics.** Inserted instructions merge their accounts into the message with **union** (never-demote) privileges, matching Solana's global message privileges: existing keys keep what they have, readonly keys can be promoted to writable (never demoted), and new signers are inserted into the signer section with placeholder signatures. Per-pubkey requirement aggregation unions duplicate account metas regardless of order, so valid instructions are never rejected based on meta ordering.

**sonar-sim:** adds the `InstructionOp` type, `apply_instruction_ops`, and the supporting `compile_instruction` / `merge_or_insert_account_key` / `promote_to_writable` / `insert_signer_account_key` helpers (with signature-alignment-preserving swaps on signer promotions). The pipeline append-fetches any accounts the inserted instructions introduce.

**sonar-cli:** adds the flags, parse helpers, handler wiring, e2e tests, and `docs/simulate.md` coverage.

Rebased onto the current `main` (the pipeline typestate refactor) — conflicts in `handlers/simulate.rs` (now use the `resolve_mutate_prepare` mutation closure) and `pipeline.rs` (re-applied the introduced-accounts fetch to the new typestate stages) were resolved.

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 905 passed, 0 failed

## Note

This branch is based on `main`, which is currently on **litesvm 0.10.0** (the 0.13.0 bump in #65 isn't merged yet). Commit 2 (`test(sim): make executor test transfers rent-exempt`) hardens the executor tests to use rent-exempt transfers; it's not strictly required on 0.10.0 but is forward-compatible and prevents these tests from breaking when #65 lands.
